### PR TITLE
Feat/camada bronze transferegov ted

### DIFF
--- a/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/bronze/notas_de_credito.sql
+++ b/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/bronze/notas_de_credito.sql
@@ -1,0 +1,23 @@
+{{ config(materialized="table") }}
+
+
+with
+	notas_de_credito_raw as (
+		select
+			id_nota::integer as id_nota,
+			id_plano_acao::integer as id_plano_acao,
+			tx_minuta_nota::text as tx_minuta_nota,
+			tx_numero_nota::text as tx_numero_nota,
+			dt_emissao_nota::timestamp as dt_emissao_nota,
+			cd_gestao_emitente_nota::text as cd_gestao_emitente_nota,
+			cd_gestao_favorecida_nota::text as cd_gestao_favorecida_nota,
+			tx_situacao_nota::text as tx_situacao_nota,
+			cd_ug_emitente_nota::text as cd_ug_emitente_nota,
+			cd_ug_favorecida_nota::text as cd_ug_favorecida_nota,
+			tx_observacao_nota::text as tx_observacao_nota,
+			(dt_ingest || '-03:00')::timestamptz as dt_ingest
+		from {{ source("transfere_gov", "notas_de_credito") }}
+	)
+
+select *
+from notas_de_credito_raw

--- a/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/bronze/planos_acao_ted.sql
+++ b/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/bronze/planos_acao_ted.sql
@@ -1,0 +1,31 @@
+{{ config(materialized="table") }}
+
+with
+	planos_acao_raw as (
+		select
+			id_plano_acao::integer as id_plano_acao,
+			id_programa::integer as id_programa,
+			sigla_unidade_descentralizada::text as sigla_unidade_descentralizada,
+			unidade_descentralizada::text as unidade_descentralizada,
+			sigla_unidade_responsavel_execucao::text as sigla_unidade_responsavel_execucao,
+			unidade_responsavel_execucao::text as unidade_responsavel_execucao,
+			nullif(vl_total_plano_acao, '')::numeric(15, 2) as vl_total_plano_acao,
+			nullif(dt_inicio_vigencia, '')::timestamp::date as dt_inicio_vigencia,
+			nullif(dt_fim_vigencia, '')::timestamp::date as dt_fim_vigencia,
+			tx_objeto_plano_acao::text as tx_objeto_plano_acao,
+			tx_justificativa_plano_acao::text as tx_justificativa_plano_acao,
+			nullif(in_forma_execucao_direta, '')::boolean as in_forma_execucao_direta,
+			nullif(in_forma_execucao_particulares, '')::boolean as in_forma_execucao_particulares,
+			nullif(in_forma_execucao_descentralizada, '')::boolean as in_forma_execucao_descentralizada,
+			tx_situacao_plano_acao::text as tx_situacao_plano_acao,
+			nullif(aa_ano_plano_acao, '')::integer as aa_ano_plano_acao,
+			nullif(vl_beneficiario_especifico, '')::numeric(15, 2) as vl_beneficiario_especifico,
+			nullif(vl_chamamento_publico, '')::numeric(15, 2) as vl_chamamento_publico,
+			sq_instrumento::text as sq_instrumento,
+			nullif(aa_instrumento, '')::integer as aa_instrumento,
+			(dt_ingest || '-03:00')::timestamptz as dt_ingest
+		from {{ source("transfere_gov", "planos_acao") }}
+	)
+
+select *
+from planos_acao_raw

