### PR TITLE
feat(dag): TEDs email empenhos parlamentares

### DIFF
--- a/airflow_lappis/dags/data_ingest/tesouro_gerencial/empenhos_tesouro_parlamentares_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/tesouro_gerencial/empenhos_tesouro_parlamentares_ingest_dag.py
@@ -1,0 +1,158 @@
+from typing import Dict, Any, Optional
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from airflow.models import Variable
+from datetime import datetime, timedelta
+import logging
+import json
+from schedule_loader import get_dynamic_schedule
+from cliente_email import fetch_and_process_email
+from cliente_postgres import ClientPostgresDB
+from postgres_helpers import get_postgres_conn
+import pandas as pd
+import io
+
+# Configurações básicas da DAG
+default_args = {
+    "owner": "Tiago",
+    "depends_on_past": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+}
+
+COLUMN_MAPPING = {
+    0: "programa_governo",
+    1: "programa_governo_descricao",
+    2: "acao_governo",
+    3: "acao_governo_descricao",
+    4: "emissao_mes",
+    5: "emissao_dia",
+    6: "ne_ccor",
+    7: "ne_num_processo",
+    8: "ne_info_complementar",
+    9: "ne_ccor_descricao",
+    10: "doc_observacao",
+    11: "natureza_despesa",
+    12: "natureza_despesa_descricao",
+    13: "ne_ccor_favorecido",
+    14: "ne_ccor_favorecido_descricao",
+    15: "ne_ccor_ano_emissao",
+    16: "ptres",
+    17: "fonte_recursos_detalhada",
+    18: "fonte_recursos_detalhada_descricao",
+    19: "despesas_empenhadas",
+    20: "despesas_liquidadas",
+    21: "despesas_pagas",
+    22: "restos_a_pagar_inscritos",
+    23: "restos_a_pagar_pagos",
+}
+
+EMAIL_SUBJECT = "notas_de_empenho_ano_atual"
+SKIPROWS = 8
+
+# Configurações da DAG
+with DAG(
+    dag_id="email_tesouro_parlamentares_ingest",
+    default_args=default_args,
+    description="Processa anexos dos empenhos vindo do email, formata e insere no db",
+    schedule_interval=get_dynamic_schedule("empenhos_tesouro_parlamentares_ingest_dag"),
+    start_date=datetime(2023, 12, 1),
+    catchup=False,
+    tags=["MIR", "email", "empenhos", "tesouro", "parlamentares"],
+) as dag:
+
+    def process_email_data(**context: Dict[str, Any]) -> Optional[Any]:
+        creds = json.loads(Variable.get("email_credentials"))
+
+        EMAIL = creds["email"]
+        PASSWORD = creds["password"]
+        IMAP_SERVER = creds["imap_server"]
+        SENDER_EMAIL = creds["sender_email"]
+
+        try:
+            logging.info("Iniciando o processamento dos emails...")
+            csv_data = fetch_and_process_email(
+                IMAP_SERVER,
+                EMAIL,
+                PASSWORD,
+                SENDER_EMAIL,
+                EMAIL_SUBJECT,
+                COLUMN_MAPPING,
+                skiprows=SKIPROWS,
+            )
+            if not csv_data:
+                logging.warning("Nenhum e-mail encontrado com o assunto esperado.")
+                return None
+
+            logging.info(
+                "CSV processado com sucesso. Dados encontrados: %s", len(csv_data)
+            )
+            return csv_data
+        except Exception as e:
+            logging.error("Erro no processamento dos emails: %s", str(e))
+            raise
+
+    def insert_data_to_db(**context: Dict[str, Any]) -> None:
+        """
+        Função para inserir os dados no banco de dados.
+        Os dados do CSV são recuperados do XCom.
+        """
+        try:
+            task_instance: Any = context["ti"]
+            csv_data: Any = task_instance.xcom_pull(task_ids="process_emails")
+
+            if not csv_data:
+                logging.warning("Nenhum dado para inserir no banco.")
+                return
+
+            df = pd.read_csv(io.StringIO(csv_data))
+            df = df[df["ne_ccor_ano_emissao"].astype(str).str.startswith("20")]
+            data = df.to_dict(orient="records")
+
+            # Adicionar dt_ingest a cada registro
+            for record in data:
+                record["dt_ingest"] = datetime.now().isoformat()
+
+            postgres_conn_str = get_postgres_conn("postgres_mir")
+            db = ClientPostgresDB(postgres_conn_str)
+
+            unique_key = [
+                "ne_ccor",
+                "natureza_despesa",
+                "doc_observacao",
+                "ne_ccor_ano_emissao",
+                "emissao_dia",
+                "emissao_mes",
+                "despesas_empenhadas",
+                "despesas_liquidadas",
+                "despesas_pagas",
+            ]
+
+            db.insert_data(
+                data,
+                "empenhos_tesouro_parlamentares",
+                conflict_fields=unique_key,
+                primary_key=unique_key,
+                schema="siafi",
+            )
+            logging.info("Dados inseridos com sucesso no banco de dados.")
+        except Exception as e:
+            logging.error("Erro ao inserir dados no banco: %s", str(e))
+            raise
+
+    # Tarefa 1: Processar os e-mails e retornar CSV
+    process_emails_task = PythonOperator(
+        task_id="process_emails",
+        python_callable=process_email_data,
+        provide_context=True,
+    )
+
+    # Tarefa 2: Inserir os dados no banco de dados
+    insert_to_db_task = PythonOperator(
+        task_id="insert_to_db",
+        python_callable=insert_data_to_db,
+        provide_context=True,
+    )
+
+    # Fluxo da DAG
+    process_emails_task >> insert_to_db_task

