### PR TITLE
feat: camada silver e view para TEDs — empenhos, NCs e Planos de Ação

### DIFF
--- a/airflow_lappis/dags/dbt/mir/macros/udfs/f_format_nc.sql
+++ b/airflow_lappis/dags/dbt/mir/macros/udfs/f_format_nc.sql
@@ -6,12 +6,27 @@
     with 
 
     pre_process as (
-        select left(in_text, 7) as prefix,
-            right(in_text, 4)::numeric as posfix
+        select
+            left(in_text, 7) as prefix,
+            right(in_text, 4) as posfix_text
+    ),
+
+    normalized as (
+        select
+            prefix,
+            case
+                when posfix_text ~ '^[0-9]{1,4}$' then posfix_text::numeric
+                else null
+            end as posfix
+        from pre_process
     )
     
-    select concat(prefix, to_char(posfix, 'FM00000')) as result
-    from pre_process 
+    select
+        case
+            when posfix is null then null
+            else concat(prefix, to_char(posfix, 'FM00000'))
+        end as result
+    from normalized
     
     $$
     language sql

--- a/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/silver/empenhos_por_plano_acao.sql
+++ b/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/silver/empenhos_por_plano_acao.sql
@@ -1,0 +1,562 @@
+with
+empenhos_sem_vinculo_ted as(
+  select
+    *,
+    right(ne_ccor, 12) as ne,
+    left(ne_ccor,6) as orgao_id,
+    null as nc,
+    null as num_transf,
+    'sem vinculo' as metodo
+  from {{ ref("empenhos_tesouro_ted") }}
+  where
+    ne_ccor_descricao ~* '\bTED[[:space:]:/().-]*(S/?[VN]|S/?VINCULO)'
+    or ne_ccor_descricao ~* 'SEM[[:space:]]+VINC[[:space:]]*(ULO|/TED)'
+),
+empenhos_filtrados as(
+  select
+    *
+  from {{ ref("empenhos_tesouro_ted") }}
+  where 
+    ne_ccor_descricao !~* '\bTED[[:space:]:/().-]*(S/?[VN]|S/?VINCULO)'
+    and ne_ccor_descricao !~* 'SEM[[:space:]]+VINC[[:space:]]*(ULO|/TED)'
+
+),
+empenhos_orgaos_metodo_1 as (
+  select
+      *,
+      -- Uma série de extrações que servirão de identificadores 
+      right(ne_ccor, 12) as ne,
+      left(ne_ccor,6) as orgao_id,
+      {{ target.schema }}.format_nc(
+            regexp_substr(ne_ccor_descricao, '([0-9]{4}NC[0-9]+)')
+      ) as nc,
+      replace(
+        (regexp_match(
+          ne_ccor_descricao,
+          '(FERENCIA|TED|CRICAO|TRANSF.|TRANF.|TRANF. |TRANSFERENCIA |TRANSFERENCIA:)(\s|^|-|)([0-9]{6}|1\w{5}|[0-9]{3}\.[0-9]{3})(\s|$|\.|,|-|\/)',
+          'i'
+        ))[3],
+          '.',
+          ''
+      ) as num_transf,
+      'metodo 1' as metodo
+  from empenhos_filtrados
+),
+
+empenhos_restantes_metodo_1 as(
+select * from empenhos_orgaos_metodo_1 where num_transf is null AND nc is null
+),
+
+empenhos_orgaos_metodo_2 as (
+  select
+      programa_governo,
+      programa_governo_descricao,
+      acao_governo,
+      acao_governo_descricao,
+      emissao_mes,
+      emissao_dia,
+      ne_ccor,
+      ne_num_processo,
+      ne_info_complementar,
+      ne_ccor_descricao,
+      doc_observacao,
+      natureza_despesa,
+      natureza_despesa_descricao,
+      ne_ccor_favorecido,
+      ne_ccor_favorecido_descricao,
+      ne_ccor_ano_emissao,
+      ptres,
+      fonte_recursos_detalhada,
+      fonte_recursos_detalhada_descricao,
+      despesas_empenhadas,
+      despesas_liquidadas,
+      despesas_pagas,
+      restos_a_pagar_inscritos,
+      restos_a_pagar_pagos,
+      dt_ingest,
+      ne,
+      orgao_id,
+      nc,
+      replace(
+          (regexp_match(
+            ne_ccor_descricao,
+            '.*(?:NOTA DE (TRANSFERENCIA|TRANFERENCIA|CREDITO))[:.[:space:]-]*((?=[A-Za-z0-9]*[0-9])[A-Za-z0-9]{6,})',
+            'i'
+          ))[2],
+          '.',
+          ''
+      ) as num_transf,
+      'metodo 2' as metodo
+  from empenhos_restantes_metodo_1 p
+),
+
+empenhos_restantes_metodo_2 as(
+select * from empenhos_orgaos_metodo_2 where num_transf is null AND nc is null
+),
+
+empenhos_orgaos_metodo_3 as (
+  select
+      programa_governo,
+      programa_governo_descricao,
+      acao_governo,
+      acao_governo_descricao,
+      emissao_mes,
+      emissao_dia,
+      ne_ccor,
+      ne_num_processo,
+      ne_info_complementar,
+      ne_ccor_descricao,
+      doc_observacao,
+      natureza_despesa,
+      natureza_despesa_descricao,
+      ne_ccor_favorecido,
+      ne_ccor_favorecido_descricao,
+      ne_ccor_ano_emissao,
+      ptres,
+      fonte_recursos_detalhada,
+      fonte_recursos_detalhada_descricao,
+      despesas_empenhadas,
+      despesas_liquidadas,
+      despesas_pagas,
+      restos_a_pagar_inscritos,
+      restos_a_pagar_pagos,
+      dt_ingest,
+      ne,
+      orgao_id,
+      nc,
+      replace(
+          (regexp_match(
+            ne_ccor_descricao,
+            '.*(?:(?:TED(?:[[:space:]]*[-.N∞øº°∅()]*))[[:space:]]*|(?:SIAFI[[:space:]]+N∫))[[:space:].-]*(?<![0-9])(([0-9]{6})|(1[A-Za-z0-9]{5}))(?![0-9])',
+            'i'
+          ))[1],
+          '.',
+          ''
+      ) as num_transf,
+      'metodo 3' as metodo
+  from empenhos_restantes_metodo_2 p
+),
+
+empenhos_restantes_metodo_3 as(
+select * from empenhos_orgaos_metodo_3 where num_transf is null AND nc is null
+),
+
+empenhos_orgaos_metodo_4 as (
+  select
+      programa_governo,
+      programa_governo_descricao,
+      acao_governo,
+      acao_governo_descricao,
+      emissao_mes,
+      emissao_dia,
+      ne_ccor,
+      ne_num_processo,
+      ne_info_complementar,
+      ne_ccor_descricao,
+      doc_observacao,
+      natureza_despesa,
+      natureza_despesa_descricao,
+      ne_ccor_favorecido,
+      ne_ccor_favorecido_descricao,
+      ne_ccor_ano_emissao,
+      ptres,
+      fonte_recursos_detalhada,
+      fonte_recursos_detalhada_descricao,
+      despesas_empenhadas,
+      despesas_liquidadas,
+      despesas_pagas,
+      restos_a_pagar_inscritos,
+      restos_a_pagar_pagos,
+      dt_ingest,
+      ne,
+      orgao_id,
+      nc,
+      replace(
+          (regexp_match(
+            fonte_recursos_detalhada_descricao,
+            'TED(?::)?(?:[[:space:]]+[A-Z/]+)?[[:space:]:-]*N?[∞∫ºo]?[[:space:]]*[0-9/]*[[:space:]:;,-]*[ø-]?[[:space:]]*([0-9]{6}|1[A-Z0-9]{5})',
+            'i'
+          ))[1],
+          '.',
+          ''
+      ) as num_transf,
+      'metodo 4' as metodo
+  from empenhos_restantes_metodo_3 p
+),
+
+empenhos_restantes_metodo_4 as(
+select * from empenhos_orgaos_metodo_4 where num_transf is null AND nc is null
+),
+
+empenhos_orgaos_metodo_5 as (
+select 
+      programa_governo,
+      programa_governo_descricao,
+      acao_governo,
+      acao_governo_descricao,
+      emissao_mes,
+      emissao_dia,
+      ne_ccor,
+      ne_num_processo,
+      ne_info_complementar,
+      ne_ccor_descricao,
+      doc_observacao,
+      natureza_despesa,
+      natureza_despesa_descricao,
+      ne_ccor_favorecido,
+      ne_ccor_favorecido_descricao,
+      ne_ccor_ano_emissao,
+      ptres,
+      fonte_recursos_detalhada,
+      fonte_recursos_detalhada_descricao,
+      despesas_empenhadas,
+      despesas_liquidadas,
+      despesas_pagas,
+      restos_a_pagar_inscritos,
+      restos_a_pagar_pagos,
+      dt_ingest,
+      ne,
+      orgao_id,
+      nc,
+      replace(
+          (regexp_match(
+            ne_info_complementar,
+            '^([0-9]{6}|1[A-Z0-9]{5})$',
+            'i'
+          ))[1],
+          '.',
+          ''
+      ) as num_transf,
+      'metodo 5' as metodo
+from empenhos_restantes_metodo_4),
+
+empenhos_restantes_metodo_5 as(
+select * from empenhos_orgaos_metodo_5 where num_transf is null AND nc is null
+),
+
+empenhos_teds_invalidos as(
+select
+      programa_governo,
+      programa_governo_descricao,
+      acao_governo,
+      acao_governo_descricao,
+      emissao_mes,
+      emissao_dia,
+      ne_ccor,
+      ne_num_processo,
+      ne_info_complementar,
+      ne_ccor_descricao,
+      doc_observacao,
+      natureza_despesa,
+      natureza_despesa_descricao,
+      ne_ccor_favorecido,
+      ne_ccor_favorecido_descricao,
+      ne_ccor_ano_emissao,
+      ptres,
+      fonte_recursos_detalhada,
+      fonte_recursos_detalhada_descricao,
+      despesas_empenhadas,
+      despesas_liquidadas,
+      despesas_pagas,
+      restos_a_pagar_inscritos,
+      restos_a_pagar_pagos,
+      dt_ingest,
+      ne,
+      orgao_id,
+      regexp_substr(ne_ccor_descricao, '((?<![0-9])[0-9]{0,3}NC[0-9]+|[0-9]{5,}NC[0-9]+|[0-9]{4}NC(?![0-9]))') as nc,
+      null as num_transf,
+      'ted ou nc invalido' as metodo
+      from empenhos_restantes_metodo_5
+),
+
+empenhos_restantes_teds_invalidos as(
+select
+programa_governo,
+programa_governo_descricao,
+acao_governo,
+acao_governo_descricao,
+emissao_mes,
+emissao_dia,
+ne_ccor,
+ne_num_processo,
+ne_info_complementar,
+ne_ccor_descricao,
+doc_observacao,
+natureza_despesa,
+natureza_despesa_descricao,
+ne_ccor_favorecido,
+ne_ccor_favorecido_descricao,
+ne_ccor_ano_emissao,
+ptres,
+fonte_recursos_detalhada,
+fonte_recursos_detalhada_descricao,
+despesas_empenhadas,
+despesas_liquidadas,
+despesas_pagas,
+restos_a_pagar_inscritos,
+restos_a_pagar_pagos,
+dt_ingest,
+ne,
+orgao_id,
+nc,
+num_transf,
+'vinculo nao encontrado' as metodo
+from empenhos_teds_invalidos where num_transf is null AND nc is null
+),
+
+raw_union AS (
+  select * from empenhos_sem_vinculo_ted
+  UNION ALL
+  select * from empenhos_orgaos_metodo_1 where num_transf is not null OR nc is not null
+  UNION ALL
+  select * from empenhos_orgaos_metodo_2 where num_transf is not null OR nc is not null
+  UNION ALL
+  select * from empenhos_orgaos_metodo_3 where num_transf is not null OR nc is not null
+  UNION ALL
+  select * from empenhos_orgaos_metodo_4 where num_transf is not null OR nc is not null
+  UNION ALL
+  select * from empenhos_orgaos_metodo_5 where num_transf is not null OR nc is not null
+  UNION ALL
+  select * from empenhos_teds_invalidos where num_transf is not null OR nc is not null
+  UNION ALL
+  select * from empenhos_restantes_teds_invalidos
+),
+
+ids_agregados_nc_ccor AS (
+    SELECT
+        ne_ccor,
+        MAX(nc) AS nc,
+        MAX(num_transf) AS num_transf
+    FROM raw_union
+    GROUP BY ne_ccor
+),
+
+empenhos_orgaos_metodo_6 AS (
+SELECT
+    ert.emissao_mes,ert.emissao_dia,ert.ne_ccor,ert.ne_num_processo,ert.ne_info_complementar,ert.ne_ccor_descricao,ert.doc_observacao,ert.natureza_despesa,ert.natureza_despesa_descricao,ert.ne_ccor_favorecido,ert.ne_ccor_favorecido_descricao,ert.ne_ccor_ano_emissao,ert.ptres,ert.fonte_recursos_detalhada,ert.fonte_recursos_detalhada_descricao,ert.despesas_empenhadas,ert.despesas_liquidadas,ert.despesas_pagas,ert.restos_a_pagar_inscritos,ert.restos_a_pagar_pagos,ert.dt_ingest, ert.ne,ert.orgao_id,
+    COALESCE(ert.nc, r.nc) AS nc,
+    COALESCE(ert.num_transf, r.num_transf) AS num_transf,
+    -- método calculado dinamicamente
+    CASE
+        WHEN (ert.nc IS NULL AND r.nc IS NOT NULL)
+          OR (ert.num_transf IS NULL AND r.num_transf IS NOT NULL)
+        THEN 'metodo 6'
+        ELSE ert.metodo
+    END AS metodo
+    FROM raw_union ert
+    LEFT JOIN ids_agregados_nc_ccor r USING (ne_ccor)
+),
+
+base_empenhos_orgaos_metodo_7 as (
+select 
+  -- seleciona todas as colunas do órgãos 1, exceto nc e num_transf
+      *,
+      trim(both ' -' from regexp_replace((regexp_match(
+          ne_ccor_descricao,
+          'TED [[:space:].:NR∫º°-]*(?:([A-Za-zÀ-ÿ/][A-Za-zÀ-ÿ0-9/ \\-]*)[[:space:]\\-]+)?([0-9]{1,5}(?:[./ \\-][0-9]{2,4})?)',
+          'i'
+      ))[1], '\s+', ' ', 'g')) AS complemento_ted,
+      replace((regexp_match(
+          ne_ccor_descricao,
+          'TED [[:space:].:NR∫º°-]*(?:([A-Za-zÀ-ÿ/][A-Za-zÀ-ÿ0-9/ \\-]*)[[:space:]\\-]+)?([0-9]{1,5}(?:[./ \\-][0-9]{2,4})?)',
+          'i'
+      ))[2], '.', '') AS num_ted,
+      'metodo 1' as metodo_ted
+from empenhos_orgaos_metodo_6),
+
+base_metodo_7 AS (
+    SELECT
+        *,
+        (regexp_match(num_ted, '^([0-9]{1,5})(?:[/.\- ]([0-9]{2,4}))?$'))[1] AS numero_base,
+        (regexp_match(num_ted, '^([0-9]{1,5})(?:[/.\- ]([0-9]{2,4}))?$'))[2] AS ano_raw
+    FROM base_empenhos_orgaos_metodo_7
+),
+norm_metodo_7 AS (
+    SELECT
+        *,
+        CASE
+            WHEN ano_raw IS NULL THEN NULL
+            WHEN length(ano_raw) = 2 THEN
+                CASE WHEN ano_raw::int <= 30
+                    THEN '20' || ano_raw       -- 24 → 2024
+                    ELSE '19' || ano_raw       -- 95 → 1995
+                END
+            ELSE ano_raw
+        END AS ano_normalizado
+    FROM base_metodo_7
+),
+agrupado_metodo_7 AS (
+  -- calculamos o ano oficial APENAS para numero_base "longos"
+  SELECT
+    orgao_id,
+    numero_base,
+    MAX(ano_normalizado) AS ano_oficial
+  FROM norm_metodo_7
+  WHERE length(numero_base) >= 3
+    AND ano_normalizado IS NOT NULL
+  GROUP BY orgao_id, numero_base
+),
+
+empenhos_orgaos_metodo_7 as (
+SELECT
+    a.*,
+    g.ano_oficial,
+    CASE
+      WHEN length(a.numero_base) <= 2
+            AND a.ano_normalizado is null
+      THEN NULL
+
+      -- se o registro não tem ano, e o numero_base é "longo", e há um ano oficial no grupo -> preencher
+      WHEN a.ano_normalizado IS NULL
+           AND length(a.numero_base) >= 3
+           AND g.ano_oficial IS NOT NULL
+      THEN a.numero_base || '/' || g.ano_oficial
+
+      -- se o registro já tem ano_normalizado -> manter esse ano (normalizado)
+      WHEN a.ano_normalizado IS NOT NULL
+      THEN a.numero_base || '/' || a.ano_normalizado
+
+      -- caso contrário (nenhum ano encontrado) -> deixar só o numero_base
+      ELSE a.numero_base
+    END AS numero_ted_normalizado
+FROM norm_metodo_7 a
+LEFT JOIN agrupado_metodo_7 g
+  ON a.orgao_id = g.orgao_id
+AND a.numero_base = g.numero_base
+),
+
+empenhos_restantes_metodo_7 as(
+  select * from empenhos_orgaos_metodo_7
+  WHERE numero_ted_normalizado is null
+),
+
+base_empenhos_orgaos_metodo_8 as (
+select 
+  -- seleciona todas as colunas do órgãos 1, exceto nc e num_transf
+      emissao_mes,emissao_dia,ne_ccor,ne_num_processo,ne_info_complementar,ne_ccor_descricao,doc_observacao,natureza_despesa,natureza_despesa_descricao,ne_ccor_favorecido,ne_ccor_favorecido_descricao,ne_ccor_ano_emissao,ptres,fonte_recursos_detalhada,fonte_recursos_detalhada_descricao,despesas_empenhadas,despesas_liquidadas,despesas_pagas,restos_a_pagar_inscritos,restos_a_pagar_pagos,dt_ingest, ne,orgao_id,nc,num_transf,metodo,
+      trim(both ' -' from regexp_replace((regexp_match(
+          doc_observacao,
+          'TED [[:space:].:NR∫º°-]*(?:([A-Za-zÀ-ÿ/][A-Za-zÀ-ÿ0-9/ \\-]*)[[:space:]\\-]+)?([0-9]{1,5}(?:[./ \\-][0-9]{2,4})?)',
+          'i'
+      ))[1], '\s+', ' ', 'g')) AS complemento_ted,
+      replace((regexp_match(
+          doc_observacao,
+          'TED [[:space:].:NR∫º°-]*(?:([A-Za-zÀ-ÿ/][A-Za-zÀ-ÿ0-9/ \\-]*)[[:space:]\\-]+)?([0-9]{1,5}(?:[./ \\-][0-9]{2,4})?)',
+          'i'
+      ))[2], '.', '') AS num_ted,
+      'metodo 2' as metodo_ted
+from empenhos_restantes_metodo_7),
+
+base_metodo_8 AS (
+    SELECT
+        *,
+        (regexp_match(num_ted, '^([0-9]{1,5})(?:[/.\- ]([0-9]{2,4}))?$'))[1] AS numero_base,
+        (regexp_match(num_ted, '^([0-9]{1,5})(?:[/.\- ]([0-9]{2,4}))?$'))[2] AS ano_raw
+    FROM base_empenhos_orgaos_metodo_8
+),
+norm_metodo_8 AS (
+    SELECT
+        *,
+        CASE
+            WHEN ano_raw IS NULL THEN NULL
+            WHEN length(ano_raw) = 2 THEN
+                CASE WHEN ano_raw::int <= 30
+                    THEN '20' || ano_raw       -- 24 → 2024
+                    ELSE '19' || ano_raw       -- 95 → 1995
+                END
+            ELSE ano_raw
+        END AS ano_normalizado
+    FROM base_metodo_8
+),
+agrupado_metodo_8 AS (
+  -- calculamos o ano oficial APENAS para numero_base "longos"
+  SELECT
+    orgao_id,
+    numero_base,
+    MAX(ano_normalizado) AS ano_oficial
+  FROM norm_metodo_7
+  WHERE length(numero_base) >= 3
+    AND ano_normalizado IS NOT NULL
+  GROUP BY orgao_id, numero_base
+),
+empenhos_orgaos_metodo_8 as(
+  SELECT
+      a.*,
+      g.ano_oficial,
+      CASE
+      WHEN length(a.numero_base) <= 2
+            AND a.ano_normalizado is null
+      THEN NULL
+
+      -- se o registro não tem ano, e o numero_base é "longo", e há um ano oficial no grupo -> preencher
+      WHEN a.ano_normalizado IS NULL
+           AND length(a.numero_base) >= 3
+           AND g.ano_oficial IS NOT NULL
+      THEN a.numero_base || '/' || g.ano_oficial
+
+      -- se o registro já tem ano_normalizado -> manter esse ano (normalizado)
+      WHEN a.ano_normalizado IS NOT NULL
+      THEN a.numero_base || '/' || a.ano_normalizado
+
+      -- caso contrário (nenhum ano encontrado) -> deixar só o numero_base
+      ELSE a.numero_base
+    END AS numero_ted_normalizado
+  FROM norm_metodo_8 a
+  LEFT JOIN agrupado_metodo_8 g
+    ON a.orgao_id = g.orgao_id
+  AND a.numero_base = g.numero_base
+  ),
+empenhos_restantes_metodo_8 as(
+  select * from empenhos_orgaos_metodo_8
+  WHERE numero_ted_normalizado is null
+),
+
+union_metodo_7_8 as(
+select * from empenhos_orgaos_metodo_7 WHERE numero_ted_normalizado is not null
+UNION ALL
+select * from empenhos_orgaos_metodo_8 WHERE numero_ted_normalizado is not null
+UNION ALL
+select * from empenhos_restantes_metodo_8),
+
+ids_agregados_num_ted_normalizado as(
+select 
+  orgao_id,
+  numero_ted_normalizado,
+  MAX(nc) AS nc,
+  MAX(num_transf) AS num_transf
+from union_metodo_7_8
+GROUP BY orgao_id,numero_ted_normalizado
+),
+
+empenhos_orgaos_metodo_9 AS (
+SELECT
+    ert.emissao_mes,ert.emissao_dia,ert.ne_ccor,ert.ne_num_processo,ert.ne_info_complementar,ert.ne_ccor_descricao,ert.doc_observacao,ert.natureza_despesa,ert.natureza_despesa_descricao,ert.ne_ccor_favorecido,ert.ne_ccor_favorecido_descricao,ert.ne_ccor_ano_emissao,ert.ptres,ert.fonte_recursos_detalhada,ert.fonte_recursos_detalhada_descricao,ert.despesas_empenhadas,ert.despesas_liquidadas,ert.despesas_pagas,ert.restos_a_pagar_inscritos,ert.restos_a_pagar_pagos,ert.dt_ingest, ert.ne,ert.orgao_id,
+    COALESCE(ert.nc, r.nc) AS nc,
+    COALESCE(ert.num_transf, r.num_transf) AS num_transf,
+    -- método calculado dinamicamente
+    CASE
+        WHEN (ert.nc IS NULL AND r.nc IS NOT NULL)
+          OR (ert.num_transf IS NULL AND r.num_transf IS NOT NULL)
+        THEN 'metodo 9'
+        ELSE ert.metodo
+    END AS metodo,
+    complemento_ted, num_ted, metodo_ted, numero_base, ano_raw, ano_normalizado, ano_oficial,
+    numero_ted_normalizado
+    FROM union_metodo_7_8 ert
+    LEFT JOIN ids_agregados_num_ted_normalizado r USING (orgao_id,numero_ted_normalizado)
+),
+empenhos_restantes_metodo_9 as (
+    select * from empenhos_orgaos_metodo_9 where (nc != '') or (num_transf is not null)
+),
+planos_de_acao as (
+    select * from {{ ref("num_transf_n_plano_acao") }} where plano_acao is not null
+),
+result_table as (
+    select distinct er.*, pa.plano_acao::integer as plano_acao, pa.num_transf as num_transf_pa
+    from empenhos_restantes_metodo_9 er
+    left join planos_de_acao pa
+    on er.num_transf=CAST(pa.num_transf AS TEXT)
+)  --
+
+select *
+from result_table