--- a/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/bronze/programas_ted.sql
+++ b/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/bronze/programas_ted.sql
@@ -1,0 +1,39 @@
+{{ config(materialized="table") }}
+
+with
+	programas_raw as (
+		select
+			id_programa::integer as id_programa,
+			tx_codigo_programa::text as tx_codigo_programa,
+			nullif(aa_ano_programa, '')::integer as aa_ano_programa,
+			tx_situacao_programa::text as tx_situacao_programa,
+			tx_nome_programa::text as tx_nome_programa,
+			sigla_unidade_descentralizadora::text as sigla_unidade_descentralizadora,
+			unidade_descentralizadora::text as unidade_descentralizadora,
+			sigla_unidade_responsavel_acompanhamento::text as sigla_unidade_responsavel_acompanhamento,
+			unidade_responsavel_acompanhamento::text as unidade_responsavel_acompanhamento,
+			tx_nome_institucional_programa::text as tx_nome_institucional_programa,
+			tx_objetivo_programa::text as tx_objetivo_programa,
+			tx_descricao_programa::text as tx_descricao_programa,
+			nullif(in_grupo_investimento_obra, '')::boolean as in_grupo_investimento_obra,
+			nullif(in_grupo_investimento_servico, '')::boolean as in_grupo_investimento_servico,
+			nullif(in_grupo_investimento_equipamento, '')::boolean as in_grupo_investimento_equipamento,
+			in_autoriza_subdescentralizacao_outro::text as in_autoriza_subdescentralizacao_outro,
+			in_autoriza_realizacao_despesas::text as in_autoriza_realizacao_despesas,
+			in_autoriza_execucao_creditos_descentralizada::text as in_autoriza_execucao_creditos_descentralizada,
+			nullif(in_beneficiario_especifico, '')::boolean as in_beneficiario_especifico,
+			nullif(dt_recebimento_plano_beneficiario_inicio, '')::timestamp::date
+			as dt_recebimento_plano_beneficiario_inicio,
+			nullif(dt_recebimento_plano_beneficiario_fim, '')::timestamp::date
+			as dt_recebimento_plano_beneficiario_fim,
+			nullif(in_chamamento_publico, '')::boolean as in_chamamento_publico,
+			nullif(dt_recebimento_plano_chamamento_inicio, '')::timestamp::date
+			as dt_recebimento_plano_chamamento_inicio,
+			nullif(dt_recebimento_plano_chamamento_fim, '')::timestamp::date
+			as dt_recebimento_plano_chamamento_fim,
+			(dt_ingest || '-03:00')::timestamptz as dt_ingest
+		from {{ source("transfere_gov", "programas") }}
+	)
+
+select *
+from programas_raw

--- a/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/bronze/schema.yaml
+++ b/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/bronze/schema.yaml
@@ -365,3 +365,208 @@ models:
           nome_tabela: 'siafi_dbt.pf_transfere_mir'
           nome_coluna: 'id_programacao'
           tipo_esperado: 'integer'
