### PR TITLE
feat: adiciona camada bronze do SICONV

### DIFF
--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/convenio.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/convenio.sql
@@ -1,0 +1,50 @@
+{{ config(materialized="table") }}
+
+with
+    convenio_raw as (
+        select
+            nullif(nr_convenio, '')::integer as nr_convenio,
+            nullif(id_proposta, '')::integer as id_proposta,
+            nullif(dia, '')::integer as dia,
+            nullif(mes, '')::integer as mes,
+            nullif(ano, '')::integer as ano,
+            to_date(nullif(dia_assin_conv, ''), 'DD/MM/YYYY') as dia_assin_conv,
+            sit_convenio::text as sit_convenio,
+            subsituacao_conv::text as subsituacao_conv,
+            situacao_publicacao::text as situacao_publicacao,
+            instrumento_ativo::text as instrumento_ativo,
+            ind_opera_obtv::text as ind_opera_obtv,
+            nr_processo::text as nr_processo,
+            nullif(ug_emitente, '')::integer as ug_emitente,
+            to_date(nullif(dia_publ_conv, ''), 'DD/MM/YYYY') as dia_publ_conv,
+            to_date(nullif(dia_inic_vigenc_conv, ''), 'DD/MM/YYYY') as dia_inic_vigenc_conv,
+            to_date(nullif(dia_fim_vigenc_conv, ''), 'DD/MM/YYYY') as dia_fim_vigenc_conv,
+            to_date(nullif(dia_fim_vigenc_original_conv, ''), 'DD/MM/YYYY') as dia_fim_vigenc_original_conv,
+            nullif(dias_prest_contas, '')::integer as dias_prest_contas,
+            to_date(nullif(dia_limite_prest_contas, ''), 'DD/MM/YYYY') as dia_limite_prest_contas,
+            to_date(nullif(data_suspensiva, ''), 'DD/MM/YYYY') as data_suspensiva,
+            to_date(nullif(data_retirada_suspensiva, ''), 'DD/MM/YYYY') as data_retirada_suspensiva,
+            nullif(dias_clausula_suspensiva, '')::integer as dias_clausula_suspensiva,
+            situacao_contratacao::text as situacao_contratacao,
+            ind_assinado::text as ind_assinado,
+            motivo_suspensao::text as motivo_suspensao,
+            ind_foto::text as ind_foto,
+            nullif(qtde_convenios, '')::integer as qtde_convenios,
+            nullif(qtd_ta, '')::integer as qtd_ta,
+            nullif(qtd_prorroga, '')::integer as qtd_prorroga,
+            replace(nullif(vl_global_conv, ''), ',', '.')::numeric(15, 2) as vl_global_conv,
+            replace(nullif(vl_repasse_conv, ''), ',', '.')::numeric(15, 2) as vl_repasse_conv,
+            replace(nullif(vl_contrapartida_conv, ''), ',', '.')::numeric(15, 2) as vl_contrapartida_conv,
+            replace(nullif(vl_empenhado_conv, ''), ',', '.')::numeric(15, 2) as vl_empenhado_conv,
+            replace(nullif(vl_desembolsado_conv, ''), ',', '.')::numeric(15, 2) as vl_desembolsado_conv,
+            replace(nullif(vl_saldo_reman_tesouro, ''), ',', '.')::numeric(15, 2) as vl_saldo_reman_tesouro,
+            replace(nullif(vl_saldo_reman_convenente, ''), ',', '.')::numeric(15, 2) as vl_saldo_reman_convenente,
+            replace(nullif(vl_rendimento_aplicacao, ''), ',', '.')::numeric(15, 2) as vl_rendimento_aplicacao,
+            replace(nullif(vl_ingresso_contrapartida, ''), ',', '.')::numeric(15, 2) as vl_ingresso_contrapartida,
+            replace(nullif(vl_saldo_conta, ''), ',', '.')::numeric(15, 2) as vl_saldo_conta,
+            replace(nullif(valor_global_original_conv, ''), ',', '.')::numeric(15, 2) as valor_global_original_conv
+        from {{ source("siconv", "convenio") }}
+    )
+
+select *
+from convenio_raw

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/cronograma_desembolso.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/cronograma_desembolso.sql
@@ -1,0 +1,17 @@
+{{ config(materialized="table") }}
+
+with
+    cronograma_desembolso_raw as (
+        select
+            nullif(id_proposta, '')::integer as id_proposta,
+            nullif(nr_convenio, '')::integer as nr_convenio,
+            nullif(nr_parcela_crono_desembolso, '')::integer as nr_parcela_crono_desembolso,
+            nullif(mes_crono_desembolso, '')::integer as mes_crono_desembolso,
+            nullif(ano_crono_desembolso, '')::integer as ano_crono_desembolso,
+            tipo_resp_crono_desembolso::text as tipo_resp_crono_desembolso,
+            replace(nullif(valor_parcela_crono_desembolso, ''), ',', '.')::numeric(15, 2) as valor_parcela_crono_desembolso
+        from {{ source("siconv", "cronograma_desembolso") }}
+    )
+
+select *
+from cronograma_desembolso_raw

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/desbloqueio.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/desbloqueio.sql
@@ -1,0 +1,18 @@
+{{ config(materialized="table") }}
+
+with
+    desbloqueio_raw as (
+        select
+            nr_convenio::integer as nr_convenio,
+            nr_ob::text as nr_ob,
+            to_date(nullif(data_cadastro, ''), 'DD/MM/YYYY') as data_cadastro,
+            to_date(nullif(data_envio, ''), 'DD/MM/YYYY') as data_envio,
+            tipo_recurso_desbloqueio::text as tipo_recurso_desbloqueio,
+            replace(nullif(vl_total_desbloqueio, ''), ',', '.')::numeric(15, 2) as vl_total_desbloqueio,
+            replace(nullif(vl_desbloqueado, ''), ',', '.')::numeric(15, 2) as vl_desbloqueado,
+            replace(nullif(vl_bloqueado, ''), ',', '.')::numeric(15, 2) as vl_bloqueado
+        from {{ source("siconv", "desbloqueio") }}
+    )
+
+select *
+from desbloqueio_raw

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/desembolso.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/desembolso.sql
@@ -1,0 +1,21 @@
+{{ config(materialized="table") }}
+
+with
+    desembolso_raw as (
+        select
+            nullif(id_desembolso, '')::integer as id_desembolso,
+            nullif(nr_convenio, '')::integer as nr_convenio,
+            to_date(nullif(dt_ult_desembolso, ''), 'DD/MM/YYYY') as dt_ult_desembolso,
+            nullif(qtd_dias_sem_desembolso, '')::integer as qtd_dias_sem_desembolso,
+            to_date(nullif(data_desembolso, ''), 'DD/MM/YYYY') as data_desembolso,
+            nullif(ano_desembolso, '')::integer as ano_desembolso,
+            nullif(mes_desembolso, '')::integer as mes_desembolso,
+            nr_siafi::text as nr_siafi,
+            nullif(ug_emitente_dh, '')::integer as ug_emitente_dh,
+            observacao_dh::text as observacao_dh,
+            replace(nullif(vl_desembolsado, ''), ',', '.')::numeric(15, 2) as vl_desembolsado
+        from {{ source("siconv", "desembolso") }}
+    )
+
+select *
+from desembolso_raw

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/empenho.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/empenho.sql
@@ -1,0 +1,28 @@
+{{ config(materialized="table") }}
+
+with
+    empenho_raw as (
+        select
+            nullif(id_empenho, '')::integer as id_empenho,
+            nullif(nr_convenio, '')::integer as nr_convenio,
+            nr_empenho::text as nr_empenho,
+            tipo_nota::text as tipo_nota,
+            desc_tipo_nota::text as desc_tipo_nota,
+            to_date(nullif(data_emissao, ''), 'DD/MM/YYYY') as data_emissao,
+            cod_situacao_empenho::text as cod_situacao_empenho,
+            desc_situacao_empenho::text as desc_situacao_empenho,
+            nullif(ug_emitente, '')::integer as ug_emitente,
+            nullif(ug_responsavel, '')::integer as ug_responsavel,
+            fonte_recurso::text as fonte_recurso,
+            natureza_despesa::text as natureza_despesa,
+            plano_interno::text as plano_interno,
+            ptres::text as ptres,
+            replace(nullif(valor_empenho, ''), ',', '.')::numeric(15, 2) as valor_empenho,
+            resultado_primario::text as resultado_primario,
+            observacao_empenho::text as observacao_empenho,
+            descricao_emenda_siafi::text as descricao_emenda_siafi
+        from {{ source("siconv", "empenho") }}
+    )
+
+select *
+from empenho_raw

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/historico_situacao.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/historico_situacao.sql
@@ -1,0 +1,16 @@
+{{ config(materialized="table") }}
+
+with
+    historico_situacao_raw as (
+        select
+            nullif(id_proposta, '')::integer as id_proposta,
+            nullif(nr_convenio, '')::integer as nr_convenio,
+            to_date(nullif(dia_historico_sit, ''), 'DD/MM/YYYY') as dia_historico_sit,
+            historico_sit::text as historico_sit,
+            nullif(dias_historico_sit, '')::integer as dias_historico_sit,
+            nullif(cod_historico_sit, '')::integer as cod_historico_sit
+        from {{ source("siconv", "historico_situacao") }}
+    )
+
+select *
+from historico_situacao_raw

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/ingresso_contrapartida.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/ingresso_contrapartida.sql
@@ -1,0 +1,13 @@
+{{ config(materialized="table") }}
+
+with
+    ingresso_contrapartida_raw as (
+        select
+            nr_convenio::integer as nr_convenio,
+            to_date(nullif(dt_ingresso_contrapartida, ''), 'DD/MM/YYYY') as dt_ingresso_contrapartida,
+            replace(nullif(vl_ingresso_contrapartida, ''), ',', '.')::numeric(15, 2) as vl_ingresso_contrapartida
+        from {{ source("siconv", "ingresso_contrapartida") }}
+    )
+
+select *
+from ingresso_contrapartida_raw

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/licitacao.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/licitacao.sql
@@ -1,0 +1,28 @@
+{{ config(materialized="table") }}
+
+with
+    licitacao_raw as (
+        select
+            nullif(id_licitacao, '')::integer as id_licitacao,
+            nullif(nr_convenio, '')::integer as nr_convenio,
+            nr_licitacao::text as nr_licitacao,
+            modalidade_licitacao::text as modalidade_licitacao,
+            tp_processo_compra::text as tp_processo_compra,
+            tipo_licitacao::text as tipo_licitacao,
+            nr_processo_licitacao::text as nr_processo_licitacao,
+            to_date(nullif(data_publicacao_licitacao, ''), 'DD/MM/YYYY') as data_publicacao_licitacao,
+            to_date(nullif(data_abertura_licitacao, ''), 'DD/MM/YYYY') as data_abertura_licitacao,
+            to_date(nullif(data_encerramento_licitacao, ''), 'DD/MM/YYYY') as data_encerramento_licitacao,
+            to_date(nullif(data_homologacao_licitacao, ''), 'DD/MM/YYYY') as data_homologacao_licitacao,
+            status_licitacao::text as status_licitacao,
+            situacao_aceite_processo_execu::text as situacao_aceite_processo_execu,
+            sistema_origem::text as sistema_origem,
+            situacao_sistema::text as situacao_sistema,
+            replace(nullif(valor_licitacao, ''), ',', '.')::numeric(20, 2) as valor_licitacao,
+            to_date(nullif(data_analise_aceite, ''), 'DD/MM/YYYY') as data_analise_aceite,
+            to_date(nullif(data_envio_analise, ''), 'DD/MM/YYYY') as data_envio_analise
+        from {{ source("siconv", "licitacao") }}
+    )
+
+select *
+from licitacao_raw

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/meta_crono_fisico.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/meta_crono_fisico.sql
@@ -1,0 +1,27 @@
+{{ config(materialized="table") }}
+
+with
+    meta_crono_fisico_raw as (
+        select
+            nullif(id_meta, '')::integer as id_meta,
+            nullif(id_proposta, '')::integer as id_proposta,
+            nullif(nr_convenio, '')::integer as nr_convenio,
+            cod_programa::text as cod_programa,
+            nome_programa::text as nome_programa,
+            nullif(nr_meta, '')::integer as nr_meta,
+            tipo_meta::text as tipo_meta,
+            desc_meta::text as desc_meta,
+            to_date(nullif(data_inicio_meta, ''), 'DD/MM/YYYY') as data_inicio_meta,
+            to_date(nullif(data_fim_meta, ''), 'DD/MM/YYYY') as data_fim_meta,
+            uf_meta::text as uf_meta,
+            municipio_meta::text as municipio_meta,
+            endereco_meta::text as endereco_meta,
+            cep_meta::text as cep_meta,
+            replace(nullif(qtd_meta, ''), ',', '.')::numeric(15, 2) as qtd_meta,
+            und_fornecimento_meta::text as und_fornecimento_meta,
+            replace(nullif(vl_meta, ''), ',', '.')::numeric(15, 2) as vl_meta
+        from {{ source("siconv", "meta_crono_fisico") }}
+    )
+
+select *
+from meta_crono_fisico_raw 

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/pagamento.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/pagamento.sql
@@ -1,0 +1,29 @@
+{{ config(materialized="table") }}
+
+with
+    pagamento_raw as (
+        select
+            nullif(nr_mov_fin, '')::integer as nr_mov_fin,
+            nullif(nr_convenio, '')::integer as nr_convenio,
+            identif_fornecedor::text as identif_fornecedor,
+            nome_fornecedor::text as nome_fornecedor,
+            tp_mov_financeira::text as tp_mov_financeira,
+            case
+                when nullif(data_pag, '') is null then null
+                when data_pag ~ '^\d{2}/\d{2}/\d{4}$' then to_date(data_pag, 'DD/MM/YYYY')
+                else to_date(data_pag, 'YYYY-MM-DD')
+            end as data_pag,
+            nr_dl::text as nr_dl,
+            desc_dl::text as desc_dl,
+            replace(nullif(vl_pago, ''), ',', '.')::numeric(15, 2) as vl_pago,
+            nullif(id_dl, '')::integer as id_dl,
+            case
+                when nullif(data_emissao_dl, '') is null then null
+                when data_emissao_dl ~ '^\d{2}/\d{2}/\d{4}$' then to_date(data_emissao_dl, 'DD/MM/YYYY')
+                else to_date(data_emissao_dl, 'YYYY-MM-DD')
+            end as data_emissao_dl
+        from {{ source("siconv", "pagamento") }}
+    )
+
+select *
+from pagamento_raw

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/pagamento_tributo.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/pagamento_tributo.sql
@@ -1,0 +1,13 @@
+{{ config(materialized="table") }}
+
+with
+    pagamento_tributo_raw as (
+        select
+            nr_convenio::integer as nr_convenio,
+            to_date(nullif(data_tributo, ''), 'DD/MM/YYYY') as data_tributo,
+            replace(nullif(vl_pag_tributos, ''), ',', '.')::numeric(15, 2) as vl_pag_tributos
+        from {{ source("siconv", "pagamento_tributo") }}
+    )
+
+select *
+from pagamento_tributo_raw

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/proposta.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/proposta.sql
@@ -1,0 +1,46 @@
+{{ config(materialized="table") }}
+
+with
+    proposta_raw as (
+        select
+            id_proposta::integer as id_proposta,
+            uf_proponente::text as uf_proponente,
+            munic_proponente::text as munic_proponente,
+            cod_munic_ibge::integer as cod_munic_ibge,
+            cod_orgao_sup::integer as cod_orgao_sup,
+            desc_orgao_sup::text as desc_orgao_sup,
+            natureza_juridica::text as natureza_juridica,
+            nr_proposta::text as nr_proposta,
+            dia_prop::integer as dia_prop,
+            mes_prop::integer as mes_prop,
+            ano_prop::integer as ano_prop,
+            to_date(nullif(dia_proposta, ''), 'DD/MM/YYYY') as dia_proposta,
+            cod_orgao::integer as cod_orgao,
+            desc_orgao::text as desc_orgao,
+            modalidade::text as modalidade,
+            identif_proponente::text as identif_proponente,
+            nm_proponente::text as nm_proponente,
+            cep_proponente::text as cep_proponente,
+            endereco_proponente::text as endereco_proponente,
+            bairro_proponente::text as bairro_proponente,
+            nm_banco::text as nm_banco,
+            situacao_conta::text as situacao_conta,
+            situacao_projeto_basico::text as situacao_projeto_basico,
+            sit_proposta::text as sit_proposta,
+            to_date(nullif(dia_inic_vigencia_proposta, ''), 'DD/MM/YYYY') as dia_inic_vigencia_proposta,
+            to_date(nullif(dia_fim_vigencia_proposta, ''), 'DD/MM/YYYY') as dia_fim_vigencia_proposta,
+            objeto_proposta::text as objeto_proposta,
+            item_investimento::text as item_investimento,
+            enviada_mandataria::text as enviada_mandataria,
+            nome_subtipo_proposta::text as nome_subtipo_proposta,
+            descricao_subtipo_proposta::text as descricao_subtipo_proposta,
+            replace(nullif(vl_global_prop, ''), ',', '.')::numeric(15, 2) as vl_global_prop,
+            replace(nullif(vl_repasse_prop, ''), ',', '.')::numeric(15, 2) as vl_repasse_prop,
+            replace(nullif(vl_contrapartida_prop, ''), ',', '.')::numeric(15, 2) as vl_contrapartida_prop,
+            cd_agencia::text as cd_agencia,
+            cd_conta::text as cd_conta
+        from {{ source("siconv", "proposta") }}
+    )
+
+select *
+from proposta_raw

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/prorroga_oficio.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/prorroga_oficio.sql
@@ -1,0 +1,17 @@
+{{ config(materialized="table") }}
+
+with
+    prorroga_oficio_raw as (
+        select
+            nullif(nr_convenio, '')::integer as nr_convenio,
+            nr_prorroga::text as nr_prorroga,
+            to_date(nullif(dt_inicio_prorroga, ''), 'DD/MM/YYYY') as dt_inicio_prorroga,
+            to_date(nullif(dt_fim_prorroga, ''), 'DD/MM/YYYY') as dt_fim_prorroga,
+            nullif(dias_prorroga, '')::integer as dias_prorroga,
+            to_date(nullif(dt_assinatura_prorroga, ''), 'DD/MM/YYYY') as dt_assinatura_prorroga,
+            sit_prorroga::text as sit_prorroga
+        from {{ source("siconv", "prorroga_oficio") }}
+    )
+
+select *
+from prorroga_oficio_raw

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/schema.yaml
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/schema.yaml
@@ -1,0 +1,742 @@
+version: 2
+
+models:
+  - name: proposta
+    description: >
+      Tabela da camada bronze contendo informações sobre propostas de convênios do SICONV,
+      com conversão de tipos, padronização de datas e valores financeiros.
+    meta:
+      tags:
+        - bronze
+    columns:
+      - name: id_proposta
+        description: "Identificador único da proposta."
+      - name: uf_proponente
+        description: "Unidade Federativa do proponente."
+      - name: munic_proponente
+        description: "Município do proponente."
+      - name: cod_munic_ibge
+        description: "Código IBGE do município."
+      - name: cod_orgao_sup
+        description: "Código do órgão superior."
+      - name: desc_orgao_sup
+        description: "Descrição do órgão superior."
+      - name: natureza_juridica
+        description: "Natureza jurídica do proponente."
+      - name: nr_proposta
+        description: "Número da proposta."
+      - name: dia_prop
+        description: "Dia da proposta."
+      - name: mes_prop
+        description: "Mês da proposta."
+      - name: ano_prop
+        description: "Ano da proposta."
+      - name: dia_proposta
+        description: "Data da proposta."
+      - name: cod_orgao
+        description: "Código do órgão."
+      - name: desc_orgao
+        description: "Descrição do órgão."
+      - name: modalidade
+        description: "Modalidade da proposta."
+      - name: identif_proponente
+        description: "Identificação do proponente (CNPJ/CPF)."
+      - name: nm_proponente
+        description: "Nome do proponente."
+      - name: cep_proponente
+        description: "CEP do proponente."
+      - name: endereco_proponente
+        description: "Endereço do proponente."
+      - name: bairro_proponente
+        description: "Bairro do proponente."
+      - name: nm_banco
+        description: "Nome do banco."
+      - name: situacao_conta
+        description: "Situação da conta bancária."
+      - name: situacao_projeto_basico
+        description: "Situação do projeto básico."
+      - name: sit_proposta
+        description: "Situação da proposta."
+      - name: dia_inic_vigencia_proposta
+        description: "Data de início da vigência da proposta."
+      - name: dia_fim_vigencia_proposta
+        description: "Data de fim da vigência da proposta."
+      - name: objeto_proposta
+        description: "Objeto da proposta."
+      - name: item_investimento
+        description: "Item de investimento."
+      - name: enviada_mandataria
+        description: "Indica se foi enviada à mandatária."
+      - name: nome_subtipo_proposta
+        description: "Nome do subtipo da proposta."
+      - name: descricao_subtipo_proposta
+        description: "Descrição do subtipo da proposta."
+      - name: vl_global_prop
+        description: "Valor global da proposta."
+      - name: vl_repasse_prop
+        description: "Valor de repasse da proposta."
+      - name: vl_contrapartida_prop
+        description: "Valor de contrapartida da proposta."
+      - name: cd_agencia
+        description: "Código da agência bancária."
+      - name: cd_conta
+        description: "Código da conta bancária."
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.proposta'
+          nome_coluna: 'id_proposta'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.proposta'
+          nome_coluna: 'vl_global_prop'
+          tipo_esperado: 'numeric'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.proposta'
+          nome_coluna: 'dia_proposta'
+          tipo_esperado: 'date'
+
+  - name: convenio
+    description: >
+      Tabela da camada bronze contendo informações sobre convênios do SICONV,
+      com conversão de tipos, padronização de datas e valores financeiros.
+    meta:
+      tags:
+        - bronze
+    columns:
+      - name: nr_convenio
+        description: "Número do convênio."
+      - name: id_proposta
+        description: "Identificador da proposta associada."
+      - name: dia
+        description: "Dia de assinatura do convênio."
+      - name: mes
+        description: "Mês de assinatura do convênio."
+      - name: ano
+        description: "Ano de assinatura do convênio."
+      - name: dia_assin_conv
+        description: "Data de assinatura do convênio."
+      - name: sit_convenio
+        description: "Situação do convênio."
+      - name: subsituacao_conv
+        description: "Subsituação do convênio."
+      - name: situacao_publicacao
+        description: "Situação de publicação do convênio."
+      - name: instrumento_ativo
+        description: "Indica se o instrumento está ativo."
+      - name: ind_opera_obtv
+        description: "Indicador de operação OBTV."
+      - name: nr_processo
+        description: "Número do processo."
+      - name: ug_emitente
+        description: "Código da UG emitente."
+      - name: dia_publ_conv
+        description: "Data de publicação do convênio."
+      - name: dia_inic_vigenc_conv
+        description: "Data de início da vigência do convênio."
+      - name: dia_fim_vigenc_conv
+        description: "Data de fim da vigência do convênio."
+      - name: dia_fim_vigenc_original_conv
+        description: "Data de fim da vigência original do convênio."
+      - name: dias_prest_contas
+        description: "Prazo em dias para prestação de contas."
+      - name: dia_limite_prest_contas
+        description: "Data limite para prestação de contas."
+      - name: data_suspensiva
+        description: "Data da cláusula suspensiva."
+      - name: data_retirada_suspensiva
+        description: "Data de retirada da cláusula suspensiva."
+      - name: dias_clausula_suspensiva
+        description: "Dias de cláusula suspensiva."
+      - name: situacao_contratacao
+        description: "Situação da contratação."
+      - name: ind_assinado
+        description: "Indica se o convênio foi assinado."
+      - name: motivo_suspensao
+        description: "Motivo da suspensão do convênio."
+      - name: ind_foto
+        description: "Indica se há foto associada."
+      - name: qtde_convenios
+        description: "Quantidade de convênios."
+      - name: qtd_ta
+        description: "Quantidade de termos aditivos."
+      - name: qtd_prorroga
+        description: "Quantidade de prorrogações."
+      - name: vl_global_conv
+        description: "Valor global do convênio."
+      - name: vl_repasse_conv
+        description: "Valor de repasse do convênio."
+      - name: vl_contrapartida_conv
+        description: "Valor de contrapartida do convênio."
+      - name: vl_empenhado_conv
+        description: "Valor empenhado do convênio."
+      - name: vl_desembolsado_conv
+        description: "Valor desembolsado do convênio."
+      - name: vl_saldo_reman_tesouro
+        description: "Valor do saldo remanescente do tesouro."
+      - name: vl_saldo_reman_convenente
+        description: "Valor do saldo remanescente do convenente."
+      - name: vl_rendimento_aplicacao
+        description: "Valor do rendimento de aplicação."
+      - name: vl_ingresso_contrapartida
+        description: "Valor de ingresso de contrapartida."
+      - name: vl_saldo_conta
+        description: "Valor do saldo em conta."
+      - name: valor_global_original_conv
+        description: "Valor global original do convênio."
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.convenio'
+          nome_coluna: 'nr_convenio'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.convenio'
+          nome_coluna: 'vl_global_conv'
+          tipo_esperado: 'numeric'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.convenio'
+          nome_coluna: 'dia_assin_conv'
+          tipo_esperado: 'date'
+
+  - name: desembolso
+    description: >
+      Tabela da camada bronze contendo informações sobre desembolsos de convênios do SICONV.
+    meta:
+      tags:
+        - bronze
+    columns:
+      - name: id_desembolso
+        description: "Identificador único do desembolso."
+      - name: nr_convenio
+        description: "Número do convênio associado."
+      - name: dt_ult_desembolso
+        description: "Data do último desembolso."
+      - name: qtd_dias_sem_desembolso
+        description: "Quantidade de dias sem desembolso."
+      - name: data_desembolso
+        description: "Data do desembolso."
+      - name: ano_desembolso
+        description: "Ano do desembolso."
+      - name: mes_desembolso
+        description: "Mês do desembolso."
+      - name: nr_siafi
+        description: "Número SIAFI do desembolso."
+      - name: ug_emitente_dh
+        description: "Código da UG emitente do documento hábil."
+      - name: observacao_dh
+        description: "Observação do documento hábil."
+      - name: vl_desembolsado
+        description: "Valor desembolsado."
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.desembolso'
+          nome_coluna: 'id_desembolso'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.desembolso'
+          nome_coluna: 'vl_desembolsado'
+          tipo_esperado: 'numeric'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.desembolso'
+          nome_coluna: 'data_desembolso'
+          tipo_esperado: 'date'
+
+  - name: desbloqueio
+    description: >
+      Tabela da camada bronze contendo informações sobre desbloqueios de recursos de convênios do SICONV.
+    meta:
+      tags:
+        - bronze
+    columns:
+      - name: nr_convenio
+        description: "Número do convênio associado."
+      - name: nr_ob
+        description: "Número da ordem bancária."
+      - name: data_cadastro
+        description: "Data de cadastro do desbloqueio."
+      - name: data_envio
+        description: "Data de envio do desbloqueio."
+      - name: tipo_recurso_desbloqueio
+        description: "Tipo de recurso desbloqueado."
+      - name: vl_total_desbloqueio
+        description: "Valor total do desbloqueio."
+      - name: vl_desbloqueado
+        description: "Valor desbloqueado."
+      - name: vl_bloqueado
+        description: "Valor bloqueado."
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.desbloqueio'
+          nome_coluna: 'nr_convenio'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.desbloqueio'
+          nome_coluna: 'vl_total_desbloqueio'
+          tipo_esperado: 'numeric'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.desbloqueio'
+          nome_coluna: 'data_cadastro'
+          tipo_esperado: 'date'
+
+  - name: solicitacao_alteracao
+    description: >
+      Tabela da camada bronze contendo informações sobre solicitações de alteração de convênios do SICONV.
+    meta:
+      tags:
+        - bronze
+    columns:
+      - name: id_solicitacao
+        description: "Identificador único da solicitação."
+      - name: nr_convenio
+        description: "Número do convênio associado."
+      - name: nr_solicitacao
+        description: "Número da solicitação."
+      - name: situacao_solicitacao
+        description: "Situação da solicitação."
+      - name: objeto_solicitacao
+        description: "Objeto da solicitação."
+      - name: data_solicitacao
+        description: "Data da solicitação."
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.solicitacao_alteracao'
+          nome_coluna: 'id_solicitacao'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.solicitacao_alteracao'
+          nome_coluna: 'data_solicitacao'
+          tipo_esperado: 'date'
+
+  - name: termo_aditivo
+    description: >
+      Tabela da camada bronze contendo informações sobre termos aditivos de convênios do SICONV.
+    meta:
+      tags:
+        - bronze
+    columns:
+      - name: nr_convenio
+        description: "Número do convênio associado."
+      - name: id_solicitacao
+        description: "Identificador da solicitação associada."
+      - name: numero_ta
+        description: "Número do termo aditivo."
+      - name: tipo_ta
+        description: "Tipo do termo aditivo."
+      - name: vl_global_ta
+        description: "Valor global do termo aditivo."
+      - name: vl_repasse_ta
+        description: "Valor de repasse do termo aditivo."
+      - name: vl_contrapartida_ta
+        description: "Valor de contrapartida do termo aditivo."
+      - name: dt_assinatura_ta
+        description: "Data de assinatura do termo aditivo."
+      - name: dt_inicio_ta
+        description: "Data de início do termo aditivo."
+      - name: dt_fim_ta
+        description: "Data de fim do termo aditivo."
+      - name: justificativa_ta
+        description: "Justificativa do termo aditivo."
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.termo_aditivo'
+          nome_coluna: 'nr_convenio'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.termo_aditivo'
+          nome_coluna: 'vl_global_ta'
+          tipo_esperado: 'numeric'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.termo_aditivo'
+          nome_coluna: 'dt_assinatura_ta'
+          tipo_esperado: 'date'
+
+  - name: solicitacao_rendimento_aplicacao
+    description: >
+      Tabela da camada bronze contendo informações sobre solicitações de rendimento de aplicação do SICONV.
+    meta:
+      tags:
+        - bronze
+    columns:
+      - name: id_solicitacao_rend_aplicacao
+        description: "Identificador único da solicitação de rendimento."
+      - name: nr_convenio
+        description: "Número do convênio associado."
+      - name: nr_solicitacao_rend_aplicacao
+        description: "Número da solicitação de rendimento."
+      - name: status_solicitacao_rend_aplicacao
+        description: "Status da solicitação de rendimento."
+      - name: data_solicitacao_rend_aplicacao
+        description: "Data da solicitação de rendimento."
+      - name: valor_solicitacao_rend_aplicacao
+        description: "Valor solicitado de rendimento."
+      - name: valor_aprovado_solicitacao_rend_aplicacao
+        description: "Valor aprovado de rendimento."
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.solicitacao_rendimento_aplicacao'
+          nome_coluna: 'id_solicitacao_rend_aplicacao'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.solicitacao_rendimento_aplicacao'
+          nome_coluna: 'valor_solicitacao_rend_aplicacao'
+          tipo_esperado: 'numeric'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.solicitacao_rendimento_aplicacao'
+          nome_coluna: 'data_solicitacao_rend_aplicacao'
+          tipo_esperado: 'date'
+
+  - name: prorroga_oficio
+    description: >
+      Tabela da camada bronze contendo informações sobre prorrogações de ofício de convênios do SICONV.
+    meta:
+      tags:
+        - bronze
+    columns:
+      - name: nr_convenio
+        description: "Número do convênio associado."
+      - name: nr_prorroga
+        description: "Número da prorrogação."
+      - name: dt_inicio_prorroga
+        description: "Data de início da prorrogação."
+      - name: dt_fim_prorroga
+        description: "Data de fim da prorrogação."
+      - name: dias_prorroga
+        description: "Quantidade de dias de prorrogação."
+      - name: dt_assinatura_prorroga
+        description: "Data de assinatura da prorrogação."
+      - name: sit_prorroga
+        description: "Situação da prorrogação."
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.prorroga_oficio'
+          nome_coluna: 'nr_convenio'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.prorroga_oficio'
+          nome_coluna: 'dt_inicio_prorroga'
+          tipo_esperado: 'date'
+
+  - name: pagamento_tributo
+    description: >
+      Tabela da camada bronze contendo informações sobre pagamentos de tributos de convênios do SICONV.
+    meta:
+      tags:
+        - bronze
+    columns:
+      - name: nr_convenio
+        description: "Número do convênio associado."
+      - name: data_tributo
+        description: "Data do pagamento do tributo."
+      - name: vl_pag_tributos
+        description: "Valor pago de tributos."
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.pagamento_tributo'
+          nome_coluna: 'nr_convenio'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.pagamento_tributo'
+          nome_coluna: 'vl_pag_tributos'
+          tipo_esperado: 'numeric'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.pagamento_tributo'
+          nome_coluna: 'data_tributo'
+          tipo_esperado: 'date'
+
+  - name: pagamento
+    description: >
+      Tabela da camada bronze contendo informações sobre pagamentos de convênios do SICONV.
+    meta:
+      tags:
+        - bronze
+    columns:
+      - name: nr_mov_fin
+        description: "Número do movimento financeiro."
+      - name: nr_convenio
+        description: "Número do convênio associado."
+      - name: identif_fornecedor
+        description: "Identificação do fornecedor (CNPJ/CPF)."
+      - name: nome_fornecedor
+        description: "Nome do fornecedor."
+      - name: tp_mov_financeira
+        description: "Tipo do movimento financeiro."
+      - name: data_pag
+        description: "Data do pagamento."
+      - name: nr_dl
+        description: "Número do documento de liquidação."
+      - name: desc_dl
+        description: "Descrição do documento de liquidação."
+      - name: vl_pago
+        description: "Valor pago."
+      - name: id_dl
+        description: "Identificador do documento de liquidação."
+      - name: data_emissao_dl
+        description: "Data de emissão do documento de liquidação."
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.pagamento'
+          nome_coluna: 'nr_mov_fin'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.pagamento'
+          nome_coluna: 'vl_pago'
+          tipo_esperado: 'numeric'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.pagamento'
+          nome_coluna: 'data_pag'
+          tipo_esperado: 'date'
+
+  - name: licitacao
+    description: >
+      Tabela da camada bronze contendo informações sobre licitações de convênios do SICONV.
+    meta:
+      tags:
+        - bronze
+    columns:
+      - name: id_licitacao
+        description: "Identificador único da licitação."
+      - name: nr_convenio
+        description: "Número do convênio associado."
+      - name: nr_licitacao
+        description: "Número da licitação."
+      - name: modalidade_licitacao
+        description: "Modalidade da licitação."
+      - name: tp_processo_compra
+        description: "Tipo do processo de compra."
+      - name: tipo_licitacao
+        description: "Tipo da licitação."
+      - name: nr_processo_licitacao
+        description: "Número do processo de licitação."
+      - name: data_publicacao_licitacao
+        description: "Data de publicação da licitação."
+      - name: data_abertura_licitacao
+        description: "Data de abertura da licitação."
+      - name: data_encerramento_licitacao
+        description: "Data de encerramento da licitação."
+      - name: data_homologacao_licitacao
+        description: "Data de homologação da licitação."
+      - name: status_licitacao
+        description: "Status da licitação."
+      - name: situacao_aceite_processo_execu
+        description: "Situação de aceite do processo de execução."
+      - name: sistema_origem
+        description: "Sistema de origem da licitação."
+      - name: situacao_sistema
+        description: "Situação no sistema."
+      - name: valor_licitacao
+        description: "Valor da licitação."
+      - name: data_analise_aceite
+        description: "Data de análise de aceite."
+      - name: data_envio_analise
+        description: "Data de envio para análise."
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.licitacao'
+          nome_coluna: 'id_licitacao'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.licitacao'
+          nome_coluna: 'valor_licitacao'
+          tipo_esperado: 'numeric'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.licitacao'
+          nome_coluna: 'data_publicacao_licitacao'
+          tipo_esperado: 'date'
+
+  - name: ingresso_contrapartida
+    description: >
+      Tabela da camada bronze contendo informações sobre ingressos de contrapartida de convênios do SICONV.
+    meta:
+      tags:
+        - bronze
+    columns:
+      - name: nr_convenio
+        description: "Número do convênio associado."
+      - name: dt_ingresso_contrapartida
+        description: "Data de ingresso da contrapartida."
+      - name: vl_ingresso_contrapartida
+        description: "Valor de ingresso da contrapartida."
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.ingresso_contrapartida'
+          nome_coluna: 'nr_convenio'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.ingresso_contrapartida'
+          nome_coluna: 'vl_ingresso_contrapartida'
+          tipo_esperado: 'numeric'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.ingresso_contrapartida'
+          nome_coluna: 'dt_ingresso_contrapartida'
+          tipo_esperado: 'date'
+
+  - name: empenho
+    description: >
+      Tabela da camada bronze contendo informações sobre empenhos de convênios do SICONV.
+    meta:
+      tags:
+        - bronze
+    columns:
+      - name: id_empenho
+        description: "Identificador único do empenho."
+      - name: nr_convenio
+        description: "Número do convênio associado."
+      - name: nr_empenho
+        description: "Número do empenho."
+      - name: tipo_nota
+        description: "Tipo da nota de empenho."
+      - name: desc_tipo_nota
+        description: "Descrição do tipo da nota."
+      - name: data_emissao
+        description: "Data de emissão do empenho."
+      - name: cod_situacao_empenho
+        description: "Código da situação do empenho."
+      - name: desc_situacao_empenho
+        description: "Descrição da situação do empenho."
+      - name: ug_emitente
+        description: "Código da UG emitente."
+      - name: ug_responsavel
+        description: "Código da UG responsável."
+      - name: fonte_recurso
+        description: "Fonte de recurso do empenho."
+      - name: natureza_despesa
+        description: "Natureza da despesa."
+      - name: plano_interno
+        description: "Plano interno do empenho."
+      - name: ptres
+        description: "Programa de Trabalho Resumido."
+      - name: valor_empenho
+        description: "Valor do empenho."
+      - name: resultado_primario
+        description: "Resultado primário do empenho."
+      - name: observacao_empenho
+        description: "Observação do empenho."
+      - name: descricao_emenda_siafi
+        description: "Descrição da emenda SIAFI."
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.empenho'
+          nome_coluna: 'id_empenho'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.empenho'
+          nome_coluna: 'valor_empenho'
+          tipo_esperado: 'numeric'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.empenho'
+          nome_coluna: 'data_emissao'
+          tipo_esperado: 'date'
+
+  - name: historico_situacao
+    description: >
+      Tabela da camada bronze contendo o histórico de situações de convênios do SICONV.
+    meta:
+      tags:
+        - bronze
+    columns:
+      - name: id_proposta
+        description: "Identificador da proposta."
+      - name: nr_convenio
+        description: "Número do convênio associado."
+      - name: dia_historico_sit
+        description: "Data do histórico de situação."
+      - name: historico_sit
+        description: "Descrição do histórico de situação."
+      - name: dias_historico_sit
+        description: "Quantidade de dias no histórico."
+      - name: cod_historico_sit
+        description: "Código do histórico de situação."
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.historico_situacao'
+          nome_coluna: 'nr_convenio'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.historico_situacao'
+          nome_coluna: 'dia_historico_sit'
+          tipo_esperado: 'date'
+
+  - name: cronograma_desembolso
+    description: >
+      Tabela da camada bronze contendo informações sobre cronogramas de desembolso de convênios do SICONV.
+    meta:
+      tags:
+        - bronze
+    columns:
+      - name: id_proposta
+        description: "Identificador da proposta."
+      - name: nr_convenio
+        description: "Número do convênio associado."
+      - name: nr_parcela_crono_desembolso
+        description: "Número da parcela do cronograma de desembolso."
+      - name: mes_crono_desembolso
+        description: "Mês do cronograma de desembolso."
+      - name: ano_crono_desembolso
+        description: "Ano do cronograma de desembolso."
+      - name: tipo_resp_crono_desembolso
+        description: "Tipo de responsável pelo cronograma de desembolso."
+      - name: valor_parcela_crono_desembolso
+        description: "Valor da parcela do cronograma de desembolso."
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.cronograma_desembolso'
+          nome_coluna: 'nr_convenio'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.cronograma_desembolso'
+          nome_coluna: 'valor_parcela_crono_desembolso'
+          tipo_esperado: 'numeric'
+
+  - name: meta_crono_fisico
+    description: >
+      Tabela da camada bronze contendo informações sobre metas do cronograma físico de convênios do SICONV.
+    meta:
+      tags:
+        - bronze
+    columns:
+      - name: id_meta
+        description: "Identificador único da meta."
+      - name: id_proposta
+        description: "Identificador da proposta."
+      - name: nr_convenio
+        description: "Número do convênio associado."
+      - name: cod_programa
+        description: "Código do programa."
+      - name: nome_programa
+        description: "Nome do programa."
+      - name: nr_meta
+        description: "Número da meta."
+      - name: tipo_meta
+        description: "Tipo da meta."
+      - name: desc_meta
+        description: "Descrição da meta."
+      - name: data_inicio_meta
+        description: "Data de início da meta."
+      - name: data_fim_meta
+        description: "Data de fim da meta."
+      - name: uf_meta
+        description: "UF da meta."
+      - name: municipio_meta
+        description: "Município da meta."
+      - name: endereco_meta
+        description: "Endereço da meta."
+      - name: cep_meta
+        description: "CEP da meta."
+      - name: qtd_meta
+        description: "Quantidade da meta."
+      - name: und_fornecimento_meta
+        description: "Unidade de fornecimento da meta."
+      - name: vl_meta
+        description: "Valor da meta."
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.meta_crono_fisico'
+          nome_coluna: 'id_meta'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.meta_crono_fisico'
+          nome_coluna: 'vl_meta'
+          tipo_esperado: 'numeric'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.meta_crono_fisico'
+          nome_coluna: 'data_inicio_meta'
+          tipo_esperado: 'date'

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/solicitacao_alteracao.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/solicitacao_alteracao.sql
@@ -1,0 +1,20 @@
+{{ config(materialized="table") }}
+
+with
+    solicitacao_alteracao_raw as (
+        select
+            nullif(id_solicitacao, '')::integer as id_solicitacao,
+            nullif(nr_convenio, '')::integer as nr_convenio,
+            nr_solicitacao::text as nr_solicitacao,
+            situacao_solicitacao::text as situacao_solicitacao,
+            objeto_solicitacao::text as objeto_solicitacao,
+            case
+                when nullif(data_solicitacao, '') is null then null
+                when data_solicitacao ~ '^\d{2}/\d{2}/\d{4}$' then to_date(data_solicitacao, 'DD/MM/YYYY')
+                else to_date(data_solicitacao, 'YYYY-MM-DD')
+            end as data_solicitacao
+        from {{ source("siconv", "solicitacao_alteracao") }}
+    )
+
+select *
+from solicitacao_alteracao_raw

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/solicitacao_rendimento_aplicacao.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/solicitacao_rendimento_aplicacao.sql
@@ -1,0 +1,21 @@
+{{ config(materialized="table") }}
+
+with
+    solicitacao_rendimento_aplicacao_raw as (
+        select
+            nullif(id_solicitacao_rend_aplicacao, '')::integer as id_solicitacao_rend_aplicacao,
+            nullif(nr_convenio, '')::integer as nr_convenio,
+            nr_solicitacao_rend_aplicacao::text as nr_solicitacao_rend_aplicacao,
+            status_solicitacao_rend_aplicacao::text as status_solicitacao_rend_aplicacao,
+            case
+                when nullif(data_solicitacao_rend_aplicacao, '') is null then null
+                when data_solicitacao_rend_aplicacao ~ '^\d{2}/\d{2}/\d{4}$' then to_date(data_solicitacao_rend_aplicacao, 'DD/MM/YYYY')
+                else to_date(data_solicitacao_rend_aplicacao, 'YYYY-MM-DD')
+            end as data_solicitacao_rend_aplicacao,
+            replace(nullif(valor_solicitacao_rend_aplicacao, ''), ',', '.')::numeric(15, 2) as valor_solicitacao_rend_aplicacao,
+            replace(nullif(valor_aprovado_solicitacao_rend_aplicacao, ''), ',', '.')::numeric(15, 2) as valor_aprovado_solicitacao_rend_aplicacao
+        from {{ source("siconv", "solicitacao_rendimento_aplicacao") }}
+    )
+
+select *
+from solicitacao_rendimento_aplicacao_raw

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/termo_aditivo.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/bronze/termo_aditivo.sql
@@ -1,0 +1,21 @@
+{{ config(materialized="table") }}
+
+with
+    termo_aditivo_raw as (
+        select
+            nullif(nr_convenio, '')::integer as nr_convenio,
+            nullif(id_solicitacao, '')::integer as id_solicitacao,
+            numero_ta::text as numero_ta,
+            tipo_ta::text as tipo_ta,
+            replace(nullif(vl_global_ta, ''), ',', '.')::numeric(15, 2) as vl_global_ta,
+            replace(nullif(vl_repasse_ta, ''), ',', '.')::numeric(15, 2) as vl_repasse_ta,
+            replace(nullif(vl_contrapartida_ta, ''), ',', '.')::numeric(15, 2) as vl_contrapartida_ta,
+            to_date(nullif(dt_assinatura_ta, ''), 'DD/MM/YYYY') as dt_assinatura_ta,
+            to_date(nullif(dt_inicio_ta, ''), 'DD/MM/YYYY') as dt_inicio_ta,
+            to_date(nullif(dt_fim_ta, ''), 'DD/MM/YYYY') as dt_fim_ta,
+            justificativa_ta::text as justificativa_ta
+        from {{ source("siconv", "termo_aditivo") }}
+    )
+
+select *
+from termo_aditivo_raw