--- a/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/silver/nc_plano_acao.sql
+++ b/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/silver/nc_plano_acao.sql
@@ -1,0 +1,25 @@
+{{ config(materialized="table") }}
+
+with
+	raw_data as (
+		select *
+		from {{ ref("nc_unificado") }}
+		where nc_transferencia != '-8'
+	),
+
+	planos_de_acao as (
+		select distinct *
+		from {{ ref("num_transf_n_plano_acao") }}
+		where plano_acao is not null
+	),
+
+	result_table as (
+		select
+			rd.*,
+			pda.plano_acao::integer as id_plano_acao
+		from raw_data rd
+		left join planos_de_acao pda on rd.nc_transferencia = pda.num_transf
+	)
+
+select *
+from result_table

--- a/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/silver/schema.yml
+++ b/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/silver/schema.yml
@@ -223,3 +223,220 @@ models:
           nome_tabela: 'siafi_dbt.nc_unificado'
           nome_coluna: 'dt_ingest'
           tipo_esperado: 'timestamp with time zone'
+
+  - name: nc_plano_acao
+    description: >
+      Tabela silver que parte de nc_unificado e enriquece com o identificador do Plano de Ação
+      do TransfereGov (id_plano_acao) via a ponte num_transf_n_plano_acao (nc_transferencia -> plano_acao).
+      Filtra registros com nc_transferencia = '-8' (NCs sem vínculo de transferência válido).
+      Retorna todas as colunas de nc_unificado acrescidas de id_plano_acao, que pode ser nulo
+      quando a NC do SIAFI não possui correspondência no TransfereGov.
+    meta:
+      tags:
+        - silver
+    columns:
+      - name: id_plano_acao
+        description: >
+          Identificador do Plano de Ação no TransfereGov (integer), obtido via ponte
+          num_transf_n_plano_acao pelo nc_transferencia. Nulo quando a NC não possui
+          correspondência no TransfereGov.
+      - name: programa_governo
+        description: "Código do programa de governo (SIAFI, somente dados pré-2026; enriquecido por PTRES via nc_unificado)."
+      - name: programa_governo_descricao
+        description: "Descrição do programa de governo (SIAFI, somente dados pré-2026; enriquecido por PTRES via nc_unificado)."
+      - name: acao_governo
+        description: "Código da ação de governo (SIAFI, somente dados pré-2026; enriquecido por PTRES via nc_unificado)."
+      - name: acao_governo_descricao
+        description: "Descrição da ação de governo (SIAFI, somente dados pré-2026; enriquecido por PTRES via nc_unificado)."
+      - name: nc
+        description: "Número completo da Nota de Crédito no SIAFI. Primeiros 6 dígitos = UG emitente; últimos 12 = identificador da NC."
+      - name: nc_transferencia
+        description: "Número da transferência TED associado à NC — chave de ligação com a ponte num_transf_n_plano_acao."
+      - name: nc_fonte_recursos
+        description: "Código da fonte de recursos da NC (pré-2026: nc_fonte_recursos; pós-2026: fonte_codigo)."
+      - name: nc_fonte_recursos_descricao
+        description: "Descrição da fonte de recursos (pré-2026: nc_fonte_recursos_descricao; pós-2026: fonte_nome)."
+      - name: ptres
+        description: "Programa de Trabalho Resumido (PTRES) vinculado à NC no SIAFI."
+      - name: nc_evento_descricao
+        description: "Descrição do evento contábil (pré-2026: nc_evento_descricao; pós-2026: tipo_nc)."
+      - name: nc_ug_responsavel
+        description: "Código da UG responsável pela NC (pré-2026: nc_ug_responsavel; pós-2026: emitente_codigo)."
+      - name: nc_ug_responsavel_descricao
+        description: "Nome da UG responsável (pré-2026: nc_ug_responsavel_descricao; pós-2026: emitente_nome)."
+      - name: nc_natureza_despesa
+        description: "Código da natureza de despesa (pré-2026: nc_natureza_despesa; pós-2026: gnd_codigo)."
+      - name: nc_natureza_despesa_descricao
+        description: "Descrição da natureza de despesa (pré-2026: nc_natureza_despesa_descricao; pós-2026: gnd_nome)."
+      - name: nc_plano_interno
+        description: "Código do plano interno da NC (pré-2026: nc_plano_interno; pós-2026: pi_codigo)."
+      - name: nc_plano_interno_descricao1
+        description: "Descrição principal do plano interno (pré-2026: nc_plano_interno_descricao1; pós-2026: pi_nome)."
+      - name: nc_plano_interno_descricao2
+        description: "Descrição secundária do plano interno. Somente dados pré-2026; nulo para pós-2026."
+      - name: favorecido_doc
+        description: "CPF/CNPJ do favorecido (pré-2026: favorecido_doc; pós-2026: favorecido_codigo)."
+      - name: favorecido_doc_descricao
+        description: "Nome ou razão social do favorecido (pré-2026: favorecido_doc_descricao; pós-2026: favorecido_nome)."
+      - name: favorecido_municipio
+        description: "Código do município do favorecido. Somente dados pré-2026; nulo para pós-2026."
+      - name: favorecido_municipio_descricao
+        description: "Nome do município do favorecido. Somente dados pré-2026; nulo para pós-2026."
+      - name: valor_celula
+        description: "Valor financeiro da linha da NC (numeric). Pré-2026: nc_valor_linha; pós-2026: valor_celula. Sem correção de sinal."
+      - name: movimento_liquido_moeda_origem
+        description: "Movimento líquido na moeda de origem. Pré-2026: campo homônimo; pós-2026: total_lista."
+      - name: descricao
+        description: "Descrição geral da NC. Somente dados pós-2026; nulo para pré-2026."
+      - name: nc_evento
+        description: "Código do evento contábil da NC. Somente dados pré-2026; nulo para pós-2026. Usado no gold para classificar orcamento_recebido/devolvido."
+      - name: nc_item_detalhamento
+        description: "Indicador S/N de detalhamento do item da NC. Somente dados pós-2026; nulo para pré-2026."
+      - name: emissao_dia
+        description: "Data de emissão da NC (date). Somente dados pós-2026; nulo para pré-2026."
+      - name: emissao_mes
+        description: "Mês de emissão da NC (text). Somente dados pós-2026; nulo para pré-2026."
+      - name: emissao_ano
+        description: "Ano de emissão da NC (text). Somente dados pós-2026; nulo para pré-2026."
+      - name: ro
+        description: "Registro de Operação associado à NC. Somente dados pós-2026; nulo para pré-2026."
+      - name: dc
+        description: "Indicador Débito/Crédito da NC. Somente dados pós-2026; nulo para pré-2026."
+      - name: total_lista
+        description: "Valor total da lista de itens da NC (numeric). Somente dados pós-2026; nulo para pré-2026."
+      - name: esfera_orcamentaria_codigo
+        description: "Código da esfera orçamentária. Somente dados pós-2026; nulo para pré-2026."
+      - name: esfera_orcamentaria_nome
+        description: "Nome da esfera orçamentária. Somente dados pós-2026; nulo para pré-2026."
+      - name: dt_ingest
+        description: "Timestamp de ingestão do SIAFI (timestamptz, UTC-3)."
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.nc_plano_acao'
+          nome_coluna: 'id_plano_acao'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.nc_plano_acao'
+          nome_coluna: 'valor_celula'
+          tipo_esperado: 'numeric'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.nc_plano_acao'
+          nome_coluna: 'emissao_dia'
+          tipo_esperado: 'date'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.nc_plano_acao'
+          nome_coluna: 'dt_ingest'
+          tipo_esperado: 'timestamp with time zone'
+
+  - name: empenhos_por_plano_acao
+    description: >
+      Tabela silver que vincula as Notas de Empenho do SIAFI aos Planos de Ação do TransfereGov.
+      O vínculo é desafiador porque a NE não possui um campo estruturado para o número de
+      transferência — ele está embutido no campo livre ne_ccor_descricao ou em campos auxiliares.
+      O modelo aplica 9 métodos sequenciais de extração via regex, processando cada NE apenas
+      uma vez pelo primeiro método que obtiver resultado. Ao final, cruza o num_transf encontrado
+      com a view num_transf_n_plano_acao para obter o plano_acao correspondente.
+    meta:
+      tags:
+        - silver
+    columns:
+      - name: emissao_mes
+        description: "Mês de emissão da NE no SIAFI"
+      - name: emissao_dia
+        description: "Data de emissão da NE no SIAFI"
+      - name: ne_ccor
+        description: "Chave completa da Nota de Empenho no SIAFI"
+      - name: ne_num_processo
+        description: "Número do processo administrativo associado à NE, limpo de pontos, barras e hifens."
+      - name: ne_info_complementar
+        description: "Campo complementar da NE. Usado pelo método 5 de extração: quando contém exatamente 6 dígitos ou padrão 1XXXXX, é tratado como num_transf."
+      - name: ne_ccor_descricao
+        description: "Descrição livre da NE — campo principal de onde os métodos 1 a 5 e 7 extraem o num_transf via regex."
+      - name: doc_observacao
+        description: "Campo de observação do documento associado à NE. Usado pelo método 8 de extração via padrão 'TED NNN/AAAA'."
+      - name: natureza_despesa
+        description: "Código da natureza de despesa da NE (ex: 339030)."
+      - name: natureza_despesa_descricao
+        description: "Descrição da natureza de despesa da NE."
+      - name: ne_ccor_favorecido
+        description: "CNPJ ou CPF do favorecido do empenho, padronizado em maiúsculas."
+      - name: ne_ccor_favorecido_descricao
+        description: "Nome ou razão social do favorecido da NE."
+      - name: ne_ccor_ano_emissao
+        description: "Ano de emissão da NE (integer, YYYY), validado via regex para garantir 4 dígitos numéricos."
+      - name: ptres
+        description: "Programa de Trabalho Resumido (PTRES) vinculado à NE no SIAFI."
+      - name: fonte_recursos_detalhada
+        description: "Código detalhado da fonte de recursos da NE."
+      - name: fonte_recursos_detalhada_descricao
+        description: "Descrição da fonte de recursos. Usado pelo método 4 de extração do num_transf via regex no padrão 'TED: NNNNNN'."
+      - name: despesas_empenhadas
+        description: "Valor empenhado da NE (numeric 15,2). Positivo = novo empenho; negativo = anulação de empenho."
+      - name: despesas_liquidadas
+        description: "Valor liquidado (numeric 15,2) — despesas com bens ou serviços confirmados como entregues."
+      - name: despesas_pagas
+        description: "Valor efetivamente pago no exercício corrente (numeric 15,2)."
+      - name: restos_a_pagar_inscritos
+        description: "Valor inscrito em Restos a Pagar (numeric 15,2) — empenhado e não pago até o encerramento do exercício."
+      - name: restos_a_pagar_pagos
+        description: "Valor de Restos a Pagar efetivamente quitado (numeric 15,2)."
+      - name: dt_ingest
+        description: "Timestamp de ingestão da NE no SIAFI (timestamptz, UTC-3)."
+      - name: ne
+        description: "Identificador curto da Nota de Empenho — últimos 12 caracteres de ne_ccor."
+      - name: orgao_id
+        description: "Código do órgão emitente da NE — primeiros 6 caracteres de ne_ccor."
+      - name: nc
+        description: "Número da Nota de Crédito associada à NE, extraído de ne_ccor_descricao via regex e formatado pela UDF format_nc."
+      - name: num_transf
+        description: "Número da transferência TED extraído da NE pelos métodos 1 a 9. Chave de ligação com a ponte num_transf_n_plano_acao."
+      - name: metodo
+        description: >
+          Identifica qual método resolveu o vínculo da NE. Valores possíveis:
+          'sem vinculo' (NEs com TED explícito sem número), 'metodo 1' a 'metodo 9',
+          'ted ou nc invalido' e 'vinculo nao encontrado' (sem vínculo identificado).
+      - name: complemento_ted
+        description: "Complemento textual do TED extraído antes do número (ex: nome do programa), produzido pelos métodos 7 e 8."
+      - name: num_ted
+        description: "Número bruto do TED extraído do campo de texto pelos métodos 7 e 8, antes da normalização de ano."
+      - name: metodo_ted
+        description: "Indica a origem do numero_ted_normalizado: 'metodo 1' (ne_ccor_descricao) ou 'metodo 2' (doc_observacao)."
+      - name: numero_base
+        description: "Parte numérica do TED sem o ano, extraída de num_ted para o processo de normalização."
+      - name: ano_raw
+        description: "Ano bruto extraído de num_ted antes da normalização (pode ser 2 ou 4 dígitos)."
+      - name: ano_normalizado
+        description: "Ano com 4 dígitos após normalização: anos de 2 dígitos <= 30 viram '20XX'; > 30 viram '19XX'."
+      - name: ano_oficial
+        description: "Ano mais recente observado para o mesmo (orgao_id, numero_base), usado para preencher NEs sem ano explícito."
+      - name: numero_ted_normalizado
+        description: "Número do TED no formato canônico 'numero_base/ano_oficial' (ex: '42/2024'). Nulo quando nenhum ano pôde ser determinado com numero_base curto (<= 2 dígitos)."
+      - name: plano_acao
+        description: "Identificador do Plano de Ação no TransfereGov (integer), obtido via ponte num_transf_n_plano_acao a partir do num_transf. Nulo para NEs sem correspondência."
+      - name: num_transf_pa
+        description: "num_transf conforme registrado na ponte num_transf_n_plano_acao — usado para conferência cruzada com o num_transf extraído da NE."
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.empenhos_por_plano_acao'
+          nome_coluna: 'despesas_empenhadas'
+          tipo_esperado: 'numeric'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.empenhos_por_plano_acao'
+          nome_coluna: 'despesas_liquidadas'
+          tipo_esperado: 'numeric'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.empenhos_por_plano_acao'
+          nome_coluna: 'restos_a_pagar_inscritos'
+          tipo_esperado: 'numeric'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.empenhos_por_plano_acao'
+          nome_coluna: 'ne_ccor_ano_emissao'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.empenhos_por_plano_acao'
+          nome_coluna: 'plano_acao'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.empenhos_por_plano_acao'
+          nome_coluna: 'dt_ingest'
+          tipo_esperado: 'timestamp with time zone'

