### PR TITLE
feat: parametrização data recebimento email dags MIR para ingestão eficiente

### DIFF
--- a/airflow_lappis/dags/data_ingest/tesouro_gerencial/empenhos_tesouro_emendas_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/tesouro_gerencial/empenhos_tesouro_emendas_ingest_dag.py
@@ -2,6 +2,7 @@ from typing import Dict, Any, Optional
 from airflow import DAG
 from airflow.operators.python import PythonOperator
 from airflow.models import Variable
+from airflow.models.param import Param
 from datetime import datetime, timedelta
 import logging
 import json
@@ -53,7 +54,7 @@ COLUMN_MAPPING = {
     29: "despesas_liquidadas",
     30: "despesas_pagas",
     31: "restos_a_pagar_inscritos",
-    32: "restos_a_pagar_pagos"
+    32: "restos_a_pagar_pagos",
 }
 
 EMAIL_SUBJECT = "notas_de_empenhos_emendas_parlamentares"
@@ -67,6 +68,17 @@ with DAG(
     schedule_interval=get_dynamic_schedule("empenhos_tesouro_emendas_ingest_dag"),
     start_date=datetime(2023, 12, 1),
     catchup=False,
+    params={
+        "data_referencia": Param(
+            default=None,
+            type=["string", "null"],
+            title="Data de Referencia",
+            description=(
+                "Data para filtrar os e-mails recebidos (formato YYYY-MM-DD). "
+                "Se nao informado, usa o dia atual."
+            ),
+        )
+    },
     tags=["MIR", "email", "empenhos", "tesouro", "emendas"],
 ) as dag:
 
