### PR TITLE
fix: incluindo todos os deputados ativos e nao ativos

### DIFF
--- a/airflow_lappis/dags/data_ingest/dados_abertos/deputados_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/dados_abertos/deputados_ingest_dag.py
@@ -31,16 +31,24 @@ def deputados_ingest_dag() -> None:
 
         deputados_data = api.get_all_deputados()
 
-        if deputados_data and len(deputados_data) > 0:
-            vistos= set()
+        unique_key = ["id", "siglapartido", "idlegislatura"]
+
+        if deputados_data:
+            vistos = set()
             lista_limpa = []
 
             for item in deputados_data:
-                if item["id"] not in vistos:
+
+                if item.get("siglaPartido") is None:
+                    item["siglaPartido"] = "Sem Partido"
+
+                chave_unica = tuple(item.get(key) for key in unique_key)
+
+                if chave_unica not in vistos:
                     item["dt_ingest"] = datetime.now().isoformat()
                     lista_limpa.append(item)
-                    vistos.add(item["id"])
-            
+                    vistos.add(chave_unica)
+
             deputados_data = lista_limpa
 
             logging.info(
@@ -51,8 +59,8 @@ def deputados_ingest_dag() -> None:
             db.insert_data(
                 deputados_data,
                 "deputados",
-                conflict_fields=["id"],
-                primary_key=["id"],
+                conflict_fields=["id", "siglapartido", "idlegislatura"],
+                primary_key=["id", "siglapartido", "idlegislaturax  "],
                 schema="camara_deputados",
             )
 

--- a/airflow_lappis/dags/data_ingest/dados_abertos/deputados_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/dados_abertos/deputados_ingest_dag.py
@@ -32,8 +32,16 @@ def deputados_ingest_dag() -> None:
         deputados_data = api.get_all_deputados()
 
         if deputados_data and len(deputados_data) > 0:
+            vistos= set()
+            lista_limpa = []
+
             for item in deputados_data:
-                item["dt_ingest"] = datetime.now().isoformat()
+                if item["id"] not in vistos:
+                    item["dt_ingest"] = datetime.now().isoformat()
+                    lista_limpa.append(item)
+                    vistos.add(item["id"])
+            
+            deputados_data = lista_limpa
 
             logging.info(
                 f"[deputados_ingest_dag.py] Inserindo "

--- a/airflow_lappis/plugins/cliente_deputados.py
+++ b/airflow_lappis/plugins/cliente_deputados.py
@@ -50,7 +50,7 @@ class ClienteDeputados(ClienteBase):
         pagina = 1
 
         while True:
-            params = {"pagina": pagina, "itens": 100}
+            params = {"pagina": pagina, "itens": 1000, "dataInicio": "1823-01-01"}
             deputados = self.get_deputados(**params)
 
             if not deputados:


### PR DESCRIPTION

## O que foi feito

### 1. Expansão do Escopo de Ingestão (Histórico Completo)
- Alteração do parâmetro de busca para capturar dados desde **1823** (início da série histórica da API da Câmara).
- Transição da ingestão que antes buscava apenas **deputados atuais** para uma carga que abrange **todos os deputados (atuais e não atuais)**

### 2. Implementação de filtro de unicidade (Deduplicação)
- Introdução de uma lógica de triagem utilizando `vistos = set()` para garantir que cada `id` de deputado seja processado apenas uma vez por execução.

#### Issue #89 