+
+  - name: notas_de_credito
+    description: >
+      Modelo da camada bronze para Notas de Crédito do TransfereGov (módulo TED),
+      com padronização de tipos e ajuste do timestamp de ingestão para UTC-3.
+    meta:
+      tags:
+        - bronze
+    columns:
+      - name: id_nota
+        description: "Identificador único da Nota de Crédito."
+      - name: id_plano_acao
+        description: "Identificador único do Plano de Ação associado."
+      - name: tx_minuta_nota
+        description: "Minuta/identificador textual da Nota de Crédito."
+      - name: tx_numero_nota
+        description: "Número da Nota de Crédito."
+      - name: dt_emissao_nota
+        description: "Data/hora de emissão da Nota de Crédito."
+      - name: cd_gestao_emitente_nota
+        description: "Código da gestão emitente da Nota de Crédito."
+      - name: cd_gestao_favorecida_nota
+        description: "Código da gestão favorecida da Nota de Crédito."
+      - name: tx_situacao_nota
+        description: "Situação da Nota de Crédito."
+      - name: cd_ug_emitente_nota
+        description: "Código da Unidade Gestora emitente da Nota de Crédito."
+      - name: cd_ug_favorecida_nota
+        description: "Código da Unidade Gestora favorecida da Nota de Crédito."
+      - name: tx_observacao_nota
+        description: "Observações/texto livre da Nota de Crédito."
+      - name: dt_ingest
+        description: "Timestamp de ingestão ajustado para UTC-3."
+
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.notas_de_credito_mir'
+          nome_coluna: 'id_nota'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.notas_de_credito_mir'
+          nome_coluna: 'id_plano_acao'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.notas_de_credito_mir'
+          nome_coluna: 'dt_emissao_nota'
+          tipo_esperado: 'timestamp without time zone'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.notas_de_credito_mir'
+          nome_coluna: 'dt_ingest'
+          tipo_esperado: 'timestamp with time zone'
+
+  - name: programas_ted
+    description: >
+      Modelo da camada bronze para Programas do TransfereGov (módulo TED),
+      com padronização de tipos e ajuste do timestamp de ingestão para UTC-3.
+    meta:
+      tags:
+        - bronze
+    columns:
+      - name: id_programa
+        description: "Identificador único do Programa."
+      - name: tx_codigo_programa
+        description: "Código do Programa."
+      - name: aa_ano_programa
+        description: "Ano do Programa."
+      - name: tx_situacao_programa
+        description: "Situação do Programa."
+      - name: tx_nome_programa
+        description: "Nome do Programa."
+      - name: sigla_unidade_descentralizadora
+        description: "Sigla da unidade descentralizadora."
+      - name: unidade_descentralizadora
+        description: "Unidade descentralizadora."
+      - name: sigla_unidade_responsavel_acompanhamento
+        description: "Sigla da unidade responsável pelo acompanhamento."
+      - name: unidade_responsavel_acompanhamento
+        description: "Unidade responsável pelo acompanhamento."
+      - name: tx_nome_institucional_programa
+        description: "Nome institucional do Programa."
+      - name: tx_objetivo_programa
+        description: "Objetivo do Programa."
+      - name: tx_descricao_programa
+        description: "Descrição do Programa."
+      - name: in_grupo_investimento_obra
+        description: "Indicador do grupo de investimento (obra)."
+      - name: in_grupo_investimento_servico
+        description: "Indicador do grupo de investimento (serviço)."
+      - name: in_grupo_investimento_equipamento
+        description: "Indicador do grupo de investimento (equipamento)."
+      - name: in_autoriza_subdescentralizacao_outro
+        description: "Indicador/flag de autorização de subdescentralização (outro)."
+      - name: in_autoriza_realizacao_despesas
+        description: "Indicador/flag de autorização para realização de despesas."
+      - name: in_autoriza_execucao_creditos_descentralizada
+        description: "Indicador/flag de autorização para execução de créditos descentralizada."
+      - name: in_beneficiario_especifico
+        description: "Indicador de beneficiário específico."
+      - name: dt_recebimento_plano_beneficiario_inicio
+        description: "Data de início do recebimento do plano de beneficiário."
+      - name: dt_recebimento_plano_beneficiario_fim
+        description: "Data final do recebimento do plano de beneficiário."
+      - name: in_chamamento_publico
+        description: "Indicador de chamamento público."
+      - name: dt_recebimento_plano_chamamento_inicio
+        description: "Data de início do recebimento do plano de chamamento."
+      - name: dt_recebimento_plano_chamamento_fim
+        description: "Data final do recebimento do plano de chamamento."
+      - name: dt_ingest
+        description: "Timestamp de ingestão ajustado para UTC-3."
+
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.programas_mir'
+          nome_coluna: 'id_programa'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.programas_mir'
+          nome_coluna: 'aa_ano_programa'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.programas_mir'
+          nome_coluna: 'in_beneficiario_especifico'
+          tipo_esperado: 'boolean'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.programas_mir'
+          nome_coluna: 'dt_recebimento_plano_beneficiario_inicio'
+          tipo_esperado: 'date'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.programas_mir'
+          nome_coluna: 'dt_ingest'
+          tipo_esperado: 'timestamp with time zone'
+
+  - name: planos_acao_ted
+    description: >
+      Modelo da camada bronze para Planos de Ação do TransfereGov (módulo TED),
+      com padronização de tipos e ajuste do timestamp de ingestão para UTC-3.
+    meta:
+      tags:
+        - bronze
+    columns:
+      - name: id_plano_acao
+        description: "Identificador único do Plano de Ação."
+      - name: id_programa
+        description: "Identificador do Programa associado."
+      - name: sigla_unidade_descentralizada
+        description: "Sigla da unidade descentralizada."
+      - name: unidade_descentralizada
+        description: "Unidade descentralizada."
+      - name: sigla_unidade_responsavel_execucao
+        description: "Sigla da unidade responsável pela execução."
+      - name: unidade_responsavel_execucao
+        description: "Unidade responsável pela execução."
+      - name: vl_total_plano_acao
+        description: "Valor total do Plano de Ação."
+      - name: dt_inicio_vigencia
+        description: "Data de início de vigência do Plano de Ação."
+      - name: dt_fim_vigencia
+        description: "Data de fim de vigência do Plano de Ação."
+      - name: tx_objeto_plano_acao
+        description: "Objeto do Plano de Ação."
+      - name: tx_justificativa_plano_acao
+        description: "Justificativa do Plano de Ação."
+      - name: in_forma_execucao_direta
+        description: "Indicador da forma de execução direta."
+      - name: in_forma_execucao_particulares
+        description: "Indicador da forma de execução por particulares."
+      - name: in_forma_execucao_descentralizada
+        description: "Indicador da forma de execução descentralizada."
+      - name: tx_situacao_plano_acao
+        description: "Situação do Plano de Ação."
+      - name: aa_ano_plano_acao
+        description: "Ano do Plano de Ação."
+      - name: vl_beneficiario_especifico
+        description: "Valor do beneficiário específico."
+      - name: vl_chamamento_publico
+        description: "Valor do chamamento público."
+      - name: sq_instrumento
+        description: "Sequencial do instrumento."
+      - name: aa_instrumento
+        description: "Ano do instrumento."
+      - name: dt_ingest
+        description: "Timestamp de ingestão ajustado para UTC-3."
+
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.planos_acao_mir'
+          nome_coluna: 'id_plano_acao'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.planos_acao_mir'
+          nome_coluna: 'id_programa'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.planos_acao_mir'
+          nome_coluna: 'vl_total_plano_acao'
+          tipo_esperado: 'numeric'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.planos_acao_mir'
+          nome_coluna: 'dt_inicio_vigencia'
+          tipo_esperado: 'date'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.planos_acao_mir'
+          nome_coluna: 'dt_ingest'
+          tipo_esperado: 'timestamp with time zone'

