### PR TITLE
style: roda lint dags emendas especiais

### DIFF
--- a/airflow_lappis/dags/data_ingest/transferegov_emendas/finalidade_especial_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/transferegov_emendas/finalidade_especial_ingest_dag.py
@@ -48,10 +48,16 @@ def api_finalidade_especial_dag() -> None:
             db.insert_data(
                 finalidades_data,
                 "finalidades_especiais",
-                conflict_fields=["id_executor", "cd_area_politica_publica_tipo_pt", 
-                                 "area_politica_publica_pt"],
-                primary_key=["id_executor", "cd_area_politica_publica_tipo_pt",
-                             "area_politica_publica_pt"],
+                conflict_fields=[
+                    "id_executor",
+                    "cd_area_politica_publica_tipo_pt",
+                    "area_politica_publica_pt",
+                ],
+                primary_key=[
+                    "id_executor",
+                    "cd_area_politica_publica_tipo_pt",
+                    "area_politica_publica_pt",
+                ],
                 schema="transferegov_emendas",
             )
 
@@ -67,5 +73,6 @@ def api_finalidade_especial_dag() -> None:
             )
 
     fetch_and_store_finalidade_especial()
+
 
 api_finalidade_especial_dag()

--- a/airflow_lappis/dags/data_ingest/transferegov_emendas/ordem_bancaria_especial_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/transferegov_emendas/ordem_bancaria_especial_ingest_dag.py
@@ -66,4 +66,5 @@ def api_ordem_bancaria_especial_dag() -> None:
 
     fetch_and_store_ordem_bancaria_especial()
 
+
 api_ordem_bancaria_especial_dag()

--- a/airflow_lappis/plugins/cliente_transferegov_emendas.py
+++ b/airflow_lappis/plugins/cliente_transferegov_emendas.py
@@ -857,8 +857,7 @@ class ClienteTransfereGov(ClienteBase):
             f"Total records: {len(all_data)}"
         )
         return all_data
-      
-    
+
     def get_ordens_bancarias_especiais(
         self, limit: int = 1000, offset: int = 0
     ) -> Optional[list]:
@@ -955,7 +954,9 @@ class ClienteTransfereGov(ClienteBase):
         )
         return all_data
 
-    def get_relatorio_gestao_novo_especial(self, limit: int = 1000, offset: int = 0) -> Optional[list]:
+    def get_relatorio_gestao_novo_especial(
+        self, limit: int = 1000, offset: int = 0
+    ) -> Optional[list]:
         """
         Obter relatórios de gestão novo especial com paginação.
 
@@ -1048,7 +1049,7 @@ class ClienteTransfereGov(ClienteBase):
             f"Total records: {len(all_data)}"
         )
         return all_data
-    
+
     def get_plano_trabalho_especial(
         self, limit: int = 1000, offset: int = 0
     ) -> Optional[list]:
@@ -1144,7 +1145,9 @@ class ClienteTransfereGov(ClienteBase):
         )
         return all_data
 
-    def get_historico_pagamentos_especiais(self, limit: int = 1000, offset: int = 0) -> Optional[list]:
+    def get_historico_pagamentos_especiais(
+        self, limit: int = 1000, offset: int = 0
+    ) -> Optional[list]:
         """
         Obter histórico de pagamentos especiais com paginação.
 


### PR DESCRIPTION
## Descrição

Executa o **lint** nas DAGs e no cliente de emendas do **Transferegov** que não haviam sido verificados no PR anterior.

Arquivos afetados:
- `finalidades_especial_ingest_dag`
- `ordem_bancaria_especial_ingest_dag`
- `cliente_transferegov_emendas`

Este PR contém apenas ajustes de formatação e padronização automática do lint, **sem alterações de lógica ou comportamento do código**.