### PR TITLE
Nova Tabela de Metadado para dt_transform

### DIFF
--- a/airflow_lappis/dags/dbt/ipea/dbt_project.yml
+++ b/airflow_lappis/dags/dbt/ipea/dbt_project.yml
@@ -20,6 +20,9 @@ clean-targets:
 models:
   ipea: 
     +database: analytics
+    metadata:
+      +materialized: incremental
+      +schema: metadata
     contratos_dbt:
       +materialized: table
       +schema: contratos

--- a/airflow_lappis/dags/dbt/ipea/macros/metadata/generate_metadata.sql
+++ b/airflow_lappis/dags/dbt/ipea/macros/metadata/generate_metadata.sql
@@ -1,0 +1,46 @@
+{% macro get_model_metadata() %}
+{#
+    Esta macro retorna os metadados do modelo atual.
+    Pode ser usada em post-hooks para registrar metadados automaticamente.
+#}
+    SELECT
+        '{{ this.schema }}' AS schema_name,
+        '{{ this.name }}' AS table_name,
+        '{{ this.database }}' AS database_name,
+        ('{{ run_started_at }}'::TIMESTAMP AT TIME ZONE 'UTC' AT TIME ZONE 'America/Sao_Paulo') AS dt_transform,
+        '{{ invocation_id }}' AS run_id
+{% endmacro %}
+
+
+{% macro register_model_metadata() %}
+{#
+    Esta macro registra os metadados do modelo em uma tabela central.
+    Deve ser usada como post-hook nos modelos que deseja rastrear.
+    
+    Uso no dbt_project.yml:
+    models:
+      ipea:
+        +post-hook:
+          - "{{ register_model_metadata() }}"
+#}
+
+    INSERT INTO {{ target.database }}.metadata.models_metadata (
+        schema_name,
+        table_name,
+        database_name,
+        dt_transform,
+        run_id
+    )
+    VALUES (
+        '{{ this.schema }}',
+        '{{ this.name }}',
+        '{{ this.database }}',
+        ('{{ run_started_at }}'::TIMESTAMP AT TIME ZONE 'UTC' AT TIME ZONE 'America/Sao_Paulo'),
+        '{{ invocation_id }}'
+    )
+    ON CONFLICT (schema_name, table_name)
+    DO UPDATE SET
+        dt_transform = EXCLUDED.dt_transform,
+        run_id = EXCLUDED.run_id;
+
+{% endmacro %}

--- a/airflow_lappis/dags/dbt/ipea/models/metadata/models_metadata.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/metadata/models_metadata.sql
@@ -1,0 +1,67 @@
+{{
+    config(
+        materialized='incremental',
+        unique_key=['schema_name', 'table_name'],
+        on_schema_change='sync_all_columns'
+    )
+}}
+
+{#
+    Tabela de Metadados dos Modelos dbt
+    ===================================
+    
+    Esta tabela armazena metadados de todos os modelos executados no dbt.
+    
+    Campos principais:
+    - schema_name: Schema do modelo
+    - table_name: Nome da tabela/modelo
+    - dt_transform: Data da última transformação (quando o modelo foi executado)
+    - run_id: ID único da execução do dbt
+    
+    A tabela é atualizada de forma incremental, mantendo apenas o registro
+    mais recente para cada combinação de schema + table_name.
+#}
+
+WITH dbt_models AS (
+    {# 
+        Usando a função graph do dbt para iterar sobre todos os modelos do projeto.
+        Isso garante que capturamos metadados de todos os modelos definidos.
+    #}
+    {% set models_data = [] %}
+    
+    {% for node in graph.nodes.values() %}
+        {% if node.resource_type == 'model' %}
+            {% do models_data.append({
+                'schema_name': node.schema,
+                'table_name': node.name,
+                'database_name': node.database,
+                'materialization': node.config.materialized,
+                'description': node.description | default('') | replace("'", "''")
+            }) %}
+        {% endif %}
+    {% endfor %}
+
+    {% for model in models_data %}
+        SELECT
+            '{{ model.schema_name }}' AS schema_name,
+            '{{ model.table_name }}' AS table_name,
+            '{{ model.database_name }}' AS database_name,
+            '{{ model.materialization }}' AS materialization,
+            '{{ model.description[:500] }}' AS description,
+            ('{{ run_started_at }}'::TIMESTAMP AT TIME ZONE 'UTC' AT TIME ZONE 'America/Sao_Paulo') AS dt_transform,
+            '{{ invocation_id }}' AS run_id
+        {% if not loop.last %}
+        UNION ALL
+        {% endif %}
+    {% endfor %}
+)
+
+SELECT
+    schema_name,
+    table_name,
+    database_name,
+    materialization,
+    description,
+    dt_transform,
+    run_id
+FROM dbt_models

--- a/airflow_lappis/dags/dbt/ipea/models/metadata/schema.yml
+++ b/airflow_lappis/dags/dbt/ipea/models/metadata/schema.yml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest/dbt_yml_files-latest.json
+
+version: 2
+
+models:
+  - name: models_metadata
+    description: >
+      Tabela central de metadados que armazena informações sobre todos os modelos dbt executados.
+      Cada linha representa um modelo único, identificado pela combinação de schema e table_name.
+      A tabela é atualizada de forma incremental, mantendo histórico das execuções.
+    meta:
+      tags:
+        - metadata
+        - governance
+    columns:
+      - name: schema_name
+        description: Nome do schema onde o modelo está localizado.
+        tests:
+          - not_null
+
+      - name: table_name
+        description: Nome da tabela/modelo.
+        tests:
+          - not_null
+
+      - name: database_name
+        description: Nome do banco de dados onde o modelo está materializado.
+
+      - name: materialization
+        description: Tipo de materialização do modelo (table, view, incremental, etc).
+
+      - name: description
+        description: Descrição do modelo extraída do schema.yml.
+
+      - name: dt_transform
+        description: >
+          Data e hora em que o modelo foi transformado/executado pela última vez.
+          Corresponde ao momento em que a execução do dbt foi iniciada (run_started_at).
+          Timezone: America/Sao_Paulo (UTC-3).
+        tests:
+          - not_null
+
+      - name: run_id
+        description: >
+          Identificador único da execução do dbt (invocation_id).
+          Permite rastrear qual execução gerou a transformação.


### PR DESCRIPTION
## O que foi feito?

Fiz uma tabela de metadados para evitar uma coluna inteira para a data de transformação, dessa forma fica apenas uma linha para cada tabela. Aproveitei a criação dessa tabela para adicionar mais alguns dados simples.

<img width="2393" height="1258" alt="image" src="https://github.com/user-attachments/assets/a835e7ad-4e6a-43aa-b83a-270fe05f3b19" />

##### FIXES #32 