--- a/airflow_lappis/dags/dbt/mir/models/sources.yml
+++ b/airflow_lappis/dags/dbt/mir/models/sources.yml
@@ -44,3 +44,23 @@ sources:
         - name: nc_tesouro_pre_2026
         - name: pf_tesouro
         - name: programacao_acao_ptres
+
+  - name: siconv
+    schema: siconv
+    tables:
+      - name: proposta
+      - name: convenio
+      - name: desembolso
+      - name: desbloqueio
+      - name: solicitacao_alteracao
+      - name: termo_aditivo
+      - name: solicitacao_rendimento_aplicacao
+      - name: prorroga_oficio
+      - name: pagamento_tributo
+      - name: pagamento
+      - name: licitacao
+      - name: ingresso_contrapartida
+      - name: empenho
+      - name: historico_situacao
+      - name: cronograma_desembolso
+      - name: meta_crono_fisico


### PR DESCRIPTION
## Camada Bronze SICONV

Implementa a camada bronze do SICONV no dbt.

## O que foi feito

Criação de 16 models SQL na camada bronze (`models/siconv_dbt/bronze/`), um para cada tabela ingerida do SICONV. Cada model segue o padrão já estabelecido no projeto e realiza as seguintes transformações:

- **Conversão de tipos** — todas as colunas são explicitamente tipadas. Colunas de texto que representam inteiros são convertidas com `nullif(coluna, '')::integer` para tratar campos vazios sem erro. Valores numéricos financeiros são convertidos com `replace(nullif(coluna, ''), ',', '.')::numeric(15, 2)` para tratar o separador decimal em vírgula usado pelo SICONV.

