### PR TITLE
fix: ajustes na lista dos senadores para abranger os inativos e ativos

### DIFF
--- a/airflow_lappis/dags/data_ingest/dados_abertos/senadores_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/dados_abertos/senadores_ingest_dag.py
@@ -29,7 +29,7 @@ def senadores_ingest_dag() -> None:
         postgres_conn_str = get_postgres_conn("postgres_mir")
         db = ClientPostgresDB(postgres_conn_str)
 
-        senadores_data = api.get_senadores_atuais()
+        senadores_data = api.get_senadores_por_legislatura()
 
         if senadores_data and len(senadores_data) > 0:
             registros_limpos = []

--- a/airflow_lappis/dags/data_ingest/dados_abertos/senadores_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/dados_abertos/senadores_ingest_dag.py
@@ -12,7 +12,7 @@ from cliente_postgres import ClientPostgresDB
     start_date=datetime(2025, 1, 1),
     catchup=False,
     default_args={
-        "owner": "Cibelly",
+        "owner": "Ingrid",
         "retries": 1,
         "retry_delay": timedelta(minutes=5),
     },
@@ -49,7 +49,7 @@ def senadores_ingest_dag() -> None:
                     "email": info.get("EmailParlamentar"),
                     "sigla_partido": info.get("SiglaPartidoParlamentar"),
                     "uf": info.get("UfParlamentar"),
-                    "id_legislatura": mandato.get("CodigoLegislatura"),
+                    "id_legislatura": mandato.get("NumeroLegislatura"),
                     "dt_ingest": datetime.now().isoformat(),
                 }
                 registros_limpos.append(senador_simplificado)
@@ -66,8 +66,92 @@ def senadores_ingest_dag() -> None:
                 primary_key=["id"],
                 schema="senado_federal",
             )
+    @task
+    def fetch_and_store_filiacoes() -> None:
+        api = ClienteSenadores()
+        postgres_conn_str = get_postgres_conn("postgres_mir")
+        db = ClientPostgresDB(postgres_conn_str)
 
+        # 1. Busca a lista base de senadores
+        senadores_base = api.get_senadores_por_legislatura()
+        registros_filiacoes = []
+
+        for sen in senadores_base:
+            info = sen.get("IdentificacaoParlamentar", {})
+            cod_id = info.get("CodigoParlamentar")
+            nome = info.get("NomeParlamentar")
+
+            if cod_id:
+                # 2. Para cada senador, busca o histórico de filiações
+                filiacoes = api.get_filiacoes_senador(cod_id)
+                if isinstance(filiacoes, dict):
+                    filiacoes = [filiacoes]
+                elif not filiacoes:
+                    logging.debug(
+                        f"[senadores_ingest_dag.py] Nenhuma filiação encontrada para "
+                        f"{nome} (ID: {cod_id})"
+                    )
+                    continue
+                for f in filiacoes:
+                    # Extrai os dados do objeto Partido aninhado
+                    partido = f.get("Partido", {})
+                    sigla_partido = partido.get("SiglaPartido") or "Sigla não disponível"
+                    nome_partido = partido.get("NomePartido") or "Nome não disponível"
+                    ano_filiacao = f.get("AnoFiliacao") or "Data não disponível"
+                    ano_desfiliacao = f.get("AnoDesfiliacao")
+
+                    registro = {
+                        "id": cod_id,
+                        "nome_parlamentar": nome,
+                        "sigla_partido": sigla_partido,
+                        "nome_partido": nome_partido,
+                        "dt_filiacao": ano_filiacao,
+                        "dt_desfiliacao": ano_desfiliacao,
+                        "uf": info.get("UfParlamentar"),
+                        "dt_ingest": datetime.now().isoformat(),
+                    }
+                    registros_filiacoes.append(registro)
+                    logging.debug(
+                        f"[senadores_ingest_dag.py] Filiação processada: "
+                        f"{nome} -> {sigla_partido} ({ano_filiacao})"
+                    )
+        
+        logging.info(
+            f"[senadores_ingest_dag.py] Total de {len(registros_filiacoes)} "
+            f"registros de filiações coletados da API."
+        )
+
+        # 3. Deduplicação baseada nas chaves únicas
+        registros_deduplicated = {}
+        for registro in registros_filiacoes:
+            chave_unica = (
+                registro.get("id"),
+                registro.get("sigla_partido"),
+                registro.get("dt_filiacao"),
+            )
+            if chave_unica not in registros_deduplicated:
+                registros_deduplicated[chave_unica] = registro
+        
+        registros_filiacoes = list(registros_deduplicated.values())
+        logging.info(
+            f"[senadores_ingest_dag.py] Após deduplicação: {len(registros_filiacoes)} "
+            f"registros únicos de histórico partidário."
+        )
+
+        # 4. Inserção no banco
+        if registros_filiacoes:
+            logging.info(f"Inserindo {len(registros_filiacoes)} registros de histórico partidário.")
+            db.insert_data(
+                registros_filiacoes,
+                "senadores_filiacoes", # Nome da nova tabela única
+                conflict_fields=["id", "sigla_partido", "dt_filiacao"],
+                primary_key=["id", "sigla_partido", "dt_filiacao"], # Chave composta para permitir múltiplos registros do mesmo ID
+                schema="senado_federal",
+            )
     fetch_and_store_senadores()
