### PR TITLE
feat: silver planos cruzada com parlamentares

### DIFF
--- a/airflow_lappis/dags/dbt/mir/models/emendas_dbt/silver/planos_partidos.sql
+++ b/airflow_lappis/dags/dbt/mir/models/emendas_dbt/silver/planos_partidos.sql
@@ -1,0 +1,96 @@
+{{ config(materialized='table') }}
+
+WITH bronze_planos_acoes AS (
+    SELECT * FROM {{ ref('planos_acoes') }} 
+),
+
+bronze_deputados AS (
+    SELECT * FROM {{ ref('deputados') }}
+),
+
+bronze_senadores AS (
+    SELECT * FROM {{ ref('senadores') }}
+),
+
+parlamentares_unificados AS (
+    SELECT 
+        id AS id_parlamentar,
+        TRIM(UPPER(nome)) AS chave_join_nome, 
+        nome AS nome_parlamentar,
+        'Deputado' AS cargo_parlamentar,
+        siglapartido AS sigla_partido,
+        siglauf AS uf_parlamentar,
+        urlfoto AS url_foto,
+        email
+    FROM bronze_deputados
+
+    UNION ALL
+
+    SELECT 
+        id AS id_parlamentar,
+        TRIM(UPPER(nome_parlamentar)) AS chave_join_nome, 
+        nome_parlamentar AS nome_parlamentar,
+        'Senador' AS cargo_parlamentar,
+        sigla_partido AS sigla_partido,
+        uf AS uf_parlamentar,
+        url_foto AS url_foto,
+        email
+    FROM bronze_senadores
+),
+
+planos_acoes_tratado AS (
+    SELECT 
+        *,
+        TRIM(UPPER(nome_parlamentar_emenda_plano_acao)) AS chave_join_nome
+    FROM bronze_planos_acoes
+),
+
+final AS (
+    SELECT 
+        -- Todas as features de Planos de Ação
+        pa.id_plano_acao,
+        pa.codigo_plano_acao,
+        pa.ano_plano_acao,
+        pa.modalidade_plano_acao,
+        pa.situacao_plano_acao,
+        pa.cnpj_beneficiario_plano_acao,
+        pa.nome_beneficiario_plano_acao,
+        pa.uf_beneficiario_plano_acao,
+        pa.codigo_banco_plano_acao,
+        pa.codigo_situacao_dado_bancario_plano_acao,
+        pa.nome_banco_plano_acao,
+        pa.numero_agencia_plano_acao,
+        pa.dv_agencia_plano_acao,
+        pa.numero_conta_plano_acao,
+        pa.dv_conta_plano_acao,
+        pa.nome_parlamentar_emenda_plano_acao,
+        pa.ano_emenda_parlamentar_plano_acao,
+        pa.codigo_parlamentar_emenda_plano_acao,
+        pa.sequencial_emenda_parlamentar_plano_acao,
+        pa.numero_emenda_parlamentar_plano_acao,
+        pa.codigo_emenda_parlamentar_formatado_plano_acao,
+        pa.codigo_descricao_areas_politicas_publicas_plano_acao,
+        pa.descricao_programacao_orcamentaria_plano_acao,
+        pa.motivo_impedimento_plano_acao,
+        pa.valor_custeio_plano_acao,
+        pa.valor_investimento_plano_acao,
+        pa.id_programa,
+        
+        -- Features unificadas dos Parlamentares
+        parl.id_parlamentar,
+        parl.cargo_parlamentar,
+        parl.nome_parlamentar,
+        parl.sigla_partido,
+        parl.uf_parlamentar,
+        parl.url_foto,
+        parl.email,
+        
+        -- Data de ingestão (mantendo a da tabela fato)
+        pa.dt_ingest
+        
+    FROM planos_acoes_tratado pa
+    LEFT JOIN parlamentares_unificados parl
+        ON pa.chave_join_nome = parl.chave_join_nome
+)
+
+SELECT * FROM final