--- a/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/views/num_transf_n_plano_acao.sql
+++ b/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/views/num_transf_n_plano_acao.sql
@@ -1,0 +1,36 @@
+{{ config(materialized="view") }}
+
+with
+
+    nc_transfere_gov as (
+        select distinct id_plano_acao, tx_numero_nota as nc, ndc.cd_ug_emitente_nota as ug
+        from {{ source("transfere_gov", "notas_de_credito") }} ndc
+        where ndc.tx_numero_nota is not null
+    ),
+
+    nc_siafi as (
+        select distinct
+            left(nc, 6) as ug, right(nc, 12) as nc, nt.nc_transferencia as num_transf
+        from {{ref("nc_tesouro_mir")}} nt
+        where nc_transferencia != '-8'
+    ),
+
+    joined as (
+        select distinct num_transf, id_plano_acao as plano_acao
+        from nc_siafi
+        left join nc_transfere_gov using (nc, ug)
+    ),
+
+    ranked as (
+        select
+            *,
+            row_number() over (
+                partition by num_transf
+                order by case when plano_acao is not null then 1 else 2 end
+            ) as rn
+        from joined
+    )
+
+select num_transf, plano_acao
+from ranked
+where rn = 1

--- a/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/views/schema.yml
+++ b/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/views/schema.yml
@@ -1,0 +1,28 @@
+version: 2
+
+models:
+
+  - name: num_transf_n_plano_acao
+    description: >
+      View de mapeamento entre o número de transferência do SIAFI (num_transf / nc_transferencia)
+      e o identificador do Plano de Ação do TransfereGov (plano_acao / id_plano_acao).
+      É a ponte central que conecta os dois sistemas.
+
+      O cruzamento é feito via Notas de Crédito: o SIAFI registra a NC com nc_transferencia
+      e o TransfereGov registra a mesma NC com id_plano_acao. A correspondência é feita
+      pela chave composta (nc, ug_emitente).
+    meta:
+      tags:
+        - view
+    columns:
+      - name: num_transf
+        description: >
+          Número da transferência TED conforme registrado no SIAFI (nc_transferencia).
+          Chave de entrada — é o identificador que NCs, NEs e PFs usam para referenciar
+          uma transferência específica.
+      - name: plano_acao
+        description: >
+          Identificador do Plano de Ação no TransfereGov (id_plano_acao), obtido via
+          cruzamento da NC entre SIAFI e TransfereGov. Pode ser nulo quando a NC do SIAFI
+          não possui correspondência no TransfereGov. Tipo text na view — consumidores
+          devem fazer cast para integer conforme necessário.