--- a/airflow_lappis/plugins/cliente_email.py
+++ b/airflow_lappis/plugins/cliente_email.py
@@ -45,15 +45,16 @@ def extract_csv_from_zip(
 
 def fetch_email_with_zip(
     imap_server: str, email: str, password: str, sender_email: str, subject: str
-) -> Optional[bytes]:
-    """Busca o primeiro e-mail do dia atual com um anexo ZIP."""
+) -> List[bytes]:
+    """Busca todos os e-mails do dia atual e retorna todos os anexos ZIP."""
     today = datetime.now(pytz.timezone("America/Sao_Paulo")).date()
+    zip_payloads: List[bytes] = []
     with MailBox(imap_server).login(email, password) as mailbox:
         for msg in mailbox.fetch(AND(date=today, from_=sender_email, subject=subject)):
             for attachment in msg.attachments:
-                if attachment.filename.endswith(".zip"):
-                    return cast(bytes, attachment.payload)
-    return None
+                if attachment.filename.lower().endswith(".zip"):
+                    zip_payloads.append(cast(bytes, attachment.payload))
+    return zip_payloads
 
 
 def fetch_and_process_email(
@@ -65,15 +66,25 @@ def fetch_and_process_email(
     column_mapping: dict,
     skiprows: int = 0,
 ) -> Optional[str]:
-    """Busca e processa o primeiro e-mail com um ZIP contendo um CSV formatado."""
+    """Busca e processa e-mails do dia, extraindo CSVs de todos os ZIPs anexados."""
     try:
-        zip_payload = fetch_email_with_zip(
+        zip_payloads = fetch_email_with_zip(
             imap_server, email, password, sender_email, subject
         )
-        if zip_payload:
+        if not zip_payloads:
+            logging.warning("Nenhum anexo ZIP encontrado.")
+            return None
+
+        dataframes: List[pd.DataFrame] = []
+        for zip_payload in zip_payloads:
             csv_data = extract_csv_from_zip(zip_payload, column_mapping, skiprows)
             if csv_data is not None:
-                return csv_data.to_csv(index=False)
+                dataframes.append(csv_data)
+
+        if dataframes:
+            combined_df = pd.concat(dataframes, ignore_index=True)
+            return combined_df.to_csv(index=False)
+
         logging.warning("Nenhum CSV processado.")
     except Exception as e:
         logging.error(f"Erro ao processar e-mails: {e}")


### PR DESCRIPTION
### O que foi feito: 
Adiciona a DAG `email_tesouro_parlamentares_ingest` e reestrutura o plugin `cliente_email` para processar múltiplos anexos ZIP em múltiplos e-mails com o mesmo assunto no mesmo dia, mantendo **compatibilidade com DAGs existentes**.

**Nova DAG**
- `empenhos_tesouro_parlamentares_ingest_dag.py`
- Processa anexos ZIP de e-mails com assunto `notas_de_empenho_ano_atual`
- Converte CSV → DataFrame
- Filtra ano válido (`ne_ccor_ano_emissao` iniciando com `20`)
- Insere em `siafi.empenhos_tesouro_parlamentares`
- Adiciona `dt_ingest`
- Conexão via `get_postgres_conn("postgres_mir")`

**Plugin `cliente_email`**
- Busca **todos os e-mails do filtro**, não apenas o primeiro
- Coleta **todos os ZIPs encontrados**
- Processa e concatena os dados

#108 