### PR TITLE
feat: cliente email xcom to drive prevenção de memória

### DIFF
--- a/airflow_lappis/dags/data_ingest/tesouro_gerencial/empenhos_tesouro_emendas_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/tesouro_gerencial/empenhos_tesouro_emendas_ingest_dag.py
@@ -10,7 +10,6 @@ from cliente_email import fetch_and_process_email
 from cliente_postgres import ClientPostgresDB
 from postgres_helpers import get_postgres_conn
 import pandas as pd
-import io
 
 # Configurações básicas da DAG
 default_args = {
@@ -75,13 +74,12 @@ with DAG(
 
         EMAIL = creds["email"]
         PASSWORD = creds["password"]
-        IMAP_SERVER = creds["imap_ser" \
-        "ver"]
+        IMAP_SERVER = creds["imap_server"]
         SENDER_EMAIL = creds["sender_email"]
 
         try:
             logging.info("Iniciando o processamento dos emails...")
-            csv_data = fetch_and_process_email(
+            csv_path = fetch_and_process_email(
                 IMAP_SERVER,
                 EMAIL,
                 PASSWORD,
@@ -89,8 +87,9 @@ with DAG(
                 EMAIL_SUBJECT,
                 COLUMN_MAPPING,
                 skiprows=SKIPROWS,
+                output_path=f"/tmp/{context['dag'].dag_id}_{context['ts_nodash']}.csv",
             )
-            if not csv_data:
+            if not csv_path:
                 logging.warning(
                     "Nenhum CSV valido foi extraido dos e-mails encontrados "
                     "para o assunto esperado."
@@ -98,9 +97,10 @@ with DAG(
                 return None
 
             logging.info(
-                "CSV processado com sucesso. Dados encontrados: %s", len(csv_data)
+                "CSV processado com sucesso e gravado em: %s",
+                csv_path,
             )
-            return csv_data
+            return csv_path
         except Exception as e:
             logging.error("Erro no processamento dos emails: %s", str(e))
             raise
@@ -112,13 +112,13 @@ with DAG(
         """
         try:
             task_instance: Any = context["ti"]
-            csv_data: Any = task_instance.xcom_pull(task_ids="process_emails")
+            csv_path: Any = task_instance.xcom_pull(task_ids="process_emails")
 
-            if not csv_data:
-                logging.warning("Nenhum dado para inserir no banco.")
+            if not csv_path:
+                logging.warning("Caminho do CSV não encontrado no XCom.")
                 return
 
-            df = pd.read_csv(io.StringIO(csv_data))
+            df = pd.read_csv(csv_path)
             df = df[df["ne_ccor_ano_emissao"].astype(str).str.startswith("20")]
             data = df.to_dict(orient="records")
 

--- a/airflow_lappis/dags/data_ingest/tesouro_gerencial/empenhos_tesouro_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/tesouro_gerencial/empenhos_tesouro_ingest_dag.py
@@ -10,7 +10,6 @@ from cliente_email import fetch_and_process_email
 from cliente_postgres import ClientPostgresDB
 from postgres_helpers import get_postgres_conn
 import pandas as pd
-import io
 
 # Configurações básicas da DAG
 default_args = {
@@ -67,7 +66,7 @@ with DAG(
 
         try:
             logging.info("Iniciando o processamento dos emails...")
-            csv_data = fetch_and_process_email(
+            csv_path = fetch_and_process_email(
                 IMAP_SERVER,
                 EMAIL,
                 PASSWORD,
@@ -75,15 +74,17 @@ with DAG(
                 EMAIL_SUBJECT,
                 COLUMN_MAPPING,
                 skiprows=SKIPROWS,
+                output_path=f"/tmp/{context['dag'].dag_id}_{context['ts_nodash']}.csv",
             )
-            if not csv_data:
+            if not csv_path:
                 logging.warning("Nenhum e-mail encontrado com o assunto esperado.")
                 return None
 
             logging.info(
-                "CSV processado com sucesso. Dados encontrados: %s", len(csv_data)
+                "CSV processado com sucesso e gravado em: %s",
+                csv_path,
             )
-            return csv_data
+            return csv_path
         except Exception as e:
             logging.error("Erro no processamento dos emails: %s", str(e))
             raise
@@ -95,13 +96,13 @@ with DAG(
         """
         try:
             task_instance: Any = context["ti"]
-            csv_data: Any = task_instance.xcom_pull(task_ids="process_emails")
+            csv_path: Any = task_instance.xcom_pull(task_ids="process_emails")
 
-            if not csv_data:
-                logging.warning("Nenhum dado para inserir no banco.")
+            if not csv_path:
+                logging.warning("Caminho do CSV não encontrado no XCom.")
                 return
 
-            df = pd.read_csv(io.StringIO(csv_data))
+            df = pd.read_csv(csv_path)
             df = df[df["ne_ccor_ano_emissao"].astype(str).str.startswith("20")]
             data = df.to_dict(orient="records")
 

--- a/airflow_lappis/dags/data_ingest/tesouro_gerencial/mcid/dotacao_execucao_outras_fontes_mcid_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/tesouro_gerencial/mcid/dotacao_execucao_outras_fontes_mcid_ingest_dag.py
@@ -116,7 +116,8 @@ with DAG(
 
         try:
             logging.info("Iniciando o processamento dos emails")
-            csv_data = fetch_and_process_email(
+            output_path = f"/tmp/{context['dag'].dag_id}_{context['ts_nodash']}.csv"
+            csv_path = fetch_and_process_email(
                 IMAP_SERVER,
                 EMAIL,
                 PASSWORD,
@@ -124,15 +125,14 @@ with DAG(
                 EMAIL_SUBJECT,
                 COLUMN_MAPPING,
                 skiprows=SKIPROWS,
+                output_path=output_path,
             )
-            if not csv_data:
+            if not csv_path:
                 logging.warning("Nenhum e-mail encontrado com o assunto esperado.")
                 raise AirflowSkipException("Nenhum e-mail encontrado. Task ignorada.")
 
-            logging.info(
-                "CSV processado com sucesso. Registros encontrados: %s", len(csv_data)
-            )
-            return csv_data
+            logging.info("CSV processado com sucesso. Arquivo gerado em: %s", csv_path)
+            return csv_path
         except Exception as e:
             logging.error("Erro no processamento dos emails: %s", str(e))
             raise
@@ -140,15 +140,15 @@ with DAG(
     def insert_data_to_db(**context: Dict[str, Any]) -> None:
         try:
             task_instance: Any = context["ti"]
-            csv_data: Any = task_instance.xcom_pull(task_ids="process_emails")
+            csv_path: Any = task_instance.xcom_pull(task_ids="process_emails")
 
-            if not csv_data:
+            if not csv_path:
                 logging.warning("Nenhum dado para inserir no banco.")
                 raise AirflowSkipException(
                     "Nenhum dado foi encontrado para inserção no BD"
                 )
 
-            df = pd.read_csv(io.StringIO(csv_data))
+            df = pd.read_csv(csv_path)
             data = df.to_dict(orient="records")
 
             for record in data:
@@ -156,7 +156,6 @@ with DAG(
 
             postgres_conn_str = get_postgres_conn()
             db = ClientPostgresDB(postgres_conn_str)
-
 
             db.insert_data(
                 data,

--- a/airflow_lappis/dags/data_ingest/tesouro_gerencial/mcid/empenho_emendas_parlamentares_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/tesouro_gerencial/mcid/empenho_emendas_parlamentares_ingest_dag.py
@@ -1,8 +1,7 @@
-import io
 import json
 import logging
 from datetime import datetime, timedelta
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import pandas as pd
 from airflow import DAG
@@ -55,7 +54,7 @@ COLUMN_MAPPING = {
 }
 
 EMAIL_SUBJECT = "notas_empenho_emendas_parlamentares_mcid"
-SKIPROWS = 9
+SKIPROWS = 12
 
 with DAG(
     dag_id="empenho_emendas_parlamentares_ingest_dag",
@@ -64,7 +63,7 @@ with DAG(
     schedule_interval=get_dynamic_schedule("empenho_emendas_parlamentares_ingest_dag"),
     start_date=datetime(2026, 3, 25),
     catchup=False,
-    tags=["email", "empenhos", "tesouro", "emendas"],
+    tags=["email", "mcid", "empenhos", "tesouro", "emendas"],
 ) as dag:
 
     def process_email_data(**context: Dict[str, Any]) -> Optional[Any]:
@@ -77,7 +76,8 @@ with DAG(
 
         try:
             logging.info("Iniciando o processamento dos emails")
-            csv_data = fetch_and_process_email(
+            output_path = f"/tmp/{context['dag'].dag_id}_{context['ts_nodash']}.csv"
+            csv_path = fetch_and_process_email(
                 IMAP_SERVER,
                 EMAIL,
                 PASSWORD,
@@ -85,15 +85,14 @@ with DAG(
                 EMAIL_SUBJECT,
                 COLUMN_MAPPING,
                 skiprows=SKIPROWS,
+                output_path=output_path,
             )
-            if not csv_data:
+            if not csv_path:
                 logging.warning("Nenhum e-mail encontrado com o assunto esperado.")
                 raise AirflowSkipException("Nenhum e-mail encontrado. Task ignorada.")
 
-            logging.info(
-                "CSV processado com sucesso. Dados encontrados: %s", len(csv_data)
-            )
-            return csv_data
+            logging.info("CSV processado com sucesso. Arquivo gerado em: %s", csv_path)
+            return csv_path
         except Exception as e:
             logging.error("Erro no processamento dos emails: %s", str(e))
             raise
@@ -101,15 +100,15 @@ with DAG(
     def insert_data_to_db(**context: Dict[str, Any]) -> None:
         try:
             task_instance: Any = context["ti"]
-            csv_data: Any = task_instance.xcom_pull(task_ids="process_emails")
+            csv_path: Any = task_instance.xcom_pull(task_ids="process_emails")
 
-            if not csv_data:
+            if not csv_path:
                 logging.warning("Nenhum dado para inserir no banco.")
                 raise AirflowSkipException(
                     "Nenhum dado foi encontrado para inserção no BD"
                 )
 
-            df = pd.read_csv(io.StringIO(csv_data), skiprows=[1, 2, 3])
+            df = pd.read_csv(csv_path)
             df = df[df["ne_ccor_ano_emissao"].astype(str).str.startswith("20")]
             data = df.to_dict(orient="records")
 

--- a/airflow_lappis/dags/data_ingest/tesouro_gerencial/mcid/orcamento_mcid_por_acao_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/tesouro_gerencial/mcid/orcamento_mcid_por_acao_ingest_dag.py
@@ -64,7 +64,7 @@ COLUMN_MAPPING = {
 }
 
 EMAIL_SUBJECT = "orcamento_mcid_por_acao"
-SKIPROWS = 10
+SKIPROWS = 8
 
 
 # A formatação do CSV estava como utf-16.
@@ -127,7 +127,8 @@ with DAG(
 
         try:
             logging.info("Iniciando o processamento dos emails")
-            csv_data = fetch_and_process_email(
+            output_path = f"/tmp/{context['dag'].dag_id}_{context['ts_nodash']}.csv"
+            csv_path = fetch_and_process_email(
                 IMAP_SERVER,
                 EMAIL,
                 PASSWORD,
@@ -135,15 +136,14 @@ with DAG(
                 EMAIL_SUBJECT,
                 COLUMN_MAPPING,
                 skiprows=SKIPROWS,
+                output_path=output_path,
             )
-            if not csv_data:
+            if not csv_path:
                 logging.warning("Nenhum e-mail encontrado com o assunto esperado.")
                 raise AirflowSkipException("Nenhum e-mail encontrado. Task ignorada.")
 
-            logging.info(
-                "CSV processado com sucesso. Registros encontrados: %s", len(csv_data)
-            )
-            return csv_data
+            logging.info("CSV processado com sucesso. Arquivo gerado em: %s", csv_path)
+            return csv_path
         except Exception as e:
             logging.error("Erro no processamento dos emails: %s", str(e))
             raise
@@ -151,15 +151,15 @@ with DAG(
     def insert_data_to_db(**context: Dict[str, Any]) -> None:
         try:
             task_instance: Any = context["ti"]
-            csv_data: Any = task_instance.xcom_pull(task_ids="process_emails")
+            csv_path: Any = task_instance.xcom_pull(task_ids="process_emails")
 
-            if not csv_data:
+            if not csv_path:
                 logging.warning("Nenhum dado para inserir no banco.")
                 raise AirflowSkipException(
                     "Nenhum dado foi encontrado para inserção no BD"
                 )
 
-            df = pd.read_csv(io.StringIO(csv_data))
+            df = pd.read_csv(csv_path)
             data = df.to_dict(orient="records")
 
             for record in data:
@@ -167,7 +167,6 @@ with DAG(
 
             postgres_conn_str = get_postgres_conn()
             db = ClientPostgresDB(postgres_conn_str)
-
 
             db.insert_data(
                 data,

--- a/airflow_lappis/dags/data_ingest/tesouro_gerencial/mir/empenhos_tesouro_parlamentares_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/tesouro_gerencial/mir/empenhos_tesouro_parlamentares_ingest_dag.py
@@ -71,7 +71,7 @@ with DAG(
 
         try:
             logging.info("Iniciando o processamento dos emails...")
-            csv_data = fetch_and_process_email(
+            csv_path = fetch_and_process_email(
                 IMAP_SERVER,
                 EMAIL,
                 PASSWORD,
@@ -79,8 +79,9 @@ with DAG(
                 EMAIL_SUBJECT,
                 COLUMN_MAPPING,
                 skiprows=SKIPROWS,
+                output_path=f"/tmp/{context['dag'].dag_id}_{context['ts_nodash']}.csv",
             )
-            if not csv_data:
+            if not csv_path:
                 logging.warning(
                     "Nenhum CSV valido foi extraido dos e-mails encontrados "
                     "para o assunto esperado."
@@ -88,9 +89,10 @@ with DAG(
                 return None
 
             logging.info(
-                "CSV processado com sucesso. Dados encontrados: %s", len(csv_data)
+                "CSV processado com sucesso e gravado em: %s",
+                csv_path,
             )
-            return csv_data
+            return csv_path
         except Exception as e:
             logging.error("Erro no processamento dos emails: %s", str(e))
             raise
@@ -101,14 +103,15 @@ with DAG(
         Os dados do CSV são recuperados do XCom.
         """
         try:
-            task_instance: Any = context["ti"]
-            csv_data: Any = task_instance.xcom_pull(task_ids="process_emails")
+            ti = context["ti"]
+            csv_path = ti.xcom_pull(task_ids="process_emails")
 
-            if not csv_data:
-                logging.warning("Nenhum dado para inserir no banco.")
+            if not csv_path:
+                logging.warning("Caminho do CSV não encontrado no XCom")
                 return
 
-            df = pd.read_csv(io.StringIO(csv_data))
+            df = pd.read_csv(csv_path)
+
             df = df[df["ne_ccor_ano_emissao"].astype(str).str.startswith("20")]
             data = df.to_dict(orient="records")
 

--- a/airflow_lappis/dags/data_ingest/tesouro_gerencial/nc_tesouro_ingest.dag.py
+++ b/airflow_lappis/dags/data_ingest/tesouro_gerencial/nc_tesouro_ingest.dag.py
@@ -6,7 +6,6 @@ from datetime import datetime, timedelta
 import logging
 import json
 import pandas as pd
-import io
 from schedule_loader import get_dynamic_schedule
 from cliente_email import fetch_and_process_email
 from cliente_postgres import ClientPostgresDB
@@ -69,9 +68,10 @@ with DAG(
     tags=["email", "ncs", "tesouro"],
 ) as dag:
 
-    def process_email_data(email_type: str, **context: Dict[str, Any]) -> pd.DataFrame:
+    def process_email_data(email_type: str, **context: Dict[str, Any]) -> str:
         """
         Função genérica para processar emails de notas de crédito.
+        Retorna sempre o caminho do arquivo CSV processado.
         """
         config = EMAIL_CONFIGS[email_type]
         creds_data = json.loads(Variable.get("email_credentials"))
@@ -80,7 +80,7 @@ with DAG(
 
         try:
             logging.info(f"Iniciando o processamento das NCs {email_type}")
-            csv_data = fetch_and_process_email(
+            csv_path = fetch_and_process_email(
                 creds["imap_server"],
                 creds["email"],
                 creds["password"],
@@ -88,13 +88,14 @@ with DAG(
                 config["subject"],
                 config["column_mapping"],
                 skiprows=config["skiprows"],
+                output_path=f"/tmp/{context['dag'].dag_id}_{context['ts_nodash']}.csv",
             )
 
-            if not csv_data:
+            if not csv_path:
                 logging.warning(f"Nenhum e-mail encontrado para NCs {email_type}")
-                return pd.DataFrame()
+                return ""
 
-            df = pd.read_csv(io.StringIO(csv_data))
+            df = pd.read_csv(csv_path)
 
             # Se não tem mapeamento de colunas (recebidas), aplicar o mapeamento padrão
             if config["column_mapping"] is None and not df.empty:
@@ -109,7 +110,9 @@ with DAG(
             logging.info(
                 f"CSV de NCs {email_type} processado com sucesso: {len(df)} registros"
             )
-            return df
+            # sobrescrever o arquivo com o schema final
+            df.to_csv(csv_path, index=False)
+            return csv_path
 
         except Exception as e:
             logging.error(
@@ -117,44 +120,49 @@ with DAG(
             )
             raise
 
-    def process_email_data_enviadas(**context: Dict[str, Any]) -> pd.DataFrame:
-        """Wrapper para processar emails enviadas."""
+    def process_email_data_enviadas(**context: Dict[str, Any]) -> str:
+        """Wrapper para processar emails enviadas, retornando caminho do CSV."""
         return process_email_data("enviadas", **context)
 
-    def process_email_data_recebidas(**context: Dict[str, Any]) -> pd.DataFrame:
-        """Wrapper para processar emails recebidas."""
+    def process_email_data_recebidas(**context: Dict[str, Any]) -> str:
+        """Wrapper para processar emails recebidas, retornando caminho do CSV."""
         return process_email_data("recebidas", **context)
 
-    def combine_data(**context: Dict[str, Any]) -> pd.DataFrame:
-        """
-        Função para combinar os dados dos dois emails.
-        """
+    def combine_data(**context: Dict[str, Any]) -> str:
+        """Combina os dados dos dois emails e retorna caminho do CSV."""
         try:
             task_instance: Any = context["ti"]
-            df_enviadas = cast(
-                pd.DataFrame, task_instance.xcom_pull(task_ids="process_emails_enviadas")
+            path_enviadas = cast(
+                str, task_instance.xcom_pull(task_ids="process_emails_enviadas") or ""
             )
-            df_recebidas = cast(
-                pd.DataFrame, task_instance.xcom_pull(task_ids="process_emails_recebidas")
+            path_recebidas = cast(
+                str, task_instance.xcom_pull(task_ids="process_emails_recebidas") or ""
             )
 
-            # Combinar DataFrames válidos
-            dfs = [
-                df
-                for df in [df_enviadas, df_recebidas]
-                if df is not None and not df.empty
-            ]
+            dfs = []
+            if path_enviadas:
+                dfs.append(pd.read_csv(path_enviadas))
+            if path_recebidas:
+                dfs.append(pd.read_csv(path_recebidas))
 
             if not dfs:
                 logging.warning("Nenhum dado foi encontrado para combinar.")
-                return pd.DataFrame()
+                return ""
 
-            # Combinar os DataFrames e adicionar dt_ingest
             combined_df = pd.concat(dfs, ignore_index=True)
             combined_df["dt_ingest"] = datetime.now().isoformat()
 
-            logging.info(f"Dados combinados: {len(combined_df)} registros no total.")
-            return combined_df
+            output_path = (
+                f"/tmp/{context['dag'].dag_id}_nc_combinadas_{context['ts_nodash']}.csv"
+            )
+            combined_df.to_csv(output_path, index=False)
+
+            logging.info(
+                "Dados combinados: %s registros no total. Arquivo: %s",
+                len(combined_df),
+                output_path,
+            )
+            return output_path
 
         except Exception as e:
             logging.error(f"Erro ao combinar os dados: {str(e)}")
@@ -166,12 +174,13 @@ with DAG(
         """
         try:
             task_instance: Any = context["ti"]
-            combined_df = task_instance.xcom_pull(task_ids="combine_data")
+            combined_path = task_instance.xcom_pull(task_ids="combine_data")
 
-            if combined_df is None or combined_df.empty:
+            if not combined_path:
                 logging.warning("Nenhum dado para inserir no banco.")
                 return
 
+            combined_df = pd.read_csv(combined_path)
             data = combined_df.to_dict(orient="records")
 
             postgres_conn_str = get_postgres_conn()

--- a/airflow_lappis/dags/data_ingest/tesouro_gerencial/pf_tesouro_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/tesouro_gerencial/pf_tesouro_ingest_dag.py
@@ -6,7 +6,6 @@ from datetime import datetime, timedelta
 import logging
 import json
 import pandas as pd
-import io
 from schedule_loader import get_dynamic_schedule
 from cliente_email import fetch_and_process_email
 from cliente_postgres import ClientPostgresDB
@@ -76,7 +75,7 @@ with DAG(
             logging.info(
                 "Iniciando o processamento dos emails de programações enviadas/devolvidas"
             )
-            csv_data = fetch_and_process_email(
+            csv_path = fetch_and_process_email(
                 IMAP_SERVER,
                 EMAIL,
                 PASSWORD,
@@ -84,15 +83,19 @@ with DAG(
                 EMAIL_SUBJECT_ENVIADAS,
                 COLUMN_MAPPING,
                 skiprows=SKIPROWS,
+                output_path=f"/tmp/{context['dag'].dag_id}_{context['ts_nodash']}.csv",
             )
-            if not csv_data:
+            if not csv_path:
                 logging.warning(
                     "Nenhum e-mail encontrado com o assunto de programações enviadas"
                 )
                 return ""
 
-            logging.info("CSV de PFs enviadas processado com sucesso.")
-            return csv_data
+            logging.info(
+                "CSV de PFs enviadas processado com sucesso e gravado em: %s",
+                csv_path,
+            )
+            return csv_path
         except Exception as e:
             logging.error(
                 "Erro no processamento dos emails de programações enviadas: %s",
@@ -115,23 +118,27 @@ with DAG(
             logging.info(
                 "Iniciando o processamento dos emails de programações recebidas..."
             )
-            csv_data = fetch_and_process_email(
+            csv_path = fetch_and_process_email(
                 IMAP_SERVER,
                 EMAIL,
                 PASSWORD,
                 SENDER_EMAIL,
                 EMAIL_SUBJECT_RECEBIDAS,
-                column_mapping=None,
+                column_mapping=COLUMN_MAPPING,
                 skiprows=SKIPROWS,
+                output_path=f"/tmp/{context['dag'].dag_id}_{context['ts_nodash']}.csv",
             )
-            if not csv_data:
+            if not csv_path:
                 logging.warning(
                     "Nenhum e-mail encontrado com o assunto de programações recebidas."
                 )
                 return ""
 
-            logging.info("CSV de PFs recebidas processado com sucesso.")
-            return csv_data
+            logging.info(
+                "CSV de PFs recebidas processado com sucesso e gravado em: %s",
+                csv_path,
+            )
+            return csv_path
         except Exception as e:
             logging.error(
                 "Erro no processamento dos emails de programações recebidas: %s", str(e)
@@ -144,21 +151,31 @@ with DAG(
         """
         try:
             task_instance: Any = context["ti"]
-            enviadas_data = (
+            enviadas_path = (
                 task_instance.xcom_pull(task_ids="process_emails_enviadas") or ""
             )
-            recebidas_data = (
+            recebidas_path = (
                 task_instance.xcom_pull(task_ids="process_emails_recebidas") or ""
             )
 
-            combined_data = enviadas_data + recebidas_data
+            dfs = []
+            if enviadas_path:
+                dfs.append(pd.read_csv(enviadas_path))
+            if recebidas_path:
+                dfs.append(pd.read_csv(recebidas_path))
 
-            if combined_data:
-                logging.info("Dados combinados com sucesso.")
-            else:
+            if not dfs:
                 logging.warning("Nenhum dado encontrado em ambos os emails.")
+                return ""
 
-            return combined_data
+            combined_df = pd.concat(dfs, ignore_index=True)
+            output_path = (
+                f"/tmp/{context['dag'].dag_id}_pf_combinadas_{context['ts_nodash']}.csv"
+            )
+            combined_df.to_csv(output_path, index=False)
+
+            logging.info("Dados combinados com sucesso e gravados em: %s", output_path)
+            return output_path
         except Exception as e:
             logging.error(f"Erro ao combinar os dados: {str(e)}")
             raise
@@ -170,13 +187,13 @@ with DAG(
         """
         try:
             task_instance: Any = context["ti"]
-            combined_data = task_instance.xcom_pull(task_ids="combine_data")
+            combined_path = task_instance.xcom_pull(task_ids="combine_data")
 
-            if not combined_data:
+            if not combined_path:
                 logging.warning("Nenhum dado para inserir no banco.")
                 return
 
-            df = pd.read_csv(io.StringIO(combined_data))
+            df = pd.read_csv(combined_path)
             data = df.to_dict(orient="records")
 
             # Adicionar dt_ingest a cada registro

--- a/airflow_lappis/dags/data_ingest/tesouro_gerencial/visao_orcamentaria_ingest.py
+++ b/airflow_lappis/dags/data_ingest/tesouro_gerencial/visao_orcamentaria_ingest.py
@@ -190,8 +190,7 @@ with DAG(
             data_lines = lines[data_start_index:]
             year_data = _process_data_block(data_lines, current_year)
             logging.info(
-                f"Processados {len(year_data)} registros para o último ano "
-                f"{current_year}"
+                f"Processados {len(year_data)} registros para o último ano {current_year}"
             )
             processed_data.extend(year_data)
 
@@ -201,14 +200,14 @@ with DAG(
         return processed_data
 
     def process_email_data(**context: Dict[str, Any]) -> Optional[str]:
-        """Processa o email e retorna os dados formatados."""
+        """Processa o email e retorna o caminho do CSV formatado."""
         creds = json.loads(Variable.get("email_credentials"))
 
         try:
             logging.info("Iniciando o processamento dos emails...")
 
             # Busca o email com attachments ZIP
-            zip_payload = fetch_email_with_zip(
+            zip_payloads = fetch_email_with_zip(
                 creds["imap_server"],
                 creds["email"],
                 creds["password"],
@@ -216,26 +215,29 @@ with DAG(
                 EMAIL_SUBJECT,
             )
 
-            if not zip_payload:
+            if not zip_payloads:
                 logging.warning("Nenhum e-mail encontrado com o assunto esperado.")
                 return None
 
+            csv_content = None
+
             # Extrai o CSV do ZIP (UTF-16)
-            with zipfile.ZipFile(io.BytesIO(zip_payload)) as zip_file:
-                for file_name in zip_file.namelist():
-                    if file_name.endswith(".csv"):
-                        raw_data = zip_file.read(file_name)
-                        csv_content = raw_data.decode("utf-16")
-                        break
-                else:
-                    logging.warning("Nenhum arquivo CSV encontrado no ZIP.")
-                    return None
+            for payload in zip_payloads:
+                with zipfile.ZipFile(io.BytesIO(payload)) as zip_file:
+                    for file_name in zip_file.namelist():
+                        if file_name.endswith(".csv"):
+                            raw_data = zip_file.read(file_name)
+                            csv_content = raw_data.decode("utf-16")
+                            break
+                    else:
+                        logging.warning("Nenhum arquivo CSV encontrado no ZIP.")
+                        return None
 
             # Processa o CSV com a lógica de blocos por ano
             processed_data = _parse_csv_by_year_blocks(csv_content)
 
-            if not processed_data:
-                logging.warning("Nenhum dado foi processado do CSV.")
+            if not csv_content:
+                logging.warning("Nenhum arquivo CSV encontrado nos ZIPs.")
                 return None
 
             df = pd.DataFrame(processed_data)
@@ -247,13 +249,15 @@ with DAG(
             for col in df.columns:
                 df[col] = df[col].astype(str)
 
-            csv_string = df.to_csv(index=False)
+            # Salva o CSV em disco (padrão /tmp) e retorna o caminho
+            output_path = f"/tmp/{context['dag'].dag_id}_{context['ts_nodash']}.csv"
+            df.to_csv(output_path, index=False)
 
             logging.info(
                 f"CSV processado com sucesso. Dados encontrados: "
-                f"{len(processed_data)} registros"
+                f"{len(processed_data)} registros. Arquivo gravado em: {output_path}"
             )
-            return csv_string
+            return output_path
 
         except Exception as e:
             logging.error(f"Erro no processamento dos emails: {str(e)}")
@@ -263,13 +267,13 @@ with DAG(
         """Insere os dados no banco e limpa duplicados."""
         try:
             task_instance: Any = context["ti"]
-            csv_data: Any = task_instance.xcom_pull(task_ids="process_emails")
+            csv_path: Any = task_instance.xcom_pull(task_ids="process_emails")
 
-            if not csv_data:
+            if not csv_path:
                 logging.warning("Nenhum dado para inserir no banco.")
                 return
 
-            df = pd.read_csv(io.StringIO(csv_data))
+            df = pd.read_csv(csv_path)
 
             # Garantir que todos os valores sejam strings para evitar problemas de tipo
             for col in df.columns:

--- a/airflow_lappis/plugins/cliente_email.py
+++ b/airflow_lappis/plugins/cliente_email.py
@@ -1,13 +1,15 @@
 import logging
 import io
+import os
 import zipfile
 from typing import Optional, cast, List, Dict
+
+import chardet
 import pandas as pd
+import pytz
+from datetime import datetime
 from pandas.errors import EmptyDataError
 from imap_tools import MailBox, AND
-import chardet
-from datetime import datetime
-import pytz
 
 # Configuração do log
 logging.basicConfig(
@@ -82,6 +84,7 @@ def fetch_and_process_email(
     subject: str,
     column_mapping: dict,
     skiprows: int = 0,
+    output_path: Optional[str] = None,
 ) -> Optional[str]:
     """Busca e processa e-mails do dia, extraindo CSVs de todos os ZIPs anexados."""
     try:
@@ -92,24 +95,52 @@ def fetch_and_process_email(
             logging.warning("Nenhum anexo ZIP encontrado.")
             return None
 
-        logging.info("Total de anexos ZIP encontrados: %s", len(zip_payloads))
+        if not output_path:
+            raise ValueError(
+                "output_path é obrigatório em fetch_and_process_email; "
+            )
 
-        dataframes: List[pd.DataFrame] = []
+        logging.info("Total de anexos ZIP encontrados: %s", len(zip_payloads))
+        output_dir = os.path.dirname(output_path)
+        if output_dir:
+            os.makedirs(output_dir, exist_ok=True)
+
+        first_chunk = True
+        total_rows = 0
+
         for idx, zip_payload in enumerate(zip_payloads, start=1):
-            csv_data = extract_csv_from_zip(zip_payload, column_mapping, skiprows)
-            if csv_data is not None:
-                dataframes.append(csv_data)
+            csv_df = extract_csv_from_zip(zip_payload, column_mapping, skiprows)
+            if csv_df is not None and not csv_df.empty:
+                rows = len(csv_df)
+                total_rows += rows
+                csv_df.to_csv(
+                    output_path,
+                    mode="w" if first_chunk else "a",
+                    header=first_chunk,
+                    index=False,
+                )
+                first_chunk = False
+                logging.info(
+                    "CSV do ZIP %s processado e gravado em disco (%s linhas).",
+                    idx,
+                    rows,
+                )
             else:
                 logging.warning(
                     "ZIP %s ignorado por nao conter CSV valido.",
                     idx,
                 )
 
-        if dataframes:
-            combined_df = pd.concat(dataframes, ignore_index=True)
-            return combined_df.to_csv(index=False)
+        if total_rows == 0:
+            logging.warning("Nenhum CSV processado.")
+            return None
 
-        logging.warning("Nenhum CSV processado.")
+        logging.info(
+            "Processamento concluido. Total de linhas gravadas em %s: %s",
+            output_path,
+            total_rows,
+        )
+        return output_path
     except Exception as e:
         logging.error(f"Erro ao processar e-mails: {e}")
         raise


### PR DESCRIPTION
## Objetivo

Evitar o uso de XCom para transporte de dados pesados (CSV em memória), substituindo por persistência em disco e passagem de caminhos de arquivos entre tasks.

## O que foi feito

- Refatoração das DAGs para substituir o uso de `csv_data` (string em memória) por `csv_path` (caminho do arquivo)
- Padronização do `fetch_and_process_email` para sempre salvar o CSV em `/tmp` e retornar o caminho do arquivo
- Atualização das tasks `process_email_data` para retornar `csv_path` via XCom
- Atualização das tasks `insert_data_to_db` para leitura via `pd.read_csv(csv_path)`
- Remoção do uso de `io.StringIO` em todas as DAGs
- Ajustes nas DAGs de NC e PF para:
  - Processamento independente (enviadas/recebidas)
  - Combinação via leitura de arquivos e geração de novo CSV consolidado
- Ajuste na DAG de visão orçamentária para suportar múltiplos payloads ZIP e persistência em arquivo
- Padronização de logs para indicar caminho do arquivo gerado
- Correções de parâmetros:
  - Ajustes de `SKIPROWS` em DAGs específicas
  - Correção de `column_mapping`
  - Ajustes de tipagem de retorno (`str` ao invés de `DataFrame`)
- Inclusão de `AirflowSkipException` onde aplicável para cenários sem dados

## Impacto

- Redução do uso de memória no Airflow (eliminação de payloads grandes no XCom)
- Melhoria de performance e estabilidade das DAGs
- Maior previsibilidade no fluxo de dados entre tasks
- Padronização do pipeline de ingestão baseado em arquivos temporários

## Observações

- Os arquivos são persistidos em `/tmp` durante a execução das DAGs
- Não há alteração na lógica de negócio, apenas no fluxo de transporte de dados