@@ -75,12 +87,25 @@ with DAG(
 
         EMAIL = creds["email"]
         PASSWORD = creds["password"]
-        IMAP_SERVER = creds["imap_ser" \
-        "ver"]
+        IMAP_SERVER = creds["imap_server"]
         SENDER_EMAIL = creds["sender_email"]
+        params = context.get("params", {})
+        data_referencia = params.get("data_referencia")
+
+        target_date = None
+        if data_referencia:
+            try:
+                target_date = datetime.strptime(data_referencia, "%Y-%m-%d").date()
+            except ValueError as exc:
+                raise ValueError(
+                    "Parametro 'data_referencia' invalido. Use o formato YYYY-MM-DD."
+                ) from exc
 
         try:
-            logging.info("Iniciando o processamento dos emails...")
+            logging.info(
+                "Iniciando o processamento dos emails para a data: %s",
+                target_date.isoformat() if target_date else "dia atual",
+            )
             csv_data = fetch_and_process_email(
                 IMAP_SERVER,
                 EMAIL,
@@ -89,6 +114,7 @@ with DAG(
                 EMAIL_SUBJECT,
                 COLUMN_MAPPING,
                 skiprows=SKIPROWS,
+                target_date=target_date,
             )
             if not csv_data:
                 logging.warning(

--- a/airflow_lappis/dags/data_ingest/tesouro_gerencial/mir/empenhos_tesouro_parlamentares_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/tesouro_gerencial/mir/empenhos_tesouro_parlamentares_ingest_dag.py
@@ -2,6 +2,7 @@ from typing import Dict, Any, List
 from airflow import DAG
 from airflow.operators.python import PythonOperator
 from airflow.models import Variable
+from airflow.models.param import Param
 from datetime import datetime, timedelta
 import logging
 import json
@@ -68,6 +69,17 @@ with DAG(
     schedule_interval=get_dynamic_schedule("empenhos_tesouro_parlamentares_ingest_dag"),
     start_date=datetime(2023, 12, 1),
     catchup=False,
+    params={
+        "data_referencia": Param(
+            default=None,
+            type=["string", "null"],
+            title="Data de Referencia",
+            description=(
+                "Data para filtrar os e-mails recebidos (formato YYYY-MM-DD). "
+                "Se nao informado, usa o dia atual."
+            ),
+        )
+    },
     tags=["MIR", "email", "empenhos", "tesouro", "parlamentares"],
 ) as dag:
 
@@ -92,6 +104,22 @@ with DAG(
     def fetch_and_ingest(**context: Dict[str, Any]) -> Dict[str, int]:
         """Processa cada anexo e ingere imediatamente, evitando acúmulo em memória."""
         creds = json.loads(Variable.get("email_credentials"))
+        params = context.get("params", {})
+        data_referencia = params.get("data_referencia")
+
+        target_date = None
+        if data_referencia:
+            try:
+                target_date = datetime.strptime(data_referencia, "%Y-%m-%d").date()
+            except ValueError as exc:
+                raise ValueError(
+                    "Parametro 'data_referencia' invalido. Use o formato YYYY-MM-DD."
+                ) from exc
+
+        logging.info(
+            "Buscando e-mails para a data: %s",
+            target_date.isoformat() if target_date else "dia atual",
+        )
 
         zip_payloads: List[bytes] = fetch_email_with_zip(
             creds["imap_server"],
@@ -99,6 +127,7 @@ with DAG(
             creds["password"],
             creds["sender_email"],
             EMAIL_SUBJECT,
+            target_date=target_date,
         )
 
         if not zip_payloads:

--- a/airflow_lappis/plugins/cliente_email.py
+++ b/airflow_lappis/plugins/cliente_email.py
@@ -6,7 +6,7 @@ import pandas as pd
 from pandas.errors import EmptyDataError
 from imap_tools import MailBox, AND
 import chardet
-from datetime import datetime
+from datetime import datetime, date
 import pytz
 
 # Configuração do log
@@ -61,14 +61,22 @@ def extract_csv_from_zip(
 
 
 def fetch_email_with_zip(
-    imap_server: str, email: str, password: str, sender_email: str, subject: str
+    imap_server: str,
+    email: str,
+    password: str,
+    sender_email: str,
+    subject: str,
+    target_date: Optional[date] = None,
 ) -> List[bytes]:
-    """Busca todos os e-mails do dia atual e retorna todos os anexos ZIP."""
-    today = datetime.now(pytz.timezone("America/Sao_Paulo")).date()
+    """Busca e-mails da data alvo (ou dia atual) e retorna os anexos ZIP."""
+    query_date = target_date or datetime.now(pytz.timezone("America/Sao_Paulo")).date()
     zip_payloads: List[bytes] = []
     with MailBox(imap_server).login(email, password) as mailbox:
         # bulk=True: single IMAP FETCH command for all messages (avoids overquota)
-        for msg in mailbox.fetch(AND(date=today, from_=sender_email, subject=subject), bulk=True):
+        for msg in mailbox.fetch(
+            AND(date=query_date, from_=sender_email, subject=subject),
+            bulk=True,
+        ):
             for attachment in msg.attachments:
                 if attachment.filename.lower().endswith(".zip"):
                     zip_payloads.append(cast(bytes, attachment.payload))
@@ -83,11 +91,17 @@ def fetch_and_process_email(
     subject: str,
     column_mapping: dict,
     skiprows: int = 0,
+    target_date: Optional[date] = None,
 ) -> Optional[str]:
-    """Busca e processa e-mails do dia, extraindo CSVs de todos os ZIPs anexados."""
+    """Busca e processa e-mails da data alvo (ou dia atual), extraindo CSVs."""
     try:
         zip_payloads = fetch_email_with_zip(
-            imap_server, email, password, sender_email, subject
+            imap_server,
+            email,
+            password,
+            sender_email,
+            subject,
+            target_date=target_date,
         )
         if not zip_payloads:
             logging.warning("Nenhum anexo ZIP encontrado.")


### PR DESCRIPTION
## Descrição da PR

Esta PR adiciona um parâmetro opcional `data_referencia` para filtrar e-mails por data nas DAGs de ingestão de empenhos do Tesouro.

### Principais pontos

- Mantém o comportamento atual como padrão (usa o dia atual se não informado).
- Parametrização aplicada nas DAGs:
  - `empenhos_tesouro_emendas_ingest_dag.py`
  - `empenhos_tesouro_parlamentares_ingest_dag.py`
- Cliente de e-mail atualizado (`cliente_email.py`) para aceitar data opcional.

### Execução

- Agendada: usa dia atual.
- Manual sem `conf`: usa dia atual.
- Manual com `conf`: usa a data informada.

### Motivação

Fiz isso para fazer a ingestão extremamente mais rápida em produção e evitando retrabalho de reenvio manual pelo sistema do tesouro gerencial.

##### ISSUE #109 