### PR DESCRIPTION
### Contexto

Implementação da pipeline de dados do módulo TED do MIR. O objetivo é vincular
os registros contábeis do SIAFI (NEs e NCs) aos Planos de Ação cadastrados no
TransfereGov, possibilitando a consolidação orçamentária e financeira por plano.

O principal desafio é que o SIAFI e o TransfereGov são sistemas independentes —
a conexão entre eles é feita exclusivamente pelo `num_transf` (número da
transferência TED), que no SIAFI aparece em campos de texto livre das Notas de
Empenho ou como campo estruturado nas Notas de Crédito.

---

### Arquivos adicionados / modificados

#### `views/num_transf_n_plano_acao.sql` _(novo)_
View que é a **ponte central** entre SIAFI e TransfereGov. Cruza as Notas de
Crédito dos dois sistemas pela chave `(nc, ug_emitente)` para construir o
mapeamento `num_transf → plano_acao`. Quando um mesmo `num_transf` aparece com
múltiplos planos, prioriza o registro com `plano_acao` não nulo via `ROW_NUMBER`.

#### `silver/nc_plano_acao.sql` _(novo)_
Tabela silver que parte de `nc_unificado` (NCs unificadas pré/pós-2026) e
enriquece cada linha com o `id_plano_acao` via `LEFT JOIN` com
`num_transf_n_plano_acao` pelo `nc_transferencia`. Filtra NCs com
`nc_transferencia = '-8'` (sem vínculo válido). O `id_plano_acao` é nulo para
NCs sem correspondência no TransfereGov.

