### PR TITLE
build: corrige setup do Poetry e remove instalação global via pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,12 @@ export PYTHONPATH := $(CURDIR)/airflow_lappis
 export MYPYPATH := $(CURDIR):$(CURDIR)/airflow_lappis/dags:$(CURDIR)/airflow_lappis/helpers:$(CURDIR)/airflow_lappis/plugins
 
 setup:
-	pip install poetry==1.8.5
+	@if ! command -v poetry >/dev/null 2>&1; then \
+		echo "Poetry não encontrado. Instale antes com pipx install poetry==1.8.5"; \
+		exit 1; \
+	fi
+	poetry self add poetry-plugin-export || true
 	poetry config virtualenvs.in-project false
-	poetry config warnings.export false
 	poetry lock
 	poetry install --no-root --with dev
 	poetry export --without-hashes --format=requirements.txt > requirements.generated.txt


### PR DESCRIPTION
## Descrição

Este PR ajusta o alvo `setup` do Makefile para tornar a configuração do ambiente local mais compatível e previsível.

## Ambiente de validação

As alterações foram testadas em ambiente Linux (Ubuntu 24.04).

## Problemas identificados

O fluxo atual de setup apresentava os seguintes problemas:

### 1. A tentativa de instalar o Poetry globalmente com:

```bash
pip install poetry==1.8.5
```

podia falhar em ambientes Linux recentes, como Ubuntu 24.04, devido a restrições do ambiente Python do sistema.

<img width="1134" height="529" alt="Screenshot from 2026-04-17 11-29-42" src="https://github.com/user-attachments/assets/d93db185-e665-4de6-aedd-563cffef3183" />

### 2. O uso da configuração:

```bash
poetry config warnings.export false
```

interrompia o setup, pois essa configuração não existe no Poetry.

<img width="555" height="94" alt="Screenshot from 2026-04-17 11-43-04" src="https://github.com/user-attachments/assets/e3e69ffb-5683-4eba-aba6-dcf7631731e6" />

---

### 3. O comando `poetry export` depende da disponibilidade do plugin `poetry-plugin-export`.

De acordo com a documentação oficial, o comando de exportação está sendo tratado como plugin e deve ser instalado explicitamente para garantir compatibilidade futura: [https://python-poetry.org/blog/announcing-poetry-1.8.0/](https://python-poetry.org/blog/announcing-poetry-1.8.0/?utm_source=chatgpt.com)



## Solução aplicada

- remoção da instalação global do Poetry via pip
- remoção da configuração inválida warnings.export
- adição da etapa:

```bash
poetry self add poetry-plugin-export || true
```

para garantir a disponibilidade do plugin necessário ao `poetry export`

## Impacto

A mudança evita falhas durante a configuração inicial e melhora a previsibilidade do processo de setup, especialmente em ambientes Linux modernos.

## Observação

Para desenvolvedores que já possuem o Poetry instalado, o setup reutiliza a instalação existente.
A etapa de adição do plugin atua sobre o ambiente do Poetry do usuário.