### PR TITLE
Passagem da coluna dt_ingest pelos modelos

### DIFF
--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/bronze/contratos.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/bronze/contratos.sql
@@ -114,7 +114,8 @@ with
                     and cast(vigencia_fim as text) ~ '^\d{4}-\d{2}-\d{2}$'
                 -- Retorna NULL se não for uma data válida
                 then to_date(cast(vigencia_fim as text), 'YYYY-MM-DD')
-            end as vigencia_fim
+            end as vigencia_fim,
+            (dt_ingest || '-03:00')::timestamptz as dt_ingest
         from {{ source("compras_gov", "contratos") }}
     )  --
 

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/bronze/cronogramas.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/bronze/cronogramas.sql
@@ -13,7 +13,8 @@ with
             anoref::integer as anoref,
             retroativo::text as retroativo,
             replace(replace(valor::text, '.', ''), ',', '.')::numeric(15, 2) as valor,
-            vencimento::date as vencimento
+            vencimento::date as vencimento,
+            (dt_ingest || '-03:00')::timestamptz as dt_ingest
         from {{ source("compras_gov", "cronograma") }}
     ),
 

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/bronze/empenhos.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/bronze/empenhos.sql
@@ -49,8 +49,8 @@ with
                     and data_emissao::text ~ '^\d{4}-\d{2}-\d{2}$'
                 -- Retorna NULL se não for uma data válida
                 then to_date(data_emissao::text, 'YYYY-MM-DD')
-            end as data_emissao
-
+            end as data_emissao,
+            (dt_ingest || '-03:00')::timestamptz as dt_ingest
         from {{ source("compras_gov", "empenhos") }}
     )
 

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/bronze/empenhos_tesouro.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/bronze/empenhos_tesouro.sql
@@ -39,7 +39,8 @@ with
             {{ parse_financial_value("despesas_pagas") }} as despesas_pagas,
             {{ parse_financial_value("restos_a_pagar_inscritos") }}
             as restos_a_pagar_inscritos,