--- a/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/silver/pf_unificado_planos_acao.sql
+++ b/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/silver/pf_unificado_planos_acao.sql
@@ -1,0 +1,96 @@
+{{ config(materialized="table") }}
+
+with
+	pf_unificado as (
+		select *
+		from {{ ref("pf_unificado") }}
+	),
+	planos_acao_deduplicado as (
+		select
+			id_plano_acao,
+			id_programa,
+			sigla_unidade_descentralizada,
+			unidade_descentralizada,
+			sigla_unidade_responsavel_execucao,
+			unidade_responsavel_execucao,
+			vl_total_plano_acao,
+			dt_inicio_vigencia,
+			dt_fim_vigencia,
+			tx_objeto_plano_acao,
+			tx_justificativa_plano_acao,
+			in_forma_execucao_direta,
+			in_forma_execucao_particulares,
+			in_forma_execucao_descentralizada,
+			tx_situacao_plano_acao,
+			aa_ano_plano_acao,
+			vl_beneficiario_especifico,
+			vl_chamamento_publico,
+			sq_instrumento,
+			aa_instrumento,
+			dt_ingest as dt_ingest_plano_acao
+		from (
+			select
+				pa.*,
+				row_number() over (
+					partition by pa.id_plano_acao
+					order by pa.dt_ingest desc
+				) as rn
+			from {{ ref("planos_acao_ted") }} pa
+		) pa_filtrado
+		where rn = 1
+	)
+
+select
+	pf.emissao_mes,
+	pf.emissao_dia,
+	pf.ug_emitente,
+	pf.ug_emitente_descricao,
+	pf.ug_favorecido,
+	pf.ug_favorecido_descricao,
+	pf.pf_evento,
+	pf.pf_evento_descricao,
+	pf.pf,
+	pf.pf_inscricao,
+	pf.pf_acao,
+	pf.pf_acao_descricao,
+	pf.pf_fonte_recursos,
+	pf.pf_fonte_recursos_descricao,
+	pf.doc_observacao,
+	pf.pf_valor_linha,
+	pf.id_programacao,
+	pf.id_plano_acao,
+	pf.tp_pf_tipo_programacao,
+	pf.tx_minuta_programacao,
+	pf.tx_numero_programacao,
+	pf.tx_situacao_programacao,
+	pf.tx_observacao_programacao,
+	pf.ug_emitente_programacao,
+	pf.ug_favorecida_programacao,
+	pf.dh_recebimento_programacao,
+	pf.pf_chave,
+	pa.id_programa,
+	pa.sigla_unidade_descentralizada,
+	pa.unidade_descentralizada,
+	pa.sigla_unidade_responsavel_execucao,
+	pa.unidade_responsavel_execucao,
+	pa.vl_total_plano_acao,
+	pa.dt_inicio_vigencia,
+	pa.dt_fim_vigencia,
+	pa.tx_objeto_plano_acao,
+	pa.tx_justificativa_plano_acao,
+	pa.in_forma_execucao_direta,
+	pa.in_forma_execucao_particulares,
+	pa.in_forma_execucao_descentralizada,
+	pa.tx_situacao_plano_acao,
+	pa.aa_ano_plano_acao,
+	pa.vl_beneficiario_especifico,
+	pa.vl_chamamento_publico,
+	pa.sq_instrumento,
+	pa.aa_instrumento,
+	coalesce(
+		greatest(pf.dt_ingest, pa.dt_ingest_plano_acao),
+		pf.dt_ingest,
+		pa.dt_ingest_plano_acao
+	) as dt_ingest
+from pf_unificado pf
+left join planos_acao_deduplicado pa using (id_plano_acao)

