### PR TITLE
feat(schedule): paramentização da periodicidade das dags usando variáveis do Airflow

### DIFF
--- a/airflow_lappis/dags/data_ingest/compras_gov/contratos_inativos_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/compras_gov/contratos_inativos_ingest_dag.py
@@ -3,13 +3,14 @@ import yaml
 from airflow.decorators import dag, task
 from airflow.models import Variable
 from datetime import datetime, timedelta
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_contratos import ClienteContratos
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("contratos_inativos_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/compras_gov/contratos_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/compras_gov/contratos_ingest_dag.py
@@ -4,13 +4,14 @@ from airflow.decorators import dag, task
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.models import Variable
 from datetime import datetime, timedelta
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_contratos import ClienteContratos
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("contratos_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/compras_gov/cronograma_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/compras_gov/cronograma_ingest_dag.py
@@ -1,13 +1,14 @@
 import logging
 from airflow.decorators import dag, task
 from datetime import datetime, timedelta
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_contratos import ClienteContratos
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("cronograma_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/compras_gov/empenhos_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/compras_gov/empenhos_ingest_dag.py
@@ -1,13 +1,14 @@
 import logging
 from airflow.decorators import dag, task
 from datetime import datetime, timedelta
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_contratos import ClienteContratos
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("empenhos_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/compras_gov/faturas_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/compras_gov/faturas_ingest_dag.py
@@ -1,13 +1,14 @@
 import logging
 from airflow.decorators import dag, task
 from datetime import datetime, timedelta
+from schedule_loader import get_dynamic_schedule
 from cliente_contratos import ClienteContratos
 from cliente_postgres import ClientPostgresDB
 from postgres_helpers import get_postgres_conn
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("faturas_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/compras_gov/terceirizados_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/compras_gov/terceirizados_ingest_dag.py
@@ -1,13 +1,14 @@
 import logging
 from airflow.decorators import dag, task
 from datetime import datetime, timedelta
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_contratos import ClienteContratos
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("terceirizados_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/siafi/nota_credito_siafi_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/siafi/nota_credito_siafi_ingest_dag.py
@@ -1,12 +1,13 @@
 from airflow.decorators import dag, task
 from datetime import datetime, timedelta
+from schedule_loader import get_dynamic_schedule
 from cliente_siafi import ClienteSiafi
 from cliente_postgres import ClientPostgresDB
 from postgres_helpers import get_postgres_conn
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("nota_credito_siafi_ingest_dag"),
     start_date=datetime(2024, 3, 12),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/siafi/nota_empenho_siafi_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/siafi/nota_empenho_siafi_ingest_dag.py
@@ -5,13 +5,14 @@ from airflow.models import Variable
 from airflow.models.param import Param
 from datetime import datetime, timedelta
 from typing import Dict, Any
+from schedule_loader import get_dynamic_schedule
 from cliente_siafi import ClienteSiafi
 from cliente_postgres import ClientPostgresDB
 from postgres_helpers import get_postgres_conn
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("nota_empenho_siafi_ingest_dag"),
     start_date=datetime(2023, 3, 17),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/siafi/programacao_financeira_siafi_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/siafi/programacao_financeira_siafi_ingest_dag.py
@@ -1,12 +1,13 @@
 from airflow.decorators import dag, task
 from datetime import datetime, timedelta
+from schedule_loader import get_dynamic_schedule
 from cliente_siafi import ClienteSiafi
 from cliente_postgres import ClientPostgresDB
 from postgres_helpers import get_postgres_conn
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("programacao_financeira_siafi_ingest_dag"),
     start_date=datetime(2024, 3, 12),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/siape/dados_afastamento_historico_siape_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/siape/dados_afastamento_historico_siape_ingest_dag.py
@@ -2,13 +2,16 @@ import os
 import logging
 from datetime import datetime, timedelta
 from airflow.decorators import dag, task
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_siape import ClienteSiape
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule(
+        "dados_afastamento_historico_siape_ingest_dag"
+    ),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/siape/dados_afastamento_siape_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/siape/dados_afastamento_siape_ingest_dag.py
@@ -2,13 +2,14 @@ import os
 import logging
 from datetime import datetime, timedelta
 from airflow.decorators import dag, task
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_siape import ClienteSiape
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("dados_afastamento_siape_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/siape/dados_curriculo_siape_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/siape/dados_curriculo_siape_ingest_dag.py
@@ -2,13 +2,14 @@ import os
 import logging
 from datetime import datetime, timedelta
 from airflow.decorators import dag, task
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_siape import ClienteSiape
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("dados_curriculo_siape_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/siape/dados_dependentes_siape_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/siape/dados_dependentes_siape_ingest_dag.py
@@ -2,13 +2,14 @@ import os
 import logging
 from datetime import datetime, timedelta
 from airflow.decorators import dag, task
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_siape import ClienteSiape
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("dados_dependentes_siape_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/siape/dados_escolares_siape_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/siape/dados_escolares_siape_ingest_dag.py
@@ -2,13 +2,14 @@ import os
 import logging
 from datetime import datetime, timedelta
 from airflow.decorators import dag, task
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_siape import ClienteSiape
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("dados_escolares_siape_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/siape/dados_financeiros_siape_dag.py
+++ b/airflow_lappis/dags/data_ingest/siape/dados_financeiros_siape_dag.py
@@ -2,13 +2,14 @@ import os
 import logging
 from datetime import datetime, timedelta
 from airflow.decorators import dag, task
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_siape import ClienteSiape
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("dados_financeiros_siape_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/siape/dados_funcionais_siape_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/siape/dados_funcionais_siape_ingest_dag.py
@@ -2,13 +2,14 @@ import os
 import logging
 from datetime import datetime, timedelta
 from airflow.decorators import dag, task
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_siape import ClienteSiape
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("dados_funcionais_siape_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/siape/dados_pa_siape_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/siape/dados_pa_siape_ingest_dag.py
@@ -2,13 +2,14 @@ import os
 import logging
 from datetime import datetime, timedelta
 from airflow.decorators import dag, task
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_siape import ClienteSiape
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("dados_pa_siape_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/siape/dados_pessoais_siape_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/siape/dados_pessoais_siape_ingest_dag.py
@@ -2,13 +2,14 @@ import os
 import logging
 from datetime import datetime, timedelta
 from airflow.decorators import dag, task
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_siape import ClienteSiape
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("dados_pessoais_siape_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/siape/dados_uorg_siape_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/siape/dados_uorg_siape_ingest_dag.py
@@ -2,13 +2,14 @@ import os
 import logging
 from datetime import datetime, timedelta
 from airflow.decorators import dag, task
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_siape import ClienteSiape
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("dados_uorg_siape_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/siape/lista_aposentadoria_siape_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/siape/lista_aposentadoria_siape_ingest_dag.py
@@ -3,13 +3,14 @@ import time
 import logging
 from datetime import datetime, timedelta
 from airflow.decorators import dag, task
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_siape import ClienteSiape
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("lista_aposentadoria_siape_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/siape/lista_servidores_siape_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/siape/lista_servidores_siape_ingest_dag.py
@@ -2,13 +2,14 @@ import os
 import logging
 from datetime import datetime, timedelta
 from airflow.decorators import dag, task
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_siape import ClienteSiape
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("lista_servidores_siape_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/siape/lista_uorgs_siape_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/siape/lista_uorgs_siape_ingest_dag.py
@@ -3,13 +3,14 @@ import logging
 from datetime import datetime
 from airflow.decorators import dag, task
 from datetime import timedelta
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_siape import ClienteSiape
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("lista_uorgs_siape_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/siape/pensoes_instituidas_siape_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/siape/pensoes_instituidas_siape_ingest_dag.py
@@ -3,13 +3,14 @@ import logging
 import requests
 from datetime import datetime, timedelta
 from airflow.decorators import dag, task
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_siape import ClienteSiape
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("pensoes_instituidas_siape_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/siorg/cargos_funcao_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/siorg/cargos_funcao_ingest_dag.py
@@ -1,13 +1,16 @@
 import logging
 from airflow.decorators import dag, task
 from datetime import datetime, timedelta
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_siorg import ClienteSiorg
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule(
+        "dados_afastamento_historico_siape_ingest_dag"
+    ),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/siorg/estrutura_organizacional_cargos_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/siorg/estrutura_organizacional_cargos_ingest_dag.py
@@ -1,13 +1,14 @@
 import logging
 from airflow.decorators import dag, task
 from datetime import datetime, timedelta
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_siorg import ClienteSiorg
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("estrutura_organizacional_cargos_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={"retries": 1, "retry_delay": timedelta(minutes=5), "owner": "Davi"},

--- a/airflow_lappis/dags/data_ingest/siorg/unidade_organizacional_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/siorg/unidade_organizacional_ingest_dag.py
@@ -1,13 +1,14 @@
 import logging
 from airflow.decorators import dag, task
 from datetime import datetime, timedelta
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_siorg import ClienteSiorg
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("unidade_organizacional_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/tesouro_gerencial/empenhos_tesouro_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/tesouro_gerencial/empenhos_tesouro_ingest_dag.py
@@ -5,6 +5,7 @@ from airflow.models import Variable
 from datetime import datetime, timedelta
 import logging
 import json
+from schedule_loader import get_dynamic_schedule
 from cliente_email import fetch_and_process_email
 from cliente_postgres import ClientPostgresDB
 from postgres_helpers import get_postgres_conn
@@ -50,7 +51,7 @@ with DAG(
     dag_id="email_empenhos_tesouro_ingest",
     default_args=default_args,
     description="Processa anexos dos empenhos vindo do email, formata e insere no db",
-    schedule_interval="0 13 * * 1-6",
+    schedule_interval=get_dynamic_schedule("empenhos_tesouro_ingest_dag"),
     start_date=datetime(2023, 12, 1),
     catchup=False,
     tags=["email", "empenhos", "tesouro"],

--- a/airflow_lappis/dags/data_ingest/tesouro_gerencial/nc_tesouro_ingest.dag.py
+++ b/airflow_lappis/dags/data_ingest/tesouro_gerencial/nc_tesouro_ingest.dag.py
@@ -7,6 +7,7 @@ import logging
 import json
 import pandas as pd
 import io
+from schedule_loader import get_dynamic_schedule
 from cliente_email import fetch_and_process_email
 from cliente_postgres import ClientPostgresDB
 from postgres_helpers import get_postgres_conn
@@ -62,7 +63,7 @@ with DAG(
     dag_id="email_notas_credito_ingest",
     default_args=default_args,
     description="Processa anexos das NCs vindo de dois emails, formata e insere no db",
-    schedule_interval="0 13 * * 1-6",
+    schedule_interval=get_dynamic_schedule("nc_tesouro_ingest_dag"),
     start_date=datetime(2023, 12, 1),
     catchup=False,
     tags=["email", "ncs", "tesouro"],

--- a/airflow_lappis/dags/data_ingest/tesouro_gerencial/pf_tesouro_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/tesouro_gerencial/pf_tesouro_ingest_dag.py
@@ -7,6 +7,7 @@ import logging
 import json
 import pandas as pd
 import io
+from schedule_loader import get_dynamic_schedule
 from cliente_email import fetch_and_process_email
 from cliente_postgres import ClientPostgresDB
 from postgres_helpers import get_postgres_conn
@@ -54,7 +55,7 @@ with DAG(
     dag_id="email_programacoes_financeiras_ingest",
     default_args=default_args,
     description="Processa anexos das PFs vindo de dois emails, formata e insere no db",
-    schedule_interval="0 13 * * 1-6",
+    schedule_interval=get_dynamic_schedule("pf_tesouro_ingest_dag"),
     start_date=datetime(2023, 12, 1),
     catchup=False,
     tags=["email", "pfs", "tesouro"],

--- a/airflow_lappis/dags/data_ingest/tesouro_gerencial/visao_orcamentaria_ingest.py
+++ b/airflow_lappis/dags/data_ingest/tesouro_gerencial/visao_orcamentaria_ingest.py
@@ -9,6 +9,7 @@ import pandas as pd
 import io
 import re
 import zipfile
+from schedule_loader import get_dynamic_schedule
 from cliente_email import fetch_email_with_zip
 from cliente_postgres import ClientPostgresDB
 from postgres_helpers import get_postgres_conn
@@ -65,7 +66,7 @@ with DAG(
         "DAG processa anexos da visão orçamentária total IPEA "
         "vindo do email, formata e insere no db"
     ),
-    schedule_interval="0 13 * * 1-6",
+    schedule_interval=get_dynamic_schedule("visao_orcamentaria_ingest"),
     start_date=datetime(2023, 12, 1),
     catchup=False,
     tags=["email", "visao_orcamentaria", "tesouro"],

--- a/airflow_lappis/dags/data_ingest/transfere_gov/notas_de_credito_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/transfere_gov/notas_de_credito_ingest_dag.py
@@ -1,13 +1,14 @@
 import logging
 from airflow.decorators import dag, task
 from datetime import datetime, timedelta
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_postgres import ClientPostgresDB
 from cliente_ted import ClienteTed
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("notas_de_credito_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/transfere_gov/plano_acao_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/transfere_gov/plano_acao_ingest_dag.py
@@ -1,13 +1,14 @@
 import logging
 from airflow.decorators import dag, task
 from datetime import datetime, timedelta
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_ted import ClienteTed
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("plano_acao_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/transfere_gov/programa_beneficiario_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/transfere_gov/programa_beneficiario_ingest_dag.py
@@ -1,13 +1,14 @@
 import logging
 from airflow.decorators import dag, task
 from datetime import datetime, timedelta
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_ted import ClienteTed
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("programa_beneficiario_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/transfere_gov/programacao_financeira_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/transfere_gov/programacao_financeira_ingest_dag.py
@@ -1,13 +1,14 @@
 import logging
 from airflow.decorators import dag, task
 from datetime import datetime, timedelta
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_postgres import ClientPostgresDB
 from cliente_ted import ClienteTed
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("programacao_financeira_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/transfere_gov/programas_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/transfere_gov/programas_ingest_dag.py
@@ -2,13 +2,14 @@ import logging
 from airflow.decorators import dag, task
 from airflow.models import Variable
 from datetime import datetime, timedelta
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_ted import ClienteTed
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("programas_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/transferegov_emendas/planos_acao_especiais_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/transferegov_emendas/planos_acao_especiais_ingest_dag.py
@@ -1,13 +1,14 @@
 import logging
 from airflow.decorators import dag, task
 from datetime import datetime, timedelta
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_transferegov_emendas import ClienteTransfereGov
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("planos_acao_especiais_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/dags/data_ingest/transferegov_emendas/programas_especiais_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/transferegov_emendas/programas_especiais_ingest_dag.py
@@ -1,13 +1,14 @@
 import logging
 from airflow.decorators import dag, task
 from datetime import datetime, timedelta
+from schedule_loader import get_dynamic_schedule
 from postgres_helpers import get_postgres_conn
 from cliente_transferegov_emendas import ClienteTransfereGov
 from cliente_postgres import ClientPostgresDB
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule_interval=get_dynamic_schedule("programas_especiais_ingest_dag"),
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/airflow_lappis/plugins/schedule_loader.py
+++ b/airflow_lappis/plugins/schedule_loader.py
@@ -1,0 +1,27 @@
+from airflow.models import Variable
+from datetime import timedelta
+
+
+def get_dynamic_schedule(dag_id: str) -> str | timedelta:
+    """
+    Retorna o schedule da Variable 'dynamic_schedules' para a DAG.
+    Suporta: 'preset'/'cron' (retorna str) e 'timedelta' (retorna timedelta).
+    """
+
+    schedules = Variable.get("dynamic_schedules", default_var={}, deserialize_json=True)
+
+    dag_schedule = schedules.get(dag_id)
+
+    if not dag_schedule:
+        raise ValueError(f"Nenhum schedule configurado para a DAG {dag_id}")
+
+    dag_type = dag_schedule.get("type")
+    dag_value = dag_schedule.get("value")
+
+    if dag_type in ["preset", "cron"]:
+        return str(dag_value)
+
+    if dag_type == "timedelta":
+        return timedelta(**dag_value)
+
+    raise ValueError(f"Tipo de schedule inválido: {dag_type}")


### PR DESCRIPTION
Implementação do helper schedule_loader.py. O arquivo centraliza o codigo de recepção e tratamento da variavel de agendamento (schedule) para DAGs específicas.

O helper suporta os tipos preset, cron e timedelta. Um exemplo de como configurar a Airflow Variable para cada caso (não real):

#33 

```json
{
  "exemplo_dag_preset": {
    "type": "preset",
    "value": "@daily"
  },
  "exemplo_dag_cron": {
    "type": "cron",
    "value": "0 12 * * *"
  },
  "exemplo_dag_timedelta": {
    "type": "timedelta",
    "value": {"days": 1} 
  }
}
```