-            {{ parse_financial_value("restos_a_pagar_pagos") }} as restos_a_pagar_pagos
+            {{ parse_financial_value("restos_a_pagar_pagos") }} as restos_a_pagar_pagos,
+            (dt_ingest || '-03:00')::timestamptz as dt_ingest
         from {{ source("siafi", "empenhos_tesouro") }}
         where ne_ccor_ano_emissao like '20%'
     )

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/bronze/faturas.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/bronze/faturas.sql
@@ -33,7 +33,8 @@ with
             dados_item_faturado::text as dados_item_faturado,
             jsonb_array_elements(
                 replace(dados_empenho, '''', '"')::jsonb
-            ) as dados_empenho
+            ) as dados_empenho,
+            (dt_ingest || '-03:00')::timestamptz as dt_ingest
         from {{ source("compras_gov", "faturas") }}
     ),
     -- Extrai os campos do JSON e transforma em colunas individuais

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/bronze/schema.yml
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/bronze/schema.yml
@@ -82,6 +82,9 @@ models:
       - name: vigencia_fim
         description: >
           Data de término da vigência do contrato, validada e convertida para formato de data padrão.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw.
     data_tests: 
       - row_count_match:
           source_table: compras_gov.contratos
@@ -157,6 +160,9 @@ models:
       - name: vencimento
         description: >
           Data de vencimento da parcela do cronograma.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw.
     data_tests: 
       - verificacao_tipagem:
           nome_tabela: 'contratos.cronogramas'
@@ -243,6 +249,9 @@ models:
       - name: valor_empenho
         description: >
           Valor do empenho extraído do campo JSON dados_empenho.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw.
     data_tests:
       - verificacao_tipagem:
           nome_tabela: 'contratos.faturas'
@@ -352,6 +361,9 @@ models:
       - name: data_emissao
         description: >
           Data de emissão do empenho, validada e convertida para formato de data padrão.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw.
     data_tests: 
       - row_count_match:
           source_table: compras_gov.empenhos
@@ -438,6 +450,9 @@ models:
       - name: restos_a_pagar_pagos
         description: >
           Valor dos restos a pagar pagos, formatado como numérico.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw.
     data_tests:
       - verificacao_tipagem:
           nome_tabela: 'contratos.empenhos_tesouro'

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/gold/contratos_comparativo_mensal.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/gold/contratos_comparativo_mensal.sql
@@ -19,7 +19,8 @@ with
             s.valor_liquidado as siafi_valor_liquidado,
             s.valor_pago as siafi_valor_pago,
             s.restos_a_pagar as siafi_restos_a_pagar,
-            s.restos_a_pagar_pago as siafi_restos_a_pagar_pago
+            s.restos_a_pagar_pago as siafi_restos_a_pagar_pago,
+            c.dt_ingest as dt_ingest
         from compras_gov_data as c
         full join siafi_data as s using (contrato_id, mes_ref)
 
@@ -38,6 +39,7 @@ select
     siafi_valor_liquidado,
     siafi_valor_pago,
     siafi_restos_a_pagar,
-    siafi_restos_a_pagar_pago
+    siafi_restos_a_pagar_pago,
+    dt_ingest
 from partial_result
 full join preenchimento using (contrato_id, mes_ref)

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/gold/contratos_resumo.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/gold/contratos_resumo.sql
@@ -1,7 +1,7 @@
 with
 
     valores_pagos_contratos as (
-        select contrato_id as id, sum(despesas_pagas) as despesas_pagas
+        select contrato_id as id, sum(despesas_pagas) as despesas_pagas, max(dt_ingest) as dt_ingest_vpc
         from {{ ref("contratos_empenhos") }}
         where contrato_id is not null
         group by contrato_id
@@ -48,5 +48,6 @@ select
         when vigencia_fim - vigencia_inicio >= 730 and num_parcelas > 1
         then 'Sim'
         else 'Não'
-    end as continuado
+    end as continuado,
+    greatest(dt_ingest, dt_ingest_vpc) as dt_ingest
 from contratos_gold

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/gold/contratos_somatorio.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/gold/contratos_somatorio.sql
@@ -11,7 +11,8 @@ select
 
     sum(siafi_valor_empenhado) as total_empenhado,
     sum(siafi_valor_liquidado) as total_liquidado,
-    sum(siafi_valor_pago) as total_pago
+    sum(siafi_valor_pago) as total_pago,
+    max(dt_ingest) as dt_ingest
 
 from {{ ref("contratos_comparativo_mensal") }}
 group by contrato_id

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/gold/schema.yml
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/gold/schema.yml
@@ -67,6 +67,9 @@ models:
       - name: continuado
         description: >
           Indica se o contrato é de prestação continuada ('Sim' quando a vigência for maior que 730 dias e tiver mais de uma parcela).
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
 
   - name: contratos_comparativo_mensal
     description: >
@@ -103,6 +106,9 @@ models:
       - name: siafi_valor_pago
         description: >
           Valor pago no mês de referência conforme registros do SIAFI.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
 
   - name: contratos_somatorio
     description: >
@@ -137,3 +143,6 @@ models:
       - name: total_pago
         description: >
           Soma de todos os valores pagos para o contrato segundo o SIAFI.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/contratos_empenhos.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/contratos_empenhos.sql
@@ -48,7 +48,8 @@ with
             ne_ccor_ano_emissao,
             despesas_empenhadas,
             despesas_liquidadas,
-            despesas_pagas
+            despesas_pagas,
+            dt_ingest
         from full_join
         where origem = 'both' or origem = 'left only'
     -- contrato_id nulo significa lacuna no lado esquerdo do RIGHT JOIN, 
@@ -98,12 +99,12 @@ with
             ne_ccor_ano_emissao,
             despesas_empenhadas,
             despesas_liquidadas,
-            despesas_pagas
+            despesas_pagas,
+            dt_ingest
         from juncao_processo
         -- WHERE origem = 'both'
         where contrato_id is not null
     ),
-
     -- ---------------------------------------------------------------------------------------------------
     empenhos_restantes_2 as (
         select *
@@ -142,11 +143,11 @@ with
             ne_ccor_ano_emissao,
             despesas_empenhadas,
             despesas_liquidadas,
-            despesas_pagas
+            despesas_pagas,
+            dt_ingest
         from juncao_cnpjs
         where contrato_id is not null
     ),
-
     -- ---------------------------------------------------------------------------------------------------
     empenhos_restantes_3 as (
         select
@@ -184,7 +185,8 @@ with
             ne_ccor_ano_emissao,
             despesas_empenhadas,
             despesas_liquidadas,
-            despesas_pagas
+            despesas_pagas,
+            dt_ingest
         from juncao_info_complementar
         where contrato_id is not null
     ),

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/contratos_estagios.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/contratos_estagios.sql
@@ -21,7 +21,8 @@ with
             valor_liquidado,
             valor_pago,
             restos_a_pagar,
-            restos_a_pagar_pago
+            restos_a_pagar_pago,
+            dt_ingest
         from {{ ref("estagios_mensal") }}
         left join id_table_1 using (ne, cnpj_cpf)
     ),
@@ -52,7 +53,8 @@ with
             valor_liquidado,
             valor_pago,
             restos_a_pagar,
-            restos_a_pagar_pago
+            restos_a_pagar_pago,
+            dt_ingest
         from empenhos_restantes_1 l
         left join id_table_2 r using (cnpj_cpf, num_processo)
     ),
@@ -81,7 +83,8 @@ with
             valor_liquidado,
             valor_pago,
             restos_a_pagar,
-            restos_a_pagar_pago
+            restos_a_pagar_pago,
+            dt_ingest
         from empenhos_restantes_2 l
         left join id_table_3 r using (cnpj_cpf, info_complementar)
     ),
@@ -105,7 +108,8 @@ select
     sum(valor_liquidado) as valor_liquidado,
     sum(valor_pago) as valor_pago,
     sum(restos_a_pagar) as restos_a_pagar,
-    sum(restos_a_pagar_pago) as restos_a_pagar_pago
+    sum(restos_a_pagar_pago) as restos_a_pagar_pago,
+    max(dt_ingest) as dt_ingest
 from result_table
 where contrato_id is not null
 group by 1, 2

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/contratos_faturas.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/contratos_faturas.sql
@@ -47,6 +47,7 @@ select
     f.id_empenho,
     f.numero_empenho,
     f.valor_empenho,
-    f.subelemento
+    f.subelemento,
+    f.dt_ingest
 from faturas_base f
 left join contratos c on f.contrato_id = c.contrato_id

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/cronogramas_faturas_mensal.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/cronogramas_faturas_mensal.sql
@@ -17,7 +17,8 @@ with
             replace(replace(valorliquido::text, '.', ''), ',', '.')::numeric(
                 15, 2
             ) as valorliquido,
-            situacao::text as situacao
+            situacao::text as situacao,
+            dt_ingest
         from {{ source("compras_gov", "faturas") }}
     ),
 
@@ -30,7 +31,8 @@ with
                 || split_part(emissao::text, '-', 2),
                 'YYYY-MM'
             ) as mes_ref,
-            sum(juros + multa + glosa + valorliquido) as valor_faturas_pagas
+            sum(juros + multa + glosa + valorliquido) as valor_faturas_pagas,
+            max(dt_ingest) as dt_ingest_pago
         from faturas_parsed
         where situacao = 'Pago'
         group by 1, 2
@@ -45,7 +47,8 @@ with
                 || split_part(emissao::text, '-', 2),
                 'YYYY-MM'
             ) as mes_ref,
-            sum(juros + multa + glosa + valorliquido) as valor_faturas_pendentes
+            sum(juros + multa + glosa + valorliquido) as valor_faturas_pendentes,
+            max(dt_ingest) as dt_ingest_pendente
         from faturas_parsed
         where situacao = 'Pendente'
         group by 1, 2
@@ -67,7 +70,8 @@ with
             coalesce(valor_faturas_pendentes, 0) as valor_faturas_pendentes,
             coalesce(valor_cronograma, 0)
             - coalesce(valor_faturas_pagas, 0)
-            - coalesce(valor_faturas_pendentes, 0) as saldo_contratual_disponivel
+            - coalesce(valor_faturas_pendentes, 0) as saldo_contratual_disponivel,
+            greatest(dt_ingest_pago, dt_ingest_pendente) AS dt_ingest
         from joined_table
         order by contrato_id, mes_ref
     )

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/estagios_mensal.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/estagios_mensal.sql
@@ -17,7 +17,8 @@ with
             despesas_liquidadas as valor_liquidado,
             despesas_pagas as valor_pago,
             restos_a_pagar_inscritos as restos_a_pagar,
-            restos_a_pagar_pagos as restos_a_pagar_pago
+            restos_a_pagar_pagos as restos_a_pagar_pago,
+            dt_ingest
         from {{ ref("empenhos_tesouro") }}
         where true and ne_ccor != 'Total'
     ),
@@ -35,7 +36,8 @@ with
             sum(valor_liquidado) as valor_liquidado,
             sum(valor_pago) as valor_pago,
             sum(restos_a_pagar) as restos_a_pagar,
-            sum(restos_a_pagar_pago) as restos_a_pagar_pago
+            sum(restos_a_pagar_pago) as restos_a_pagar_pago,
+            max(dt_ingest) as dt_ingest
         from parsed_estagios
         group by 1, 2, 3, 4, 5
         order by 1, 2
@@ -59,7 +61,8 @@ with
             valor_liquidado,
             valor_pago,
             restos_a_pagar,
-            restos_a_pagar_pago
+            restos_a_pagar_pago,
+            dt_ingest
         from grouped_estagios
     ),
 
@@ -77,7 +80,8 @@ with
             valor_liquidado,
             valor_pago,
             restos_a_pagar,
-            restos_a_pagar_pago
+            restos_a_pagar_pago,
+            dt_ingest
         from processo_fixed
     ),
 
@@ -101,7 +105,8 @@ with
                 then restos_a_pagar
                 else - restos_a_pagar
             end as restos_a_pagar,
-            restos_a_pagar_pago
+            restos_a_pagar_pago,
+            dt_ingest
         from unnest_rap
     ),
 
@@ -118,7 +123,8 @@ with
             valor_liquidado,
             valor_pago,
             restos_a_pagar,
-            restos_a_pagar_pago
+            restos_a_pagar_pago,
+            dt_ingest
         from fix_data
     )
 

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/schema.yml
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/schema.yml
@@ -55,6 +55,9 @@ models:
       - name: despesas_pagas
         description: >
           Valor total das despesas pagas para o contrato.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
 
   - name: contratos_estagios
     description: >
@@ -81,6 +84,9 @@ models:
       - name: valor_pago
         description: >
           Valor pago no mês de referência para o contrato.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
 
   - name: estagios_mensal
     description: >
@@ -115,6 +121,9 @@ models:
       - name: valor_pago
         description: >
           Valor total pago no mês e para o empenho específico.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
 
   - name: contratos_faturas
     description: >
@@ -227,6 +236,9 @@ models:
       - name: subelemento
         description: >
           Código do subelemento de despesa relacionado à fatura.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
 
   - name: cronogramas_faturas_mensal
     description: >
@@ -255,3 +267,6 @@ models:
       - name: saldo_contratual_disponivel
         description: >
           Diferença entre o valor programado no cronograma e a soma dos valores faturados (pagos e pendentes).
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.

--- a/airflow_lappis/dags/dbt/ipea/models/orcamento_dbt/bronze/visao_orcamentaria_total.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/orcamento_dbt/bronze/visao_orcamentaria_total.sql
@@ -38,7 +38,7 @@ with
             as restos_a_pagar_inscritos,
             {{ parse_financial_value("restos_a_pagar_pagos") }} as restos_a_pagar_pagos,
 
-            dt_ingest::timestamp as dt_ingest
+            (dt_ingest || '-03:00')::timestamptz as dt_ingest
 
         from source_data
     )

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/afastamento_historico.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/afastamento_historico.sql
@@ -20,7 +20,8 @@ with
             datapublicacaoafastamento,
             descdiplomaafastamento,
             descocorrencia,
-            numerodiplomaafastamento
+            numerodiplomaafastamento,
+            dt_ingest
         -- grmatricula não está presente 
         from {{ source("siape", "afastamento_historico") }}
     ),
@@ -80,7 +81,8 @@ with
             ) as descocorrencia_clean,
             nullif(
                 nullif(nullif(trim(numerodiplomaafastamento), ''), 'NaN'), '[null]'
-            ) as numerodiplomaafastamento_clean
+            ) as numerodiplomaafastamento_clean,
+            dt_ingest
         from afastamento_historico_raw
     )
 
@@ -126,5 +128,6 @@ select
     end as dt_publicacao_afastamento,
     descdiplomaafastamento_clean as desc_diploma_afastamento,
     descocorrencia_clean as desc_ocorrencia,
-    cast(numerodiplomaafastamento_clean as int) as numero_diploma_afastamento
+    cast(numerodiplomaafastamento_clean as int) as numero_diploma_afastamento,
+    (dt_ingest || '-03:00')::timestamptz as dt_ingest
 from afastamento_historico_cleaned

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/cargos_funcoes.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/cargos_funcoes.sql
@@ -18,7 +18,8 @@ with
             atonormativo__url,
             atonormativo__codigotipo,
             atonormativo__siglatipo,
-            denominacoes__denominacao
+            denominacoes__denominacao,
+            dt_ingest
         from {{ source("siorg", "cargos_funcao") }}
     ),
 
@@ -55,5 +56,6 @@ select
     atonormativo__codigotipo,
     atonormativo__siglatipo,
     denominacao_codigo,
-    denominacao_descricao
+    denominacao_descricao,
+    (dt_ingest || '-03:00')::timestamptz as dt_ingest
 from denominacoes_expandidas

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/dados_afastamento.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/dados_afastamento.sql
@@ -21,7 +21,8 @@ with
             descocorrencia,
             numerodiplomaafastamento,
             datainicioferiasinterrompidas,
-            diasrestantes
+            diasrestantes,
+            dt_ingest
         from {{ source("siape", "dados_afastamento") }}
     ),
 
@@ -55,7 +56,8 @@ with
             nullif(
                 trim(datainicioferiasinterrompidas), ''
             ) as datainicioferiasinterrompidas_clean,
-            nullif(trim(diasrestantes), '') as diasrestantes_clean
+            nullif(trim(diasrestantes), '') as diasrestantes_clean,
+            dt_ingest
         from dados_afastamento_raw
     )
 
@@ -102,5 +104,6 @@ select
         then to_date(datainicioferiasinterrompidas_clean, 'DDMMYYYY')
         else null
     end as dt_inicio_ferias_interrompidas,
-    cast(diasrestantes_clean as int) as dias_restantes
+    cast(diasrestantes_clean as int) as dias_restantes,
+    (dt_ingest || '-03:00')::timestamptz as dt_ingest
 from dados_afastamento_cleaned

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/dados_curriculo.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/dados_curriculo.sql
@@ -16,7 +16,8 @@ with
             datafim,
             projeto,
             infoadicionais,
-            tipodesc
+            tipodesc,
+            dt_ingest
         from {{ source("siape", "dados_curriculo") }}
     )
 
@@ -39,5 +40,6 @@ select
     to_date(nullif(trim(datafim), '') || '01', 'YYYYMMDD') as dt_mes_fim,
     nullif(trim(projeto), '') as descricao_projeto,
     nullif(trim(infoadicionais), '') as informacoes_adicionais,
-    nullif(trim(tipodesc), '') as tipo_descricao
+    nullif(trim(tipodesc), '') as tipo_descricao,
+    (dt_ingest || '-03:00')::timestamptz as dt_ingest
 from dados_curriculo_raw

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/dados_dependentes.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/dados_dependentes.sql
@@ -12,7 +12,8 @@ with
             codbeneficio,
             datafim,
             datainicio,
-            nomebeneficio
+            nomebeneficio,
+            dt_ingest
         from {{ source("siape", "dados_dependentes") }}
     ),
 
@@ -29,7 +30,8 @@ with
             nullif(trim(codbeneficio), 'NaN') as codbeneficio,
             nullif(trim(datafim), 'NaN') as datafim,
             nullif(trim(datainicio), 'NaN') as datainicio,
-            nullif(trim(nomebeneficio), 'NaN') as nomebeneficio
+            nullif(trim(nomebeneficio), 'NaN') as nomebeneficio,
+            dt_ingest
         from dados_dependentes_raw
     )
 
@@ -46,5 +48,6 @@ select
     -- Converte para DATE, tratando '', 'NaN' e '00000000' como NULL
     to_date(nullif(nullif(datafim, ''), '00000000'), 'DDMMYYYY') as dt_fim,
     to_date(nullif(nullif(datainicio, ''), '00000000'), 'DDMMYYYY') as dt_inicio,
-    nullif(nomebeneficio, '') as nome_beneficio
+    nullif(nomebeneficio, '') as nome_beneficio,
+    (dt_ingest || '-03:00')::timestamptz as dt_ingest
 from dados_dependentes_cleaned

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/dados_escolares.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/dados_escolares.sql
@@ -9,7 +9,8 @@ with
             nometitulacao,
             codescolaridade,
             nomeescolaridade,
-            cpf
+            cpf,
+            dt_ingest
         from {{ source("siape", "dados_escolares") }}
     )
 
@@ -22,5 +23,6 @@ select
     nullif(trim(nometitulacao), '') as nome_titulacao,
     nullif(trim(codescolaridade), '') as cod_escolaridade,
     nullif(trim(nomeescolaridade), '') as nome_escolaridade,
-    regexp_replace(nullif(trim(cpf), ''), '[^0-9]', '', 'g') as cpf
+    regexp_replace(nullif(trim(cpf), ''), '[^0-9]', '', 'g') as cpf,
+    (dt_ingest || '-03:00')::timestamptz as dt_ingest
 from dados_escolares_raw

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/dados_financeiros.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/dados_financeiros.sql
@@ -11,7 +11,8 @@ with
             mesanopagamento,
             cpf,
             indicadormovsupl,
-            perubrica
+            perubrica,
+            dt_ingest
         from {{ source("siape", "dados_financeiros") }}
     ),
 
@@ -27,7 +28,8 @@ with
             nullif(trim(mesanopagamento), '') as mes_ano_pagamento_str,
             nullif(trim(cpf), '') as cpf_str,
             nullif(trim(indicadormovsupl), '') as indicador_mov_supl,
-            nullif(trim(perubrica), '') as periodo_rubrica
+            nullif(trim(perubrica), '') as periodo_rubrica,
+            dt_ingest
         from dados_financeiros_raw
     ),
 
@@ -91,7 +93,8 @@ with
                 then '12'
                 else null
             end as mes_num_pagamento,
-            substring(mes_ano_pagamento_str, 4, 4) as ano_pagamento
+            substring(mes_ano_pagamento_str, 4, 4) as ano_pagamento,
+            max(dt_ingest) over () dt_ingest_max
         from dados_financeiros_cleaned
     )
 
@@ -119,5 +122,6 @@ select
     ) as mes_ano_pagamento,
     regexp_replace(cpf_str, '[^0-9]', '', 'g') as cpf,
     indicador_mov_supl,
-    periodo_rubrica
+    periodo_rubrica,
+    (dt_ingest_max || '-03:00')::timestamptz as dt_ingest
 from conversao_mes

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/dados_funcionais.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/dados_funcionais.sql
@@ -82,5 +82,6 @@ select
         replace(nullif(trim(valorvaletransporte), ''), ',', '.') as numeric
     ) as valor_vale_transporte,
     to_date(nullif(trim(datauorgexercicio), ''), 'DDMMYYYY') as dt_uorg_exercicio,
-    nullif(trim(pontuacaodesempenho), '') as pontuacao_desempenho  -- Mantido como varchar (Não da pra saber se é "A","B" ou é um número > tudo null)
+    nullif(trim(pontuacaodesempenho), '') as pontuacao_desempenho,  -- Mantido como varchar (Não da pra saber se é "A","B" ou é um número > tudo null)
+    (dt_ingest || '-03:00')::timestamptz as dt_ingest
 from dados_funcionais_raw

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/dados_pa.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/dados_pa.sql
@@ -12,7 +12,8 @@ with
             cpf_servidor,
             codvinculoservidor,
             nomealimentado,
-            nomevinculoservidor
+            nomevinculoservidor,
+            dt_ingest
         from {{ source("siape", "dados_pa") }}
     )
 
@@ -34,5 +35,6 @@ select
     regexp_replace(nullif(trim(cpf_servidor), ''), '[^0-9]', '', 'g') as cpf_servidor,
     nullif(trim(codvinculoservidor), '') as cod_vinculo_servidor,
     nullif(trim(nomealimentado), '') as nome_alimentado,
-    nullif(trim(nomevinculoservidor), '') as nome_vinculo_servidor
+    nullif(trim(nomevinculoservidor), '') as nome_vinculo_servidor,
+    (dt_ingest || '-03:00')::timestamptz as dt_ingest
 from dados_pa

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/dados_pessoais.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/dados_pessoais.sql
@@ -21,7 +21,8 @@ with
             coddeffisica,
             nomedeffisica,
             datachegbrasil,
-            nomepais
+            nomepais,
+            dt_ingest
         from {{ source("siape", "dados_pessoais") }}
     )
 
@@ -46,5 +47,6 @@ select
     nullif(trim(coddeffisica), '') as cod_deficiencia_fisica,
     nullif(trim(nomedeffisica), '') as nome_deficiencia_fisica,
     to_date(nullif(trim(datachegbrasil), ''), 'DDMMYYYY') as dt_chegada_brasil,
-    nullif(trim(nomepais), '') as nome_pais_origem
+    nullif(trim(nomepais), '') as nome_pais_origem,
+    (dt_ingest || '-03:00')::timestamptz as dt_ingest
 from dados_pessoais

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/dados_uorg.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/dados_uorg.sql
@@ -18,7 +18,8 @@ with
             ufuorg,
             cpf,
             complementouorg,
-            numfaxuorg
+            numfaxuorg,
+            dt_ingest
         from {{ source("siape", "dados_uorg") }}
     )
 
@@ -40,5 +41,6 @@ select
     upper(nullif(trim(ufuorg), '')) as uf_uorg,
     regexp_replace(nullif(trim(cpf), ''), '[^0-9]', '', 'g') as cpf,
     nullif(nullif(trim(complementouorg), ''), '---') as complemento_endereco_uorg,
-    regexp_replace(nullif(trim(numfaxuorg), ''), '[^0-9]', '', 'g') as fax_uorg
+    regexp_replace(nullif(trim(numfaxuorg), ''), '[^0-9]', '', 'g') as fax_uorg,
+    (dt_ingest || '-03:00')::timestamptz as dt_ingest
 from dados_uorg

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/estrutura_organizacional_cargos.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/estrutura_organizacional_cargos.sql
@@ -7,7 +7,8 @@ with
             municipio,
             uf,
             cargos,
-            ordem_grandeza
+            ordem_grandeza,
+            dt_ingest
         from {{ source("siorg", "estrutura_organizacional_cargos") }}
     ),
 
@@ -19,6 +20,7 @@ with
             f.municipio,
             f.uf,
             f.ordem_grandeza,
+            f.dt_ingest,
             cargo_elem
         from
             fonte f,
@@ -35,6 +37,7 @@ with
             ce.municipio,
             ce.uf,
             ce.ordem_grandeza,
+            ce.dt_ingest,
             cargo_elem ->> 'denominacao' as denominacao,
             cargo_elem ->> 'funcao' as funcao,
             instancia_elem ->> 'codigoInstancia' as codigo_instancia,
@@ -70,5 +73,6 @@ select
     codigo_instancia,
     nome_titular,
     cpf_titular,
-    ordem_grandeza
+    ordem_grandeza,
+    (dt_ingest || '-03:00')::timestamptz as dt_ingest
 from instancias_filtradas

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/lista_servidores.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/lista_servidores.sql
@@ -1,6 +1,6 @@
 with
     lista_servidores as (
-        select cpf, dataultimatransacao as dt_ultima_transacao, coduorg as cod_uorg
+        select cpf, dataultimatransacao as dt_ultima_transacao, coduorg as cod_uorg, (dt_ingest || '-03:00')::timestamptz as dt_ingest
         from {{ source("siape", "lista_servidores") }}
     )
 

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/lista_uorgs.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/lista_uorgs.sql
@@ -1,6 +1,6 @@
 with
     lista_uorgs as (
-        select cast(codigo as int) as codigo, dt_ultima_transacao, nome
+        select cast(codigo as int) as codigo, dt_ultima_transacao, nome, (dt_ingest || '-03:00')::timestamptz as dt_ingest
         from {{ source("siape", "lista_uorgs") }}
     )
 

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/schema.yml
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/schema.yml
@@ -54,6 +54,8 @@ models:
         description: "Descrição da ocorrência do afastamento."
       - name: numero_diploma_afastamento
         description: "Número do diploma legal do afastamento."
+      - name: dt_ingest
+        description:  "Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw."
 
 
   - name: cargos_funcoes
@@ -121,6 +123,9 @@ models:
       - name: denominacao_descricao
         description: "Descrição da denominação expandida para o cargo/função."
 
+      - name: dt_ingest
+        description:  "Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw."
+
 
   - name: dados_afastamento
     description: >
@@ -167,6 +172,9 @@ models:
         description: "CPF do servidor."
       - name: dt_fim_aquisicao
         description: "Data final do período aquisitivo de férias."
+      - name: dt_ingest
+        description:  "Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw."
+
 
 
   - name: dados_curriculo
@@ -228,6 +236,9 @@ models:
       - name: tipo_descricao
         description: "Tipo da descrição curricular. Pode indicar se o registro refere-se a curso, experiência, projeto etc."
 
+      - name: dt_ingest
+        description:  "Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw."
+
 
   - name: dados_dependentes
     description: >
@@ -283,6 +294,9 @@ models:
         description: >
           Nome do benefício associado ao dependente ( auxílio-saúde, plano de assistência etc.).
 
+      - name: dt_ingest
+        description:  "Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw."
+
 
   - name: dados_escolares
     description: >
@@ -319,6 +333,9 @@ models:
 
       - name: cpf
         description: "CPF do servidor, contendo apenas números, utilizado para identificação única."
+
+      - name: dt_ingest
+        description:  "Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw."
 
 
 
@@ -372,6 +389,9 @@ models:
       - name: periodo_rubrica
         description: >
           Período a que se refere a rubrica, podendo representar um agrupamento ou classificação contábil adicional."
+
+      - name: dt_ingest
+        description:  "Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw."
 
 
   - name: dados_funcionais
@@ -587,6 +607,9 @@ models:
           Pontuação atribuída ao servidor conforme avaliação de desempenho. 
           Pode conter letras (A, B, C) ou valores numéricos, depende da origem. Mantido como string.
 
+      - name: dt_ingest
+        description:  "Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw."
+
 
   - name: dados_pa
     description: >
@@ -619,6 +642,8 @@ models:
         description: "Nome do alimentado."
       - name: nome_vinculo_servidor
         description: "Nome do vínculo com o servidor."
+      - name: dt_ingest
+        description:  "Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw."
 
   - name: dados_pessoais
     description: >
@@ -669,6 +694,8 @@ models:
         description: "Data de chegada ao Brasil."
       - name: nome_pais_origem
         description: "Nome do país de origem."
+      - name: dt_ingest
+        description:  "Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw."
 
   - name: dados_uorg
     description: >
@@ -713,6 +740,8 @@ models:
         description: "Complemento do endereço da UORG."
       - name: fax_uorg
         description: "Fax da UORG."
+      - name: dt_ingest
+        description:  "Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw."
 
 
   - name: estrutura_organizacional_cargos
@@ -746,6 +775,8 @@ models:
         description: CPF do servidor titular do cargo (com apenas dígitos numéricos).
       - name: ordem_grandeza
         description: Nível hierárquico da unidade na estrutura, utilizado para escolher a instância mais relevante.
+      - name: dt_ingest
+        description:  "Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw."
 
 
   - name: lista_servidores
@@ -761,6 +792,8 @@ models:
         description: "Data da última transação."
       - name: cpf
         description: "CPF do servidor."
+      - name: dt_ingest
+        description:  "Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw."
 
   - name: lista_uorgs
     description: >
@@ -775,6 +808,8 @@ models:
         description: "Data da última transação."
       - name: nome
         description: "Nome da UORG."
+      - name: dt_ingest
+        description:  "Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw."
 
   - name: terceirizados
     description: >
@@ -816,6 +851,8 @@ models:
         description: Valor mensal do auxílio transporte recebido pelo trabalhador (convertido para numérico).
       - name: vale_alimentacao
         description: Valor mensal do vale alimentação recebido pelo trabalhador (convertido para numérico).
+      - name: dt_ingest
+        description:  "Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw."
 
 
   - name: unidade_organizacional
@@ -863,5 +900,7 @@ models:
         description: Nível hierárquico da unidade dentro da estrutura organizacional (quanto maior, mais profunda).
       - name: caminho_unidade
         description: Caminho hierárquico concatenado das siglas das unidades até o nível atual.
+      - name: dt_ingest
+        description:  "Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw."
 
 

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/terceirizados.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/terceirizados.sql
@@ -16,5 +16,6 @@ select
     replace(replace(aux_transporte, '.', ''), ',', '.')::numeric(15, 2) as aux_transporte,
     replace(replace(vale_alimentacao, '.', ''), ',', '.')::numeric(
         15, 2
-    ) as vale_alimentacao
+    ) as vale_alimentacao,
+    (dt_ingest || '-03:00')::timestamptz as dt_ingest
 from {{ source("compras_gov", "terceirizados") }}

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/unidade_organizacional.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/bronze/unidade_organizacional.sql
@@ -16,7 +16,8 @@ with recursive
             datafinalversaoconsulta,
             operacao,
             codigounidadepaianterior,
-            codigoorgaoentidadeanterior
+            codigoorgaoentidadeanterior,
+            (dt_ingest || '-03:00')::timestamptz as dt_ingest
         from {{ source("siorg", "unidade_organizacional") }}
     ),
 

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/aposentadorias_resumo.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/aposentadorias_resumo.sql
@@ -13,7 +13,8 @@ with
             nome_ocorr_aposentadoria,
             nome_cargo,
             sigla_nivel_cargo,
-            cod_classe || '-' || cod_padrao as classe_padrao
+            cod_classe || '-' || cod_padrao as classe_padrao,
+            dt_ingest
         from {{ ref("servidores_detalhados") }} sd
         where dt_ocorr_aposentadoria is not null
     )

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/cargos_consolidado.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/cargos_consolidado.sql
@@ -22,7 +22,11 @@ select
     siape.nome_uorg_exercicio as siape_nome_uorg,
     siape.sigla_uorg_exercicio as siape_sigla_uorg,
     siape.uf_uorg as siape_uf_uorg,
-    siape.nome_situacao_funcional as siape_situacao_funcional
+    siape.nome_situacao_funcional as siape_situacao_funcional,
+    greatest(
+        siorg.dt_ingest,
+        siape.dt_ingest
+    ) as dt_ingest
 
 from {{ ref("servidores_detalhados") }} siape
 left join

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/distribuicao_genero.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/distribuicao_genero.sql
@@ -2,7 +2,8 @@
 select
     nome_sexo as genero,
     count(*) as quantidade_servidores,
-    count(*) * 1.0 / sum(count(*)) over () as percentual_distribuicao
+    count(*) * 1.0 / sum(count(*)) over () as percentual_distribuicao,
+    max(dt_ingest) as dt_ingest
 from {{ ref("servidores_completos") }}
 group by nome_sexo
 order by percentual_distribuicao desc

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/distribuicao_mapa_uf.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/distribuicao_mapa_uf.sql
@@ -4,7 +4,8 @@ with
     -- Obter todos os servidores com localização
     servidores_localizacao as (
         select distinct
-            df.cpf, du.uf_uorg, du.nome_municipio_uorg, df.nome_situacao_funcional
+            df.cpf, du.uf_uorg, du.nome_municipio_uorg, df.nome_situacao_funcional,
+            greatest(df.dt_ingest, du.dt_ingest) as dt_ingest
         from {{ ref("dados_funcionais") }} df
         inner join {{ ref("dados_uorg") }} du on df.sigla_uorg_exercicio = du.sigla_uorg
         where du.uf_uorg is not null
@@ -12,7 +13,7 @@ with
 
     -- Contar servidores por UF
     contagem_por_uf as (
-        select uf_uorg, count(distinct cpf) as valor
+        select uf_uorg, count(distinct cpf) as valor, max(dt_ingest) as dt_ingest_uf
         from servidores_localizacao
         group by uf_uorg
     ),
@@ -29,7 +30,8 @@ select
         when coalesce(cpu.valor, 0) = 0
         then '0%'
         else concat(round((coalesce(cpu.valor, 0) * 100.0 / ts.total), 0), '%')
-    end as percentual
+    end as percentual,
+    cpu.dt_ingest_uf as dt_ingest
 from {{ ref("estados_brasil") }} eb
 cross join total_servidores ts
 left join contagem_por_uf cpu on eb.sigla_uf = cpu.uf_uorg

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/distribuicao_raca_cor.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/distribuicao_raca_cor.sql
@@ -1,5 +1,5 @@
 -- Distribuição de servidores por raça/cor
-select nome_cor as cor_raca, count(nome_cor) as quantidade_servidores
+select nome_cor as cor_raca, count(nome_cor) as quantidade_servidores, max(dt_ingest) as dt_ingest
 from {{ ref("servidores_completos") }}
 group by nome_cor
 order by quantidade_servidores desc

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/distribuicao_situacao_funcional.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/distribuicao_situacao_funcional.sql
@@ -19,14 +19,16 @@ with
                 then 'Ativo em outro órgão'
                 else df.sigla_uorg_exercicio
             end as unidade_exercicio,
-            du.nome_municipio_uorg
+            du.nome_municipio_uorg,
+            greatest(df.dt_ingest, du.dt_ingest) as dt_ingest_max
         from {{ ref("dados_funcionais") }} df
         inner join {{ ref("dados_uorg") }} du on df.sigla_uorg_exercicio = du.sigla_uorg
     )
 
 select
     nome_situacao_funcional as situacao_funcional_original,
-    count(nome_situacao_funcional) as quantidade_servidores
+    count(nome_situacao_funcional) as quantidade_servidores,
+    max(dt_ingest_max) as dt_ingest
 from dados_funcionais_enriquecidos
 group by nome_situacao_funcional
 order by quantidade_servidores desc

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/hierarquia.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/hierarquia.sql
@@ -23,7 +23,8 @@ with
             -- quanto menor a hierarquia, maior o cargo
             right(funcao_sigla, 2) as nivel_cargo,
             cast(substring(funcao_sigla, length(funcao_sigla) - 2, 1) as int) * 1000
-            - cast(right(funcao, 2) as int) as hierarquia_cargo
+            - cast(right(funcao, 2) as int) as hierarquia_cargo,
+            greatest(eorg.dt_ingest, uo.dt_ingest) as dt_ingest_siorg
         from correcao_funcao as eorg
         inner join
             {{ ref("unidade_organizacional") }} as uo
@@ -55,7 +56,8 @@ with
             uo.ordem_grandeza as ordem_grandeza_alternativa,
             substring(df.cod_funcao, 1, 1) || substring(
                 df.cod_funcao, length(df.cod_funcao) - 2, 3
-            ) as codigo_combinacao_siape
+            ) as codigo_combinacao_siape,
+            greatest(df.dt_ingest, uo.dt_ingest, uo.dt_ingest) as dt_ingest_siape
         from {{ ref("dados_funcionais") }} as df
         left join {{ ref("dados_pessoais") }} as dp on df.cpf = dp.cpf
         left join
@@ -140,7 +142,8 @@ with
             coalesce(denominacao, nome_cargo) as nome_cargo,
             case
                 when cod_situacao_funcional = '04' then 'Nomeação livre' else 'Carreira'
-            end as servidores_carreira
+            end as servidores_carreira,
+            greatest(pr.dt_ingest_siorg, pr.dt_ingest_siape, dp.dt_ingest) as dt_ingest
         from primeira_correlacao as pr
         left join {{ ref("dados_pessoais") }} as dp on pr.cpf_chefia_imediata = dp.cpf
         order by caminho_unidade, hierarquia_cargo

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/kpis_servidores.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/kpis_servidores.sql
@@ -1,47 +1,48 @@
 with
     total_servidores as (
-        select count(distinct cpf) as total from {{ ref("dados_funcionais") }}
+        select count(distinct cpf) as total, max(dt_ingest) as dt_ingest 
+        from {{ ref("dados_funcionais") }}
     ),
 
     servidores_ativos as (
-        select count(distinct cpf) as total
+        select count(distinct cpf) as total, max(dt_ingest) as dt_ingest
         from {{ ref("dados_funcionais") }}
         where nome_situacao_funcional in ('ATIVO PERMANENTE')
     ),
 
     aposentados as (
-        select count(distinct cpf) as total
+        select count(distinct cpf) as total, max(dt_ingest) as dt_ingest
         from {{ ref("dados_funcionais") }}
         where nome_situacao_funcional in ('APOSENTADO')
     ),
 
     estagiarios as (
-        select count(distinct cpf) as total
+        select count(distinct cpf) as total, max(dt_ingest) as dt_ingest
         from {{ ref("dados_funcionais") }}
         where nome_situacao_funcional in ('ESTAGIARIO SIGEPE')
     ),
 
-    terceirizados as (select count(distinct id) as total from {{ ref("terceirizados") }})
+    terceirizados as (select count(distinct id) as total, max(dt_ingest) as dt_ingest from {{ ref("terceirizados") }})
 
-select 'total_servidores' as kpi, total as valor
+select 'total_servidores' as kpi, total as valor, dt_ingest
 from total_servidores
 
 union all
 
-select 'servidores_ativos_permanentes' as kpi, total as valor
+select 'servidores_ativos_permanentes' as kpi, total as valor, dt_ingest
 from servidores_ativos
 
 union all
 
-select 'aposentados' as kpi, total as valor
+select 'aposentados' as kpi, total as valor, dt_ingest
 from aposentados
 
 union all
 
-select 'estagiarios' as kpi, total as valor
+select 'estagiarios' as kpi, total as valor, dt_ingest
 from estagiarios
 
 union all
 
-select 'terceirizados' as kpi, total as valor
+select 'terceirizados' as kpi, total as valor, dt_ingest
 from terceirizados

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/resumo_quadro_pessoal.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/resumo_quadro_pessoal.sql
@@ -3,6 +3,7 @@ select
     coalesce(nome_sexo, 'N/A') as genero,
     coalesce(nome_situacao_funcional, 'N/A') as situacao_funcional,
     coalesce(uf_uorg, 'N/A') as localidade_uf,
-    count(distinct cpf) as quantidade_servidores
+    count(distinct cpf) as quantidade_servidores,
+    max(dt_ingest) as dt_ingest
 from {{ ref("servidores_detalhados") }}
 group by 1, 2, 3, 4

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/schema.yml
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/schema.yml
@@ -42,6 +42,9 @@ models:
         description: Quantidade de meses entre o ingresso e a aposentadoria (ignora anos completos).
       - name: diff_dias
         description: Quantidade de dias entre o ingresso e a aposentadoria (ignora anos e meses completos).
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
 
 
 
@@ -97,6 +100,9 @@ models:
         description: Unidade federativa (UF) da unidade de exercício no SIAPE.
       - name: siape_situacao_funcional
         description: Situação funcional atual do servidor segundo o SIAPE.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
 
 
 
@@ -166,6 +172,9 @@ models:
         description: Nome ou denominação do cargo ocupado.
       - name: servidores_carreira
         description: Indica se o servidor está em cargo de carreira ou em nomeação livre.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
 
 
   - name: resumo_quadro_pessoal
@@ -196,6 +205,9 @@ models:
       - name: quantidade_servidores
         description: >
           Quantidade total de servidores distintos (com base no CPF) que se enquadram na combinação dos atributos anteriores.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
 
 
   - name: distribuicao_genero
@@ -217,6 +229,9 @@ models:
         description: >
           Percentual de servidores deste gênero em relação ao total de servidores,
           calculado como COUNT(*) * 1.0 / SUM(COUNT(*)) OVER ().
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
 
 
   - name: distribuicao_raca_cor
@@ -236,6 +251,9 @@ models:
           conforme autodeclaração registrada nos dados pessoais do SIAPE.
       - name: quantidade_servidores
         description: Quantidade total de servidores que se autodeclararam desta cor/raça.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
 
 
   - name: distribuicao_situacao_funcional
@@ -261,6 +279,9 @@ models:
           (ATIVO PERMANENTE, ATIVO EM OUTRO ORGAO, APOSENTADO, etc.).
       - name: quantidade_servidores
         description: Quantidade total de servidores que se enquadram nesta combinação de situação funcional.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
 
 
   - name: kpis_servidores
@@ -283,6 +304,9 @@ models:
       - name: valor
         description: >
           Valor numérico do KPI, representando a contagem de CPFs ou IDs únicos conforme a métrica.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
 
 
   - name: distribuicao_mapa_uf
@@ -305,6 +329,9 @@ models:
         description: Quantidade total de servidores com unidade de exercício neste estado.
       - name: percentual
         description: Percentual de servidores deste estado em relação ao total, formatado como string com símbolo '%'.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
 
 
   - name: tabela_servidores_agregada
@@ -331,4 +358,7 @@ models:
         description: Sigla da UF da unidade de exercício em maiúsculas.
       - name: total
         description: Quantidade total de servidores únicos (CPF) nesta combinação de atributos.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
 

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/tabela_servidores_agregada.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/tabela_servidores_agregada.sql
@@ -9,7 +9,8 @@ with
             dp.nome_sexo as genero,
             df.nome_situacao_funcional as situacao,
             du.nome_municipio_uorg as cidade,
-            du.uf_uorg as estado
+            du.uf_uorg as estado,
+            greatest(df.dt_ingest, dp.dt_ingest, du.dt_ingest) as dt_ingest
         from {{ ref("dados_funcionais") }} df
         inner join {{ ref("dados_pessoais") }} dp on df.cpf = dp.cpf
         inner join {{ ref("dados_uorg") }} du on df.sigla_uorg_exercicio = du.sigla_uorg
@@ -48,12 +49,13 @@ with
             end as situacao,
             initcap(cidade) as cidade,
             upper(estado) as estado,
-            count(distinct cpf) as total
+            count(distinct cpf) as total,
+            max(dt_ingest) as dt_ingest
         from servidores_completos
         group by nome_cargo, genero, situacao, cidade, estado
     )
 
-select cargo, genero, situacao, cidade, estado, total
+select cargo, genero, situacao, cidade, estado, total, dt_ingest
 from servidores_agregados
 where total > 0
 order by total desc, cargo, genero

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/silver/afastamento_consolidado.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/silver/afastamento_consolidado.sql
@@ -23,7 +23,8 @@ with
             desc_ocorrencia,
             numero_diploma_afastamento,
             gr_matricula,
-            'dados_afastamento' as origem_dados  -- identificar a fonte
+            'dados_afastamento' as origem_dados,  -- identificar a fonte,
+            dt_ingest
         from {{ ref("dados_afastamento") }}
 
         union all
@@ -50,7 +51,8 @@ with
             desc_ocorrencia,
             numero_diploma_afastamento,
             null as gr_matricula,  -- não tem na afastamneto historico ...
-            'afastamento_historico' as origem_dados  -- identificar a fonte
+            'afastamento_historico' as origem_dados,  -- identificar a fonte,
+            dt_ingest
         from {{ ref("afastamento_historico") }}
     ),
 
@@ -106,7 +108,8 @@ with
             desc_ocorrencia,
             numero_diploma_afastamento,
             gr_matricula,
-            origem_dados
+            origem_dados,
+            dt_ingest
         from prioridades
         where prioridade = 1
     )

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/silver/quantitativo_alocados_ocupados.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/silver/quantitativo_alocados_ocupados.sql
@@ -5,7 +5,7 @@ with
     ),
 
     codigos_siorg as (
-        select funcao, nomeunidade, siglaunidade, denominacao, count(*) as qtd_vagas_cargo
+        select funcao, nomeunidade, siglaunidade, denominacao, count(*) as qtd_vagas_cargo, max(dt_ingest) as dt_ingest
         from siorg_sem_duplicatas
         group by funcao, nomeunidade, siglaunidade, denominacao
     ),
@@ -16,7 +16,8 @@ with
             nome_uorg_exercicio,
             sigla_uorg_exercicio,
             nome_cargo,
-            count(*) as qtd_vagas_ocupadas
+            count(*) as qtd_vagas_ocupadas,
+            max(dt_ingest) as dt_ingest
         from siape_sem_duplicatas
         where cod_funcao is not null and dt_ocorr_aposentadoria is null
         group by cod_funcao, nome_uorg_exercicio, sigla_uorg_exercicio, nome_cargo
@@ -33,7 +34,8 @@ with
             substring(replace(funcao, ' ', ''), 1, 1) || substring(
                 replace(funcao, ' ', ''), length(replace(funcao, ' ', '')) - 2, 3
             ) as codigo_combinacao_siorg,
-            qtd_vagas_cargo
+            qtd_vagas_cargo,
+            dt_ingest
         from codigos_siorg
     ),
 
@@ -46,13 +48,26 @@ with
             substring(cod_funcao, 1, 1) || substring(
                 cod_funcao, length(cod_funcao) - 2, 3
             ) as codigo_combinacao_siape,
-            qtd_vagas_ocupadas
+            qtd_vagas_ocupadas,
+            dt_ingest
         from codigos_siape
     ),
 
     primeira_correlacao as (
         select
-            *,
+            siorg.funcao,
+            siorg.nomeunidade,
+            siorg.siglaunidade,
+            siorg.denominacao,
+            siorg.codigo_combinacao_siorg,
+            siorg.qtd_vagas_cargo,
+            siape.cod_funcao,
+            siape.nome_uorg_exercicio,
+            siape.sigla_uorg_exercicio,
+            siape.nome_cargo,
+            siape.codigo_combinacao_siape,
+            siape.qtd_vagas_ocupadas,
+            greatest(siorg.dt_ingest, siape.dt_ingest) as dt_ingest,
             case
                 when
                     siorg.codigo_combinacao_siorg is not null
@@ -88,5 +103,6 @@ select
         when qtd_vagas_ocupadas is null
         then qtd_vagas_cargo
         else (qtd_vagas_cargo - qtd_vagas_ocupadas)
-    end as qtd_cargos_vagos
+    end as qtd_cargos_vagos,
+    dt_ingest
 from primeira_correlacao

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/silver/schema.yml
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/silver/schema.yml
@@ -65,6 +65,9 @@ models:
         description: Código da função de chefia ou cargo de confiança ocupado pelo servidor no momento do afastamento.
       - name: sigla_uorg_exercicio
         description: Sigla da unidade organizacional onde o servidor exercia suas funções.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
 
 
 
@@ -97,6 +100,9 @@ models:
         description: >
           Diferença entre o número de vagas previstas (`qtd_vagas_cargo`) e as ocupadas (`qtd_vagas_ocupadas`).
           Indica o total de cargos vagos. Retorna `null` se a quantidade de vagas previstas não estiver disponível.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
 
 
   - name: servidores_detalhados
@@ -219,6 +225,9 @@ models:
         description: Valor mensal do vale transporte recebido.
       - name: pontuacao_desempenho
         description: Pontuação de desempenho do servidor, se aplicável.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
 
 
 
@@ -290,6 +299,9 @@ models:
         description: Denominação do cargo ocupado, conforme SIAPE ou SIORG.
       - name: servidores_carreira
         description: Classificação se o cargo é de carreira ou nomeação livre.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
 
 
   - name: unidades_organizacionais_siorg_siape
@@ -317,4 +329,7 @@ models:
           - "ambos": unidade presente no SIAPE e SIORG.
           - "apenas_siorg": presente apenas no SIORG.
           - "apenas_siape": presente apenas no SIAPE.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
 

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/silver/servidores_completos.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/silver/servidores_completos.sql
@@ -4,7 +4,35 @@
 with
     hierarquia_enriquecida as (
         select
-            ph.*,
+            ph.codigo_siape,
+            ph.codigo_siorg,
+            ph.codigo_combinacao_siape,
+            ph.codigo_combinacao_siorg,
+            ph.matricula_siape,
+            ph.cpf,
+            ph.cpf_chefia_imediata,
+            ph.cod_situacao_funcional,
+            ph.nome_situacao_funcional,
+            ph.hierarquia_cargo,
+            ph.servidor,
+            ph.dt_nascimento,
+            ph.nome_sexo,
+            ph.nome_estado_civil,
+            ph.nome_nacionalidade,
+            ph.nome_cor,
+            ph.uf_nascimento,
+            ph.nome_municipio_nascimento,
+            ph.nome_chefia,
+            ph.codigounidade,
+            ph.codigounidadepai,
+            ph.caminho_unidade,
+            ph.ordem_grandeza,
+            ph.nomeunidade,
+            ph.siglaunidade,
+            ph.nome_cargo,
+            ph.servidores_carreira,
+            ph.dt_ingest as dt_ingest_ph,
+            df.dt_ingest as dt_ingest_df,
             case
                 when df.modalidade_pgd is null
                 then 'Não participa'
@@ -27,17 +55,47 @@ with
     ),
 
     servidores_enriquecidos as (
-        select distinct ph.*, du.nome_municipio_uorg
+        select distinct ph.*, du.nome_municipio_uorg, du.dt_ingest as dt_ingest_du
         from hierarquia_enriquecida ph
         inner join {{ ref("dados_uorg") }} du on ph.siglaunidade = du.sigla_uorg
         order by caminho_unidade, hierarquia_cargo
     )
 
 select distinct
-    se.*,
+        se.codigo_siape,
+    se.codigo_siorg,
+    se.codigo_combinacao_siape,
+    se.codigo_combinacao_siorg,
+    se.matricula_siape,
+    se.cpf,
+    se.cpf_chefia_imediata,
+    se.cod_situacao_funcional,
+    se.nome_situacao_funcional,
+    se.hierarquia_cargo,
+    se.servidor,
+    se.dt_nascimento,
+    se.nome_sexo,
+    se.nome_estado_civil,
+    se.nome_nacionalidade,
+    se.nome_cor,
+    se.uf_nascimento,
+    se.nome_municipio_nascimento,
+    se.nome_chefia,
+    se.codigounidade,
+    se.codigounidadepai,
+    se.caminho_unidade,
+    se.ordem_grandeza,
+    se.nomeunidade,
+    se.siglaunidade,
+    se.nome_cargo,
+    se.servidores_carreira,
+    se.pdg,
+    se.unidade_exercicio,
+    se.nome_municipio_uorg,
     sd.cod_escolaridade_principal,
     sd.nome_escolaridade_principal,
     sd.nome_deficiencia_fisica,
-    sd.nome_cargo as nome_cargo_emprego
+    sd.nome_cargo as nome_cargo_emprego,
+    greatest(se.dt_ingest_ph, se.dt_ingest_df, se.dt_ingest_du, sd.dt_ingest) as dt_ingest
 from servidores_enriquecidos se
 inner join {{ ref("servidores_detalhados") }} sd on se.cpf = sd.cpf

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/silver/servidores_detalhados.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/silver/servidores_detalhados.sql
@@ -1,6 +1,6 @@
 with
     educacao_principal as (
-        select cpf, cod_escolaridade, nome_escolaridade, cod_titulacao, nome_titulacao
+        select cpf, cod_escolaridade, nome_escolaridade, cod_titulacao, nome_titulacao, dt_ingest as dt_ingest_ep
         from {{ ref("dados_escolares") }}
     ),
     uorg_completo as (
@@ -22,7 +22,8 @@ with
             du.uf_uorg,
             du.cpf,
             du.complemento_endereco_uorg,
-            du.fax_uorg
+            du.fax_uorg,
+            du.dt_ingest as dt_ingest_du
         -- lu.dt_ultima_transacao AS dt_ultima_transacao_uorg, os codigos não batem e a
         -- informação aparentemente ja existe...
         -- lu.nome AS nome_uorg_lista
@@ -142,7 +143,14 @@ select
     uorg_c.sigla_uorg,
     uorg_c.uf_uorg,
     uorg_c.complemento_endereco_uorg,
-    uorg_c.fax_uorg
+    uorg_c.fax_uorg,
+
+    greatest(
+        dp.dt_ingest,
+        df.dt_ingest,
+        ep.dt_ingest_ep,
+        uorg_c.dt_ingest_du
+    ) as dt_ingest
 
 from {{ ref("dados_pessoais") }} dp
 left join {{ ref("dados_funcionais") }} df on dp.cpf = df.cpf

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/silver/tabela_correlacao_cargos.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/silver/tabela_correlacao_cargos.sql
@@ -1,7 +1,10 @@
 with
 
     correcao_funcao as (
-        select *, replace(funcao, ' ', '') as funcao_sigla
+        select 
+            *,
+            replace(funcao, ' ', '') as funcao_sigla,
+            dt_ingest as dt_ingest_estrutura
         from {{ ref("estrutura_organizacional_cargos") }}
     ),
 
@@ -13,6 +16,7 @@ with
             eorg.ordem_grandeza,
             eorg.denominacao,
             eorg.codigo_instancia,
+            eorg.dt_ingest_estrutura,
             uo.codigounidadepai,
             uo.caminho_unidade,
             case
@@ -24,7 +28,8 @@ with
             -- quanto menor a hierarquia, maior o cargo
             right(funcao_sigla, 2) as nivel_cargo,
             cast(substring(funcao_sigla, length(funcao_sigla) - 2, 1) as int) * 1000
-            - cast(right(funcao, 2) as int) as hierarquia_cargo
+            - cast(right(funcao, 2) as int) as hierarquia_cargo,
+            uo.dt_ingest as dt_ingest_uorg
         from correcao_funcao as eorg
         inner join
             {{ ref("unidade_organizacional") }} as uo
@@ -56,7 +61,10 @@ with
             uo.ordem_grandeza as ordem_grandeza_alternativa,
             substring(df.cod_funcao, 1, 1) || substring(
                 df.cod_funcao, length(df.cod_funcao) - 2, 3
-            ) as codigo_combinacao_siape
+            ) as codigo_combinacao_siape,
+            df.dt_ingest as dt_ingest_funcionais,
+            dp.dt_ingest as dt_ingest_pessoais,
+            uo.dt_ingest as dt_ingest_uorg_alt
         from {{ ref("dados_funcionais") }} as df
         left join {{ ref("dados_pessoais") }} as dp on df.cpf = dp.cpf
         left join
@@ -161,7 +169,15 @@ with
             coalesce(denominacao, nome_cargo) as nome_cargo,
             case
                 when cod_situacao_funcional = '04' then 'Nomeação livre' else 'Carreira'
-            end as servidores_carreira
+            end as servidores_carreira,
+
+            greatest(
+                pr.dt_ingest_estrutura,
+                pr.dt_ingest_uorg,
+                pr.dt_ingest_funcionais,
+                pr.dt_ingest_pessoais,
+                pr.dt_ingest_uorg_alt
+            ) as dt_ingest
         from primeira_correlacao as pr
         left join {{ ref("dados_pessoais") }} as dp on pr.cpf_chefia_imediata = dp.cpf
         order by caminho_unidade, hierarquia_cargo

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/silver/unidades_organizacionais_siorg_siape.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/silver/unidades_organizacionais_siorg_siape.sql
@@ -1,11 +1,13 @@
 with
     preparacao as (
-        select distinct
+        select
             du.codigo_orgao::integer as codigo_orgao,
             du.codigo_orgao_uorg as combinacao_codigo_lista,
             (right(du.codigo_orgao_uorg, 7))::integer as codigo_lista_uorg,
-            du.sigla_uorg as sigla_uorg
+            du.sigla_uorg as sigla_uorg,
+            max(du.dt_ingest) as dt_ingest_du
         from {{ ref("dados_uorg") }} du
+        group by 1, 2, 3, 4
     ),
 
     join_lista_uorgo_dados_uorg as (
@@ -14,10 +16,13 @@ with
             p.combinacao_codigo_lista,
             p.codigo_lista_uorg,
             p.sigla_uorg,
+            p.dt_ingest_du,
             lu.dt_ultima_transacao,
-            lu.nome as nome_unidade
+            lu.nome as nome_unidade,
+            max(lu.dt_ingest) as dt_ingest_lu
         from preparacao p
         join {{ ref("lista_uorgs") }} lu on p.codigo_lista_uorg = lu.codigo
+        group by 1, 2, 3, 4, 5, 6, 7
     ),
 
     unidade_organizacional as (
@@ -32,6 +37,7 @@ with
             coalesce(a.sigla_uorg, sigla_unidade) as sigla_uorg,
             a.codigo_lista_uorg as codigo_unidade_siape,
             uo.codigounidade as codigo_unidade_siorg,
+            greatest(a.dt_ingest_du, a.dt_ingest_lu) as dt_ingest,
             case
                 when a.nome_unidade is null and uo.nome is not null
                 then 'apenas_siorg'

--- a/airflow_lappis/dags/dbt/ipea/models/ted_dbt/bronze/nc_tesouro.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/ted_dbt/bronze/nc_tesouro.sql
@@ -21,7 +21,8 @@ with
             favorecido_doc,
             favorecido_doc_descricao,
             replace(nc_valor_linha, ',', '.')::numeric(15, 2) as nc_valor_linha,
-            {{ parse_financial_value("movimento_liquido") }} as movimento_liquido
+            {{ parse_financial_value("movimento_liquido") }} as movimento_liquido,
+            (dt_ingest || '-03:00')::timestamptz as dt_ingest
         from {{ source("siafi", "nc_tesouro") }}
     )
 

--- a/airflow_lappis/dags/dbt/ipea/models/ted_dbt/bronze/pf_tesouro.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/ted_dbt/bronze/pf_tesouro.sql
@@ -22,7 +22,8 @@ with
             pf_recurso,
             pf_recurso_descricao,
             doc_observacao,
-            replace(pf_valor_linha, ',', '.')::numeric(15, 2) as pf_valor_linha
+            replace(pf_valor_linha, ',', '.')::numeric(15, 2) as pf_valor_linha,
+            (dt_ingest || '-03:00')::timestamptz as dt_ingest
         from {{ source("siafi", "pf_tesouro") }}
     )
 

--- a/airflow_lappis/dags/dbt/ipea/models/ted_dbt/bronze/planos_acao.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/ted_dbt/bronze/planos_acao.sql
@@ -26,7 +26,8 @@ with
             vl_beneficiario_especifico::numeric(15, 2) as vl_beneficiario_especifico,
             vl_chamamento_publico::numeric(15, 2) as vl_chamamento_publico,
             sq_instrumento,
-            aa_instrumento
+            aa_instrumento,
+            (dt_ingest || '-03:00')::timestamptz as dt_ingest
         from {{ source("transfere_gov", "planos_acao") }}
     )
 

--- a/airflow_lappis/dags/dbt/ipea/models/ted_dbt/bronze/schema.yml
+++ b/airflow_lappis/dags/dbt/ipea/models/ted_dbt/bronze/schema.yml
@@ -74,6 +74,9 @@ models:
     - name: pf_valor_linha
       description: >
         Valor monetário individual da linha da Programação Financeira.
+    - name: dt_ingest
+      description: >
+        Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw.
     data_tests:
         - verificacao_tipagem:
             nome_tabela: 'ted.pf_tesouro'
@@ -152,6 +155,9 @@ models:
     - name: movimento_liquido
       description: >
         Valor líquido do movimento financeiro associado à Nota de Crédito, após deduções ou acréscimos aplicáveis.
+    - name: dt_ingest
+      description: >
+        Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw.
 
   - name: planos_acao
     description: >
@@ -223,3 +229,6 @@ models:
     - name: aa_instrumento
       description: >
         Ano de referência do instrumento associado ao Plano de Ação.
+    - name: dt_ingest
+      description: >
+        Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw.

--- a/airflow_lappis/dags/dbt/ipea/models/ted_dbt/gold/schema.yml
+++ b/airflow_lappis/dags/dbt/ipea/models/ted_dbt/gold/schema.yml
@@ -58,4 +58,7 @@ models:
     - name: financeiro_cancelado
       description: >
         Valor total de cancelamentos financeiros identificados na programação, com ação 'CANCELAMENTO'.
+    - name: dt_ingest
+      description: >
+        Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
 

--- a/airflow_lappis/dags/dbt/ipea/models/ted_dbt/gold/ted_resumo_orcamentario.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/ted_dbt/gold/ted_resumo_orcamentario.sql
@@ -8,7 +8,8 @@ with
             id_plano_acao as plano_acao,
             vl_total_plano_acao as valor_firmado,
             sigla_unidade_descentralizada,
-            ted_beneficiario_emitente
+            ted_beneficiario_emitente,
+            dt_ingest as dt_ingest_vf
         from {{ ref("planos_acao") }}
     ),
 
@@ -23,7 +24,8 @@ with
             ) as orcamento_recebido,
             sum(
                 case when nc_evento in ('300301', '300307') then nc_valor else 0 end
-            ) as orcamento_devolvido
+            ) as orcamento_devolvido,
+            min(dt_ingest) as dt_ingest_vo
         from {{ ref("nc_plano_acao") }}
         where ptres not in ('-9')
         group by plano_acao, num_transf
@@ -46,7 +48,8 @@ with
             sum(despesas_pagas) as despesas_pagas_exercicio,
             sum(restos_a_pagar_pagos) as despesas_pagas_rap,
             sum(restos_a_pagar_inscritos) as restos_a_pagar,
-            sum(despesas_liquidadas) as despesas_liquidada
+            sum(despesas_liquidadas) as despesas_liquidada,
+            min(dt_ingest) as dt_ingest_ve
         from {{ ref("empenhos_plano_acao") }}
         group by plano_acao, num_transf
     ),
@@ -67,17 +70,20 @@ with
             ) as financeiro_devolvido,
             sum(
                 case when pf_acao = 'CANCELAMENTO' then pf_valor_linha else 0 end
-            ) as financeiro_cancelado
+            ) as financeiro_cancelado,
+            min(dt_ingest) as dt_ingest_vfin
         from {{ ref("pf_plano_acao") }}
         group by plano_acao, num_transf
     ),
     -- Saldo financeiro = Financeiro recebido - Financeiro devolvido - Utilizado/pago
     -- Financeiro a receber = Valor firmado - Financeiro recebido + Financeiro devolvido
     join_parcial as (
-        select *
-        from valores_orcamentos_tb
-        full join valores_empenhados_tb using (plano_acao, num_transf)
-        full join valores_financeiro_tb using (plano_acao, num_transf)
+        select 
+            *,
+            LEAST(vo.dt_ingest_vo, ve.dt_ingest_ve, vfin.dt_ingest_vfin) as dt_ingest_jp
+        from valores_orcamentos_tb vo
+        full join valores_empenhados_tb ve using (plano_acao, num_transf)
+        full join valores_financeiro_tb vfin using (plano_acao, num_transf)
 
     )
 -- Final
@@ -103,7 +109,8 @@ select
     despesas_liquidada,
     financeiro_recebido,
     financeiro_devolvido,
-    financeiro_cancelado
-from valor_firmado_tb
-full join join_parcial using (plano_acao)
+    financeiro_cancelado,
+    LEAST(vf.dt_ingest_vf, jp.dt_ingest_jp) as dt_ingest
+from valor_firmado_tb vf
+full join join_parcial jp using (plano_acao)
 where (plano_acao is not null) or (num_transf is not null)

--- a/airflow_lappis/dags/dbt/ipea/models/ted_dbt/gold/ted_resumo_orcamentario.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/ted_dbt/gold/ted_resumo_orcamentario.sql
@@ -25,7 +25,7 @@ with
             sum(
                 case when nc_evento in ('300301', '300307') then nc_valor else 0 end
             ) as orcamento_devolvido,
-            min(dt_ingest) as dt_ingest_vo
+            max(dt_ingest) as dt_ingest_vo
         from {{ ref("nc_plano_acao") }}
         where ptres not in ('-9')
         group by plano_acao, num_transf
@@ -49,7 +49,7 @@ with
             sum(restos_a_pagar_pagos) as despesas_pagas_rap,
             sum(restos_a_pagar_inscritos) as restos_a_pagar,
             sum(despesas_liquidadas) as despesas_liquidada,
-            min(dt_ingest) as dt_ingest_ve
+            max(dt_ingest) as dt_ingest_ve
         from {{ ref("empenhos_plano_acao") }}
         group by plano_acao, num_transf
     ),
@@ -71,7 +71,7 @@ with
             sum(
                 case when pf_acao = 'CANCELAMENTO' then pf_valor_linha else 0 end
             ) as financeiro_cancelado,
-            min(dt_ingest) as dt_ingest_vfin
+            max(dt_ingest) as dt_ingest_vfin
         from {{ ref("pf_plano_acao") }}
         group by plano_acao, num_transf
     ),
@@ -80,7 +80,7 @@ with
     join_parcial as (
         select 
             *,
-            LEAST(vo.dt_ingest_vo, ve.dt_ingest_ve, vfin.dt_ingest_vfin) as dt_ingest_jp
+            greatest(vo.dt_ingest_vo, ve.dt_ingest_ve, vfin.dt_ingest_vfin) as dt_ingest_jp
         from valores_orcamentos_tb vo
         full join valores_empenhados_tb ve using (plano_acao, num_transf)
         full join valores_financeiro_tb vfin using (plano_acao, num_transf)
@@ -110,7 +110,7 @@ select
     financeiro_recebido,
     financeiro_devolvido,
     financeiro_cancelado,
-    LEAST(vf.dt_ingest_vf, jp.dt_ingest_jp) as dt_ingest
+    greatest(vf.dt_ingest_vf, jp.dt_ingest_jp) as dt_ingest
 from valor_firmado_tb vf
 full join join_parcial jp using (plano_acao)
 where (plano_acao is not null) or (num_transf is not null)

--- a/airflow_lappis/dags/dbt/ipea/models/ted_dbt/silver/nc_plano_acao.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/ted_dbt/silver/nc_plano_acao.sql
@@ -25,7 +25,8 @@ with
                 when nc_evento in ('300302', '300308', '300311', '300083')
                 then (-1) * nc_valor_linha
                 else nc_valor_linha
-            end as nc_valor
+            end as nc_valor,
+            rd.dt_ingest
         from raw_data rd
         left join planos_de_acao pda on rd.nc_transferencia = pda.num_transf
     )

--- a/airflow_lappis/dags/dbt/ipea/models/ted_dbt/silver/pf_plano_acao.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/ted_dbt/silver/pf_plano_acao.sql
@@ -11,7 +11,8 @@ with
             pf_evento,
             pf_evento_descricao,
             substring(pf_acao_descricao, '(\w+) ') as pf_acao,
-            pf_valor_linha
+            pf_valor_linha,
+            dt_ingest as dt_ingest_pf
         from {{ ref("pf_tesouro") }}
     ),
 
@@ -19,24 +20,55 @@ with
         select
             tx_numero_programacao as pf,
             ug_emitente_programacao as ug_emitente,
-            id_plano_acao as plano_acao
-        from {{ source("transfere_gov", "programacao_financeira") }}
+            id_plano_acao as plano_acao,
+            (dt_ingest || '-03:00')::timestamptz as dt_ingest_tg 
+        from {{ source("transfere_gov", "programacao_financeira") }} -- raw
     ),
 
     joined_by_transfere_gov as (
-        select pf.*, t.plano_acao
+        select 
+            pf,
+            num_transf,
+            emissao_mes,
+            emissao_dia,
+            ug_emitente,
+            ug_favorecido,
+            pf_evento,
+            pf_evento_descricao,
+            pf_acao,
+            pf_valor_linha,
+            t.plano_acao, 
+            greatest(pf.dt_ingest_pf, t.dt_ingest_tg) as dt_ingest
         from programacoes_financeira pf
         inner join pf_transfere_gov t using (pf, ug_emitente)
     ),
 
     joined_by_num_transf as (
-        select pf.*, v.plano_acao
+        select 
+            pf.pf,
+            pf.num_transf,
+            pf.emissao_mes,
+            pf.emissao_dia,
+            pf.ug_emitente,
+            pf.ug_favorecido,
+            pf.pf_evento,
+            pf.pf_evento_descricao,
+            pf.pf_acao,
+            pf.pf_valor_linha,
+            v.plano_acao,
+            pf.dt_ingest_pf as dt_ingest
         from programacoes_financeira pf
         inner join {{ ref("num_transf_n_plano_acao") }} v using (num_transf)
+        -- Exclui registros que já existem em joined_by_transfere_gov
+        where not exists (
+            select 1 
+            from pf_transfere_gov t 
+            where t.pf = pf.pf and t.ug_emitente = pf.ug_emitente
+        )
     )
 
 select *
 from joined_by_transfere_gov
-union
+union all
 select *
 from joined_by_num_transf

--- a/airflow_lappis/dags/dbt/ipea/models/ted_dbt/silver/schema.yml
+++ b/airflow_lappis/dags/dbt/ipea/models/ted_dbt/silver/schema.yml
@@ -31,6 +31,9 @@ models:
     - name: demais_colunas
       description: >
         Outras colunas provenientes da tabela `empenhos_tesouro`, contendo informações adicionais sobre os empenhos, como data de emissão, valor, unidade gestora, entre outras.
+    - name: dt_ingest
+      description: >
+        Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
 
   - name: nc_plano_acao
     description: >
@@ -73,6 +76,9 @@ models:
     - name: nc_valor
       description: >
         Valor monetário da Nota de Crédito, ajustado conforme o tipo de evento contábil.
+    - name: dt_ingest
+      description: >
+        Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
 
   - name: pf_plano_acao
     description: >
@@ -114,3 +120,6 @@ models:
     - name: plano_acao
       description: >
         Identificador do Plano de Ação associado à Programação Financeira, determinado por correspondência direta com o sistema TransfereGov ou via número de transferência.
+    - name: dt_ingest
+      description: >
+        Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.


### PR DESCRIPTION
## O que foi feito

Passagem do valor da data de ingestão vinda da raw por todos os modelos.

1. **Modelos Bronze:**
- Adicionada conversão de `dt_ingest` de *string* para `timestamptz` com timezone UTC-3 (Brasília).  
  Formato: `(dt_ingest || '-03:00')::timestamptz`

2. **Modelos Silver:**
- Propagação do `dt_ingest` usando `GREATEST()` e `MAX()` quando há múltiplas fontes.  
  Mantém a data mais recente entre as tabelas utilizadas.

3. **Modelos Gold:**
- Propagação do `dt_ingest` usando `GREATEST()` e `MAX()`.

Ao dar *merge* neste PR, é necessário rodar o comando abaixo:
```bash
dbt run -m empenho_tesouro --full-refresh
```
Isso é necessário porque, como essa é a única tabela incremental (devido à natureza desse tipo de tabela), quando há adição de coluna é preciso recarregar a tabela por completo.

##### FIXES #32 