--- a/airflow_lappis/dags/dbt/mir/models/emendas_dbt/silver/schema.yml
+++ b/airflow_lappis/dags/dbt/mir/models/emendas_dbt/silver/schema.yml
@@ -1,0 +1,168 @@
+version: 2
+
+models:
+
+  - name: planos_partidos
+    description: >
+      Tabela silver que integra as informações dos planos de ação especiais relacionados a emendas
+      parlamentares do TransfereGov com metadados de parlamentares (deputados e senadores).
+      A partir da tabela bronze planos_acoes e das bases de deputados e senadores, enriquece cada
+      plano de ação com dados de identificação do parlamentar, partido, UF, foto e e-mail.
+    meta:
+      tags:
+        - silver
+    columns:
+      # Colunas de planos de ação (herdadas da camada bronze)
+      - name: id_plano_acao
+        description: >
+          Identificador único do Plano de Ação (PA).
+      - name: codigo_plano_acao
+        description: >
+          Código do Programa concatenado com o ID do Plano de Ação.
+      - name: ano_plano_acao
+        description: >
+          Ano de criação do Plano de Ação.
+      - name: modalidade_plano_acao
+        description: >
+          Modalidade de Transferência do Plano de Ação.
+      - name: situacao_plano_acao
+        description: >
+          Situação do Plano de Ação.
+      - name: cnpj_beneficiario_plano_acao
+        description: >
+          CNPJ – Cadastro Nacional de Pessoa Jurídica do Beneficiário do Plano de Ação.
+      - name: nome_beneficiario_plano_acao
+        description: >
+          Nome do Beneficiário do Plano de Ação.
+      - name: uf_beneficiario_plano_acao
+        description: >
+          Sigla da Unidade de Federação do beneficiário.
+      - name: codigo_banco_plano_acao
+        description: >
+          Código do Banco do Plano de Ação.
+      - name: codigo_situacao_dado_bancario_plano_acao
+        description: >
+          Código da Situação da Conta Corrente do Plano de Ação.
+      - name: nome_banco_plano_acao
+        description: >
+          Nome do Banco do Plano de Ação.
+      - name: numero_agencia_plano_acao
+        description: >
+          Número da Agência Bancária da Conta Corrente do Plano de Ação.
+      - name: dv_agencia_plano_acao
+        description: >
+          Dígito Verificador da Agência Bancária da Conta Corrente do Plano de Ação.
+      - name: numero_conta_plano_acao
+        description: >
+          Número da Conta Corrente do Plano de Ação.
+      - name: dv_conta_plano_acao
+        description: >
+          Dígito Verificador da Conta Corrente do Plano de Ação.
+      - name: nome_parlamentar_emenda_plano_acao
+        description: >
+          Nome do Parlamentar Autor da Emenda vinculado ao Plano de Ação.
+      - name: ano_emenda_parlamentar_plano_acao
+        description: >
+          Ano da Emenda Parlamentar associada ao Plano de Ação.
+      - name: codigo_parlamentar_emenda_plano_acao
+        description: >
+          Código do Parlamentar Autor da Emenda.
+      - name: sequencial_emenda_parlamentar_plano_acao
+        description: >
+          Sequencial da Emenda por Parlamentar no Ano.
+      - name: numero_emenda_parlamentar_plano_acao
+        description: >
+          Concatenação do Ano, Código e Sequencial do Parlamentar, formando o identificador da emenda.
+      - name: codigo_emenda_parlamentar_formatado_plano_acao
+        description: >
+          Código formatado da Emenda Parlamentar associada ao Plano de Ação.
+      - name: codigo_descricao_areas_politicas_publicas_plano_acao
+        description: >
+          Concatenação dos códigos e descrições dos tipos das áreas de políticas públicas
+          com os códigos e descrições das áreas das políticas públicas.
+      - name: descricao_programacao_orcamentaria_plano_acao
+        description: >
+          Concatenação das programações orçamentárias constantes da Lei Orçamentária do ente
+          beneficiado na qual o recurso será apropriado.
+      - name: motivo_impedimento_plano_acao
+        description: >
+          Motivo do impedimento do Plano de Ação, quando existente.
+      - name: valor_custeio_plano_acao
+        description: >
+          Valor consolidado de custeio das emendas parlamentares do Plano de Ação.
+      - name: valor_investimento_plano_acao
+        description: >
+          Valor consolidado de investimento das emendas parlamentares do Plano de Ação.
+      - name: id_programa
+        description: >
+          Identificador único do Programa associado ao Plano de Ação.
+      # Colunas de metadados dos parlamentares
+      - name: id_parlamentar
+        description: >
+          Identificador único do parlamentar na base unificada de deputados e senadores.
+      - name: cargo_parlamentar
+        description: >
+          Cargo do parlamentar responsável pela emenda (por exemplo, Deputado ou Senador).
+      - name: nome_parlamentar
+        description: >
+          Nome do parlamentar conforme registrado na base de origem (Câmara dos Deputados ou Senado Federal).
+      - name: sigla_partido
+        description: >
+          Sigla do partido ao qual o parlamentar está filiado.
+      - name: uf_parlamentar
+        description: >
+          Sigla da Unidade Federativa (UF) que o parlamentar representa.
+      - name: url_foto
+        description: >
+          URL da foto oficial do parlamentar na base de origem.
+      - name: email
+        description: >
+          Endereço de e-mail institucional do parlamentar.
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) mais recente de ingestão dos dados das tabelas fonte utilizadas neste modelo.
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'emendas.planos_partidos'
+          nome_coluna: 'id_plano_acao'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'emendas.planos_partidos'
+          nome_coluna: 'ano_plano_acao'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'emendas.planos_partidos'
+          nome_coluna: 'codigo_situacao_dado_bancario_plano_acao'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'emendas.planos_partidos'
+          nome_coluna: 'numero_agencia_plano_acao'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'emendas.planos_partidos'
+          nome_coluna: 'numero_conta_plano_acao'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'emendas.planos_partidos'
+          nome_coluna: 'sequencial_emenda_parlamentar_plano_acao'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'emendas.planos_partidos'
+          nome_coluna: 'valor_custeio_plano_acao'
+          tipo_esperado: 'numeric'
+      - verificacao_tipagem:
+          nome_tabela: 'emendas.planos_partidos'
+          nome_coluna: 'valor_investimento_plano_acao'
+          tipo_esperado: 'numeric'
+      - verificacao_tipagem:
+          nome_tabela: 'emendas.planos_partidos'
+          nome_coluna: 'id_programa'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'emendas.planos_partidos'
+          nome_coluna: 'id_parlamentar'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'emendas.planos_partidos'
+          nome_coluna: 'dt_ingest'
+          tipo_esperado: 'timestamp with time zone'


### PR DESCRIPTION
## Descrição do PR

Este PR cria o modelo **silver `planos_partidos`**, integrando dados de planos de ação de emendas com informações de deputados e senadores.

O modelo unifica os dados do autor da emenda (cargo, nome, partido, UF, e-mail e URL da foto), enriquecendo a base original.

As colunas de negócio de `planos_acoes` foram mantidas, garantindo rastreabilidade com a camada bronze.

A documentação do modelo foi adicionada em `emendas_dbt/silver/schema.yml`, com descrição das colunas.

##### FIXES #106 