#### `silver/empenhos_por_plano_acao.sql` _(novo)_
Tabela silver que vincula Notas de Empenho do SIAFI aos Planos de Ação. Como a
NE não possui campo estruturado para `num_transf`, o modelo aplica **9 métodos
sequenciais de extração via regex**, cada um tentando encontrar o número de
transferência em uma posição diferente:

| Método | Campo fonte | Padrão buscado |
|--------|-------------|----------------|
| 1 | `ne_ccor_descricao` | `TED 123456` / `TRANSFERENCIA 123456` |
| 2 | `ne_ccor_descricao` | `NOTA DE TRANSFERENCIA/CREDITO: XXXXXX` |
| 3 | `ne_ccor_descricao` | `TED Nº` / `SIAFI Nº` + 6 dígitos |
| 4 | `fonte_recursos_detalhada_descricao` | `TED: NNNNNN` |
| 5 | `ne_info_complementar` | exatamente 6 dígitos ou padrão `1XXXXX` |
| 6 | propagação por `ne_ccor` | cross-NE do mesmo empenho |
| 7 | `ne_ccor_descricao` | `TED NNN/AAAA` (com normalização de ano) |
| 8 | `doc_observacao` | `TED NNN/AAAA` (com normalização de ano) |
| 9 | propagação por `(orgao_id, numero_ted_normalizado)` | cross-NE |

Ao final, cruza o `num_transf` extraído com `num_transf_n_plano_acao` para obter
o `plano_acao`.

#### `macros/udfs/f_format_nc.sql` _(modificado)_
Correção de robustez na UDF `format_nc`: adicionada validação do sufixo antes do
cast para `numeric`, evitando erro de runtime quando o campo contém valores não
numéricos. A UDF agora retorna `null` para entradas inválidas em vez de falhar.

---