### PR TITLE
feat(silver): cruzamento emendas tg com parlamentares

### DIFF
--- a/airflow_lappis/dags/dbt/mir/models/emendas_dbt/silver/emendas_partidos.sql
+++ b/airflow_lappis/dags/dbt/mir/models/emendas_dbt/silver/emendas_partidos.sql
@@ -1,0 +1,71 @@
+{{ config(materialized='table') }}
+
+WITH tg_emendas AS (
+	SELECT *
+	FROM {{ ref('tg_emendas') }}
+),
+
+parlamentares AS (
+	SELECT *
+	FROM {{ ref('parlamentares') }}
+),
+
+tg_emendas_tratado AS (
+	SELECT
+		*,
+		TRIM(UPPER(autor_emendas_orcamento_nome)) AS chave_join_nome
+	FROM tg_emendas
+),
+
+final AS (
+	SELECT
+		e.emissao_mes,
+		e.emissao_dia,
+		e.programa_governo AS codigo_programa,
+		e.programa_governo_descricao AS programa,
+		e.acao_governo AS codigo_acao_ajustada,
+		e.acao_governo_descricao AS acao_ajustada,
+		e.autor_emendas_orcamento_descricao,
+		e.uf_pt AS uf,
+		e.uf_pt_descricao AS uf_descricao,
+		e.municipio_pt AS municipio,
+		'Brasil' AS pais,
+		e.ne_ccor,
+		e.ne_num_processo,
+		e.ne_info_complementar,
+		e.ne_ccor_descricao,
+		e.doc_observacao,
+		e.grupo_despesa AS codigo_gnd,
+		e.grupo_despesa_descricao AS gnd,
+		e.natureza_despesa,
+		e.natureza_despesa_descricao,
+		e.modalidade_aplicacao AS codigo_modalidade,
+		e.modalidade_aplicacao_descricao AS modalidade,
+		e.ne_ccor_favorecido,
+		e.ne_ccor_favorecido_descricao,
+		e.ne_ccor_ano_emissao,
+		e.ptres,
+		e.item_informacao,
+		e.item_informacao_descricao,
+		e.despesas_empenhadas,
+		e.despesas_liquidadas,
+		e.despesas_pagas,
+
+		p.id_parlamentar as id_autor,
+		p.cargo_parlamentar as cargo_autor,
+		p.nome_parlamentar as autor,
+		p.sigla_partido as partido,
+		p.uf_parlamentar as uf_autor,
+		p.url_foto as url_foto_autor,
+		p.email as email_autor,
+		p.url_logo_partido as url_foto_partido,
+
+		e.dt_ingest
+
+	FROM tg_emendas_tratado e
+	LEFT JOIN parlamentares p
+		ON e.chave_join_nome = p.chave_join_nome
+)
+
+SELECT *
+FROM final

--- a/airflow_lappis/dags/dbt/mir/models/emendas_dbt/silver/schema.yml
+++ b/airflow_lappis/dags/dbt/mir/models/emendas_dbt/silver/schema.yml
@@ -166,3 +166,145 @@ models:
           nome_tabela: 'emendas.planos_partidos'
           nome_coluna: 'dt_ingest'
           tipo_esperado: 'timestamp with time zone'