--- a/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/silver/schema.yml
+++ b/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/silver/schema.yml
@@ -84,3 +84,47 @@ models:
           nome_tabela: 'siafi_dbt.pf_unificado'
           nome_coluna: 'id_plano_acao'
           tipo_esperado: 'integer'
+
+  - name: pf_unificado_planos_acao
+    description: >
+      Tabela silver que enriquece a base pf_unificado com os dados de planos de acao
+      do Transferegov, por meio do id_plano_acao. O cruzamento preserva todas as
+      linhas de PF e deduplica planos de acao por id_plano_acao, mantendo o registro
+      mais recente por dt_ingest.
+    meta:
+      tags:
+        - silver
+    columns:
+      - name: id_programacao
+        description: "Identificador da programacao financeira no Transferegov."
+      - name: id_plano_acao
+        description: "Identificador do plano de acao usado como chave de cruzamento."
+      - name: id_programa
+        description: "Identificador do programa associado ao plano de acao."
+      - name: pf
+        description: "Identificador completo da programacao financeira no Tesouro."
+      - name: tx_numero_programacao
+        description: "Numero da programacao financeira no Transferegov."
+      - name: tx_situacao_plano_acao
+        description: "Situacao do plano de acao no Transferegov."
+      - name: vl_total_plano_acao
+        description: "Valor total informado para o plano de acao."
+      - name: dt_ingest
+        description: "Maior timestamp de ingestao entre pf_unificado e planos_acao_ted."
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.pf_unificado_planos_acao'
+          nome_coluna: 'id_programacao'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.pf_unificado_planos_acao'
+          nome_coluna: 'id_plano_acao'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.pf_unificado_planos_acao'
+          nome_coluna: 'id_programa'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.pf_unificado_planos_acao'
+          nome_coluna: 'vl_total_plano_acao'
+          tipo_esperado: 'numeric'

--- a/airflow_lappis/dags/dbt/mir/models/sources.yml
+++ b/airflow_lappis/dags/dbt/mir/models/sources.yml
@@ -30,7 +30,10 @@ sources:
   - name: transfere_gov
     schema: transfere_gov
     tables:
+      - name: programas
+      - name: planos_acao
       - name: programacao_financeira
+      - name: notas_de_credito
 
   - name: siafi
     schema: siafi


### PR DESCRIPTION
# Criação das camadas Bronze e Silver para dados de TEDs

## Descrição
Implementa a criação da camada **Bronze** para ingestão de todos os dados relacionados aos TEDs provenientes do Transferegov.

Além disso, é criada a camada **Silver**, responsável por realizar a junção dos dados de `planos_de_acao` oriundos do Transferegov e a unificação com as informações de programa financeiro provenientes do SIAFI.

## Principais alterações
- Criação da camada Bronze para dados brutos de TEDs (Transferegov)
- Implementação da camada Silver com:
  - Junção dos dados de `planos_de_acao`
  - Integração com dados de programa financeiro do SIAFI
