### PR TITLE
feat: camada bronze data legislaturas e documentação

### DIFF
--- a/airflow_lappis/dags/dbt/mir/models/dados_abertos_dbt/bronze/legislaturas.sql
+++ b/airflow_lappis/dags/dbt/mir/models/dados_abertos_dbt/bronze/legislaturas.sql
@@ -1,0 +1,15 @@
+{{ config(materialized="table") }}
+
+with
+    legislaturas_raw as (
+        select
+            id::integer as id,
+            data_inicio::date as data_inicio,
+            data_fim::date as data_fim,
+            data_eleicao::date as data_eleicao,
+            (dt_ingest || '-03:00')::timestamptz as dt_ingest
+        from {{ source("senado_federal", "legislaturas") }}
+    )
+
+select *
+from legislaturas_raw

--- a/airflow_lappis/dags/dbt/mir/models/dados_abertos_dbt/bronze/schema.yml
+++ b/airflow_lappis/dags/dbt/mir/models/dados_abertos_dbt/bronze/schema.yml
@@ -194,3 +194,61 @@ models:
         nome_tabela: 'senadores.senadores'
         nome_coluna: 'dt_ingest'
         tipo_esperado: 'timestamp with time zone'
+
+  - name: legislaturas
+    description: >
+      Tabela com informações de legislaturas da Câmara dos Deputados, incluindo
+      identificador, período de vigência e data de eleição.
+      Esta tabela representa a camada bronze do pipeline, com padronização de tipos
+      e ajuste de fuso horário na data de ingestão.
+      Os dados são provenientes da fonte camara_deputados.legislaturas (camada raw) e
+      passam por conversão explícita de tipos para garantir consistência e rastreabilidade.
+    meta:
+      tags:
+        - bronze
+    columns:
+      - name: id
+        description: >
+          Identificador único da legislatura na API da Câmara dos Deputados.
+
+      - name: data_inicio
+        description: >
+          Data de início da legislatura.
+
+      - name: data_fim
+        description: >
+          Data de término da legislatura.
+
+      - name: data_eleicao
+        description: >
+          Data da eleição associada à legislatura.
+
+      - name: dt_ingest
+        description: >
+          Data e hora (UTC-3 Brasília) em que os dados foram ingeridos da fonte original para a camada raw.
+
+    tests:
+    - verificacao_tipagem:
+        nome_tabela: 'legislaturas.legislaturas'
+        nome_coluna: 'id'
+        tipo_esperado: 'integer'
+
+    - verificacao_tipagem:
+        nome_tabela: 'legislaturas.legislaturas'
+        nome_coluna: 'data_inicio'
+        tipo_esperado: 'date'
+
+    - verificacao_tipagem:
+        nome_tabela: 'legislaturas.legislaturas'
+        nome_coluna: 'data_fim'
+        tipo_esperado: 'date'
+
+    - verificacao_tipagem:
+        nome_tabela: 'legislaturas.legislaturas'
+        nome_coluna: 'data_eleicao'
+        tipo_esperado: 'date'
+
+    - verificacao_tipagem:
+        nome_tabela: 'legislaturas.legislaturas'
+        nome_coluna: 'dt_ingest'
+        tipo_esperado: 'timestamp with time zone'

--- a/airflow_lappis/dags/dbt/mir/models/sources.yml
+++ b/airflow_lappis/dags/dbt/mir/models/sources.yml
@@ -26,6 +26,7 @@ sources:
     schema: senado_federal
     tables:
       - name: senadores
+      - name: legislaturas
 
   - name: transfere_gov
     schema: transfere_gov


### PR DESCRIPTION
## O que foi feito:

Este PR introduz a tabela de legislaturas na camada bronze do pipeline de dados abertos e remove uma DAG vazia que não estava sendo utilizada.

## Alterações

* Cria modelo `legislaturas` (camada bronze)
* Padroniza tipos (`id`, datas, `dt_ingest` com UTC-3)
* Adiciona documentação + testes no `schema.yml`
* Inclui source `legislaturas`

## Correção:
* Remove DAG vazia de mandatos

##### ISSUE #144 