+
+  - name: emendas_partidos
+    description: >
+      Tabela silver que integra as informações de execução orçamentária do SIAFI (Tesouro Gerencial)
+      para emendas parlamentares (tabela bronze tg_emendas) com metadados de parlamentares (dimensão
+      silver parlamentares). Enriquece cada registro de execução com identificação do parlamentar,
+      partido, UF, foto, e-mail e logo do partido, quando houver correspondência pelo nome.
+    meta:
+      tags:
+        - silver
+    columns:
+      # Colunas da tabela fato tg_emendas
+      - name: emissao_mes
+        description: "Mês/ano de emissão da nota de empenho (primeiro dia do mês)."
+      - name: emissao_dia
+        description: "Data de emissão da nota de empenho."
+      - name: codigo_programa
+        description: "Código do programa de governo no orçamento."
+      - name: programa
+        description: "Descrição do programa de governo."
+      - name: codigo_acao_ajustada
+        description: "Código da ação de governo associada à emenda."
+      - name: acao_ajustada
+        description: "Descrição da ação de governo associada à emenda."
+      - name: autor_emendas_orcamento_descricao
+        description: "Descrição completa do autor da emenda no orçamento."
+      - name: uf
+        description: "UF de aplicação da programação orçamentária (PT)."
+      - name: uf_descricao
+        description: "Descrição da UF da programação orçamentária."
+      - name: municipio
+        description: "Município de aplicação da programação orçamentária."
+      - name: pais
+        description: "País de aplicação da programação orçamentária."
+      - name: ne_ccor
+        description: "Código da NE/CCOR no SIAFI."
+      - name: ne_num_processo
+        description: "Número do processo administrativo associado à NE."
+      - name: ne_info_complementar
+        description: "Informações complementares cadastradas na NE."
+      - name: ne_ccor_descricao
+        description: "Descrição textual da NE/CCOR."
+      - name: doc_observacao
+        description: "Observações adicionais registradas no documento SIAFI."
+      - name: codigo_gnd
+        description: "Código do grupo de despesa orçamentária."
+      - name: gnd
+        description: "Descrição do grupo de despesa orçamentária."
+      - name: natureza_despesa
+        description: "Código da natureza de despesa."
+      - name: natureza_despesa_descricao
+        description: "Descrição da natureza de despesa."
+      - name: codigo_modalidade
+        description: "Código da modalidade de aplicação."
+      - name: modalidade
+        description: "Descrição da modalidade de aplicação."
+      - name: ne_ccor_favorecido
+        description: "Identificador do favorecido na NE/CCOR."
+      - name: ne_ccor_favorecido_descricao
+        description: "Nome/descrição do favorecido na NE/CCOR."
+      - name: ne_ccor_ano_emissao
+        description: "Ano de emissão da NE/CCOR."
+      - name: ptres
+        description: "PTRES associado à despesa da emenda."
+      - name: item_informacao
+        description: "Código do item de informação orçamentária."
+      - name: item_informacao_descricao
+        description: "Descrição do item de informação orçamentária."
+      - name: despesas_empenhadas
+        description: "Valor total das despesas empenhadas."
+      - name: despesas_liquidadas
+        description: "Valor total das despesas liquidadas."
+      - name: despesas_pagas
+        description: "Valor total das despesas pagas."
+      # Colunas de metadados dos parlamentares
+      - name: id_autor
+        description: "Identificador único do parlamentar na base unificada."
+      - name: cargo_autor
+        description: "Cargo do parlamentar (Deputado ou Senador)."
+      - name: autor
+        description: "Nome do parlamentar conforme registrado na base unificada."
+      - name: partido
+        description: "Sigla do partido (padronizada quando aplicável)."
+      - name: uf_autor
+        description: "UF representada pelo parlamentar."
+      - name: url_foto_autor
+        description: "URL da foto oficial do parlamentar."
+      - name: email_autor
+        description: "E-mail institucional do parlamentar."
+      - name: url_foto_partido
+        description: "URL do logo do partido."
+      - name: dt_ingest
+        description: "Data e hora (UTC-3 Brasília) mais recente de ingestão da tabela fato."
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'emendas.emendas_partidos'
+          nome_coluna: 'emissao_mes'
+          tipo_esperado: 'date'
+      - verificacao_tipagem:
+          nome_tabela: 'emendas.emendas_partidos'
+          nome_coluna: 'emissao_dia'
+          tipo_esperado: 'date'
+      - verificacao_tipagem:
+          nome_tabela: 'emendas.emendas_partidos'
+          nome_coluna: 'codigo_programa'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'emendas.emendas_partidos'
+          nome_coluna: 'codigo_gnd'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'emendas.emendas_partidos'
+          nome_coluna: 'codigo_modalidade'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'emendas.emendas_partidos'
+          nome_coluna: 'ne_ccor_ano_emissao'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'emendas.emendas_partidos'
+          nome_coluna: 'ptres'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'emendas.emendas_partidos'
+          nome_coluna: 'despesas_empenhadas'
+          tipo_esperado: 'numeric'
+      - verificacao_tipagem:
+          nome_tabela: 'emendas.emendas_partidos'
+          nome_coluna: 'despesas_liquidadas'
+          tipo_esperado: 'numeric'
+      - verificacao_tipagem:
+          nome_tabela: 'emendas.emendas_partidos'
+          nome_coluna: 'despesas_pagas'
+          tipo_esperado: 'numeric'
+      - verificacao_tipagem:
+          nome_tabela: 'emendas.emendas_partidos'
+          nome_coluna: 'id_autor'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'emendas.emendas_partidos'
+          nome_coluna: 'dt_ingest'
+          tipo_esperado: 'timestamp with time zone'


### PR DESCRIPTION
## Descrição
Cria uma tabela **silver** que cruza execução de emendas com metadados de parlamentares, enriquecendo dados orçamentários com contexto político.

##  Implementação
- Novo modelo silver integrando SIAFI/TesouroGerencial + dimensão de parlamentares  (STAR)
- Join por nome do autor (normalizado com `TRIM + UPPER`)  
- Enriquecimento com: id, cargo, nome, partido, UF, foto, e-mail e logo  
- Atualização do schema dbt (descrições + testes de tipagem)  

## Resultado
Visão consolidada para análises voltadas para o BI de emendas no MIR quase completa.

-> Oque falta:
1. Falta mapear em uma lookup table o PTRES de cada ano para extrair o `subtitulo` que seria a abrangência de atuação da emenda.
2. Número referente a emenda como usado no BI, não encontrei.
3. Restos a Pagar não estão explícitos.

## Observações
- Dependência de match textual do nome do autor  **(pode ser uma fragilidade)**

#### Draft -> Preciso checar com João os 3 pontos.

##### Fixes #142