+
+    fetch_and_store_filiacoes()
+
 
 
 senadores_ingest_dag()

--- a/airflow_lappis/plugins/cliente_senadores.py
+++ b/airflow_lappis/plugins/cliente_senadores.py
@@ -18,12 +18,12 @@ class ClienteSenadores(ClienteBase):
             f"[cliente_senadores.py] Initialized ClienteSenadores em: {ClienteSenadores.BASE_URL}"
         )
 
-    def get_senadores_atuais(self) -> list:
+    def get_senadores_por_legislatura(self) -> list:
         """
-        Obtém a lista de senadores em exercício.
+        Obtém a lista de senadores ativose inativos.
         O Senado geralmente retorna tudo em uma única chamada, sem paginação complexa como a Câmara.
         """
-        endpoint = "/senador/lista/atual"
+        endpoint = "/senador/lista/legislatura/0/100"
         logging.info("[cliente_senadores.py] Fetching senadores atuais")
 
         status, data = self.request(
@@ -31,9 +31,9 @@ class ClienteSenadores(ClienteBase):
         )
 
         if status == http.HTTPStatus.OK and isinstance(data, dict):
-            # A estrutura do JSON do Senado é: ListaParlamentarEmExercicio -> Parlamentares -> Parlamentar
+            # A estrutura do JSON do Senado é: ListaParlamentarLegislatura -> Parlamentares -> Parlamentar
             try:
-                lista_root = data.get("ListaParlamentarEmExercicio", {})
+                lista_root = data.get("ListaParlamentarLegislatura", {})
                 parlamentares = lista_root.get("Parlamentares", {}).get("Parlamentar", [])
 
                 if isinstance(parlamentares, dict):

--- a/airflow_lappis/plugins/cliente_senadores.py
+++ b/airflow_lappis/plugins/cliente_senadores.py
@@ -51,3 +51,29 @@ class ClienteSenadores(ClienteBase):
         else:
             logging.warning(f"[cliente_senadores.py] Failed with status: {status}")
             return []
+        
+    def get_filiacoes_senador(self, codigo_parlamentar: int) -> list:
+        """
+        Obtém o histórico de filiações partidárias de um senador específico.
+        """
+        endpoint = f"/senador/{codigo_parlamentar}/filiacoes"
+        logging.info(f"[cliente_senadores.py] Fetching filiações para o senador: {codigo_parlamentar}")
+
+        status, data = self.request(
+            http.HTTPMethod.GET, endpoint, headers=self.BASE_HEADER
+        )
+
+        if status == http.HTTPStatus.OK and isinstance(data, dict):
+            try:
+                # Estrutura: FiliacaoPartidaria -> Parlamentar -> Filiacoes -> Filiacao
+                filiacoes_root = data.get("FiliacaoParlamentar", {}).get("Parlamentar", {})
+                filiacoes = filiacoes_root.get("Filiacoes", {}).get("Filiacao", [])
+
+                if isinstance(filiacoes, dict):
+                    filiacoes = [filiacoes]
+
+                return filiacoes
+            except Exception as e:
+                logging.error(f"[cliente_senadores.py] Erro ao parsear filiações: {e}")
+                return []
+        return []


### PR DESCRIPTION
## 📝 Descrição
Este PR atualiza o cliente de integração com a API do Senado Federal. A principal mudança é a transição do endpoint de senadores em exercício para o endpoint de legislaturas, permitindo a extração de um volume maior de dados (parlamentares ativos e inativos).

## 🚀 Alterações
- Alteração do endpoint de `senador/lista/atual` para `/senador/lista/legislatura/{inicio}/{fim}`.
- Atualização do método de extração para tratar a nova estrutura do JSON (`ListaParlamentarLegislatura`).