- **Padronização de datas** — as datas do SICONV vêm majoritariamente no formato `DD/MM/YYYY`, convertidas com `to_date(nullif(coluna, ''), 'DD/MM/YYYY')`. Algumas tabelas apresentaram datas no formato `YYYY-MM-DD`, tratadas com um `CASE WHEN` que detecta o formato via regex antes de converter.

- **Tratamento de nulos** — campos vazios `''` são convertidos para `NULL` com `nullif` antes de qualquer cast, evitando erros de conversão.

## Problemas encontrados e soluções

**Campos inteiros com valores textuais** — alguns campos como `cod_situacao_empenho`, `ptres` e `resultado_primario` na tabela `empenho` continham valores como `"ENVIADO"` e `"@"`, impossibilitando o cast para integer. Esses campos foram mantidos como `text`.

**Overflow numérico** — a tabela `licitacao` continha valores maiores que `numeric(15, 2)` suporta. A precisão foi aumentada para `numeric(20, 2)`.

**Formatos de data mistos** — algumas tabelas como `pagamento`, `solicitacao_alteracao` e `solicitacao_rendimento_aplicacao` continham datas em dois formatos diferentes (`DD/MM/YYYY` e `YYYY-MM-DD`) na mesma coluna. Resolvido com `CASE WHEN coluna ~ '^\d{2}/\d{2}/\d{4}$'` para detectar o formato antes de converter.

## Documentação e testes

Criação do `schema.yml` com descrições de todas as 16 tabelas e suas colunas, seguindo o padrão do projeto. Adicionados 44 testes de tipagem (`verificacao_tipagem`) cobrindo as colunas mais críticas de cada tabela — inteiros, numéricos e datas — todos passando com `PASS=44 WARN=0 ERROR=0`.

## Tabelas da camada bronze

`proposta`, `convenio`, `desembolso`, `desbloqueio`, `solicitacao_alteracao`, `termo_aditivo`, `solicitacao_rendimento_aplicacao`, `prorroga_oficio`, `pagamento_tributo`, `pagamento`, `licitacao`, `ingresso_contrapartida`, `empenho`, `historico_situacao`, `cronograma_desembolso`, `meta_crono_fisico`