### PR TITLE
Ingestão BACEN - Financiamentos imobiliários (Concessões, taxa de juros e inadimplência) PF e PJ

### DIFF
--- a/airflow_lappis/dags/data_ingest/bacen/bacen_financiamentos_imobiliarios_historico_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/bacen/bacen_financiamentos_imobiliarios_historico_ingest_dag.py
@@ -2,7 +2,11 @@ import logging
 from datetime import datetime, timedelta
 
 from airflow.decorators import dag, task
-from airflow.exceptions import AirflowException, AirflowFailException, AirflowSkipException
+from airflow.exceptions import (
+    AirflowException,
+    AirflowFailException,
+    AirflowSkipException,
+)
 
 from cliente_bacen import ClienteBacen
 from cliente_postgres import ClientPostgresDB
@@ -27,6 +31,7 @@ SERIES_BACEN = {
 
 # Série histórica disponível a partir de 01/03/2011 (conforme SGS)
 DATA_INICIO_HISTORICO = "01/03/2011"
+
 
 @dag(
     dag_id="bacen_financiamentos_imobiliarios_historico_dag",
@@ -69,16 +74,15 @@ def bacen_financiamentos_imobiliarios_historico_dag() -> None:
 
             if df is None:
                 raise AirflowFailException(
-                "[bacen_historico_dag] ClienteBacen falhou buscando séries históricas."
-                f"Verifique os códigos SGS: {list(SERIES_BACEN.keys())}"
-            )
+                    "[bacen_historico_dag] ClienteBacen falhou buscando séries históricas."
+                    f"Verifique os códigos SGS: {list(SERIES_BACEN.keys())}"
+                )
 
             if df.empty:
                 raise AirflowSkipException(
                     "[bacen_historico_dag] DataFrame retornado está vazio — "
                     "nenhum dado disponível para o período histórico solicitado."
                 )
-
 
             registros = df.to_dict(orient="records")
             dt_ingest = datetime.now().isoformat()
@@ -113,7 +117,6 @@ def bacen_financiamentos_imobiliarios_historico_dag() -> None:
             raise AirflowException(
                 f"[bacen_historico_dag] Erro inesperado na carga histórica: {e}"
             ) from e
-
 
     fetch_and_store_historico()
 

--- a/airflow_lappis/dags/data_ingest/bacen/bacen_financiamentos_imobiliarios_historico_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/bacen/bacen_financiamentos_imobiliarios_historico_ingest_dag.py
@@ -1,0 +1,121 @@
+import logging
+from datetime import datetime, timedelta
+
+from airflow.decorators import dag, task
+from airflow.exceptions import AirflowException, AirflowFailException, AirflowSkipException
+
+from cliente_bacen import ClienteBacen
+from cliente_postgres import ClientPostgresDB
+from postgres_helpers import get_postgres_conn
+
+logger = logging.getLogger(__name__)
+
+default_args = {
+    "owner": "Lucas Bottino",
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+}
+
+SERIES_BACEN = {
+    20704: "pf_concessoes_rs_mi",
+    20774: "pf_taxa_juros_aa",
+    21151: "pf_inadimplencia_pct",
+    20692: "pj_concessoes_rs_mi",
+    20763: "pj_taxa_juros_aa",
+    21139: "pj_inadimplencia_pct",
+}
+
+# Série histórica disponível a partir de 01/03/2011 (conforme SGS)
+DATA_INICIO_HISTORICO = "01/03/2011"
+
+@dag(
+    dag_id="bacen_financiamentos_imobiliarios_historico_dag",
+    schedule_interval=None,  # Execução manual — carga histórica única
+    start_date=datetime(2025, 1, 1),
+    catchup=False,
+    default_args=default_args,
+    tags=["bacen", "financiamentos", "imobiliarios", "historico"],
+)
+def bacen_financiamentos_imobiliarios_historico_dag() -> None:
+    """
+    DAG de carga histórica do BACEN SGS — execução manual (schedule_interval=None).
+    Puxa toda a série disponível desde 01/03/2011 até o mês anterior à execução.
+    Deve ser rodada uma única vez para popular a tabela base antes
+    de ativar a DAG incremental trimestral.
+    """
+
+    @task
+    def fetch_and_store_historico() -> None:
+        logger.info("[bacen_historico_dag] Iniciando carga histórica BACEN")
+
+        try:
+            exec_date = datetime.now()
+            primeiro_dia_mes_atual = exec_date.replace(day=1)
+            ultimo_dia_mes_anterior = primeiro_dia_mes_atual - timedelta(days=1)
+            data_fim = ultimo_dia_mes_anterior.strftime("%d/%m/%Y")
+
+            logger.info(
+                "[bacen_historico_dag] Janela histórica: %s até %s",
+                DATA_INICIO_HISTORICO,
+                data_fim,
+            )
+
+            cliente = ClienteBacen()
+            df = cliente.fetch_and_transform(
+                SERIES_BACEN,
+                DATA_INICIO_HISTORICO,
+                data_fim,
+            )
+
+            if df is None:
+                raise AirflowFailException(
+                "[bacen_historico_dag] ClienteBacen falhou buscando séries históricas."
+                f"Verifique os códigos SGS: {list(SERIES_BACEN.keys())}"
+            )
+
+            if df.empty:
+                raise AirflowSkipException(
+                    "[bacen_historico_dag] DataFrame retornado está vazio — "
+                    "nenhum dado disponível para o período histórico solicitado."
+                )
+
+
+            registros = df.to_dict(orient="records")
+            dt_ingest = datetime.now().isoformat()
+            for r in registros:
+                r["dt_ingest"] = dt_ingest
+                r["fonte"] = "BACEN_SGS"
+
+            postgres_conn_str = get_postgres_conn()
+            db = ClientPostgresDB(postgres_conn_str)
+
+            logger.info(
+                "[bacen_historico_dag] Inserindo %d registros históricos em "
+                "bacen.financiamentos_imobiliarios",
+                len(registros),
+            )
+
+            db.insert_data(
+                registros,
+                table_name="financiamentos_imobiliarios",
+                schema="bacen",
+                conflict_fields=["data_referencia"],
+                primary_key=["data_referencia"],
+            )
+
+            logger.info("[bacen_historico_dag] Carga histórica concluída com sucesso")
+        except AirflowSkipException:
+            raise
+        except AirflowFailException:
+            raise
+        except Exception as e:
+            logger.error("[bacen_historico_dag] Erro na carga histórica: %s", e)
+            raise AirflowException(
+                f"[bacen_historico_dag] Erro inesperado na carga histórica: {e}"
+            ) from e
+
+
+    fetch_and_store_historico()
+
+
+dag_instance = bacen_financiamentos_imobiliarios_historico_dag()

--- a/airflow_lappis/dags/data_ingest/bacen/bacen_financiamentos_imobiliarios_trimestral_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/bacen/bacen_financiamentos_imobiliarios_trimestral_ingest_dag.py
@@ -1,0 +1,131 @@
+import logging
+from datetime import datetime, timedelta
+
+from airflow.decorators import dag, task
+from airflow.exceptions import AirflowException, AirflowFailException, AirflowSkipException
+
+from cliente_bacen import ClienteBacen
+from cliente_postgres import ClientPostgresDB
+from postgres_helpers import get_postgres_conn
+from schedule_loader import get_dynamic_schedule
+
+logger = logging.getLogger(__name__)
+
+default_args = {
+    "owner": "Lucas Bottino",
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+}
+
+SERIES_BACEN = {
+    20704: "pf_concessoes_rs_mi",
+    20774: "pf_taxa_juros_aa",
+    21151: "pf_inadimplencia_pct",
+    20692: "pj_concessoes_rs_mi",
+    20763: "pj_taxa_juros_aa",
+    21139: "pj_inadimplencia_pct",
+}
+
+
+@dag(
+    dag_id="bacen_financiamentos_imobiliarios_dag",
+    schedule_interval=get_dynamic_schedule("bacen_financiamentos_imobiliarios"),
+    start_date=datetime(2025, 1, 1),
+    catchup=False,
+    default_args=default_args,
+    tags=["bacen", "financiamentos", "imobiliarios"],
+)
+def bacen_financiamentos_imobiliarios_dag() -> None:
+    """
+    DAG de ingestão incremental trimestral do BACEN SGS.
+    Puxa os 3 meses do trimestre anterior à data de execução.
+    Depende da carga histórica prévia via
+    bacen_financiamentos_imobiliarios_historico_dag.
+    """
+
+    @task
+    def fetch_and_store() -> None:
+        logger.info("[bacen_dag] Iniciando ingestão trimestral BACEN")
+
+        try:
+            exec_date = datetime.now()
+
+            # Identifica o trimestre anterior completo
+            mes_atual = exec_date.month
+            ano_atual = exec_date.year
+
+            primeiro_mes_trimestre_atual = ((mes_atual - 1) // 3) * 3 + 1
+
+            ultimo_dia_trim_anterior = datetime(
+                ano_atual, primeiro_mes_trimestre_atual, 1
+            ) - timedelta(days=1)
+
+            primeiro_mes_trim_anterior = ((ultimo_dia_trim_anterior.month - 1) // 3) * 3 + 1
+            primeiro_dia_trim_anterior = datetime(
+                ultimo_dia_trim_anterior.year, primeiro_mes_trim_anterior, 1
+            )
+
+            data_ini = primeiro_dia_trim_anterior.strftime("%d/%m/%Y")
+            data_fim = ultimo_dia_trim_anterior.strftime("%d/%m/%Y")
+
+            logger.info(
+                "[bacen_dag] Buscando trimestre: %s até %s",
+                data_ini,
+                data_fim,
+            )
+
+            cliente = ClienteBacen()
+            df = cliente.fetch_and_transform(
+                SERIES_BACEN,
+                data_ini,
+                data_fim,
+            )
+
+            if df is None:
+                raise AirflowFailException(
+                    f"[bacen_dag] ClienteBacen falhou ao buscar séries. "
+                    f"Verifique os códigos SGS: {list(SERIES_BACEN.keys())}"
+                )
+
+            if df.empty:
+                raise AirflowSkipException(
+                    f"[bacen_dag] Nenhum dado retornado pelo BACEN para o período "
+                    f"{data_ini} até {data_fim} — publicação pode estar pendente."
+                )
+
+            registros = df.to_dict(orient="records")
+            dt_ingest = datetime.now().isoformat()
+            for r in registros:
+                r["dt_ingest"] = dt_ingest
+                r["fonte"] = "BACEN_SGS"
+
+            postgres_conn_str = get_postgres_conn()
+            db = ClientPostgresDB(postgres_conn_str)
+
+            logger.info(
+                "[bacen_dag] Inserindo %d registros em bacen.financiamentos_imobiliarios",
+                len(registros),
+            )
+
+            db.insert_data(
+                registros,
+                table_name="financiamentos_imobiliarios",
+                schema="bacen",
+                conflict_fields=["data_referencia"],
+                primary_key=["data_referencia"],
+            )
+
+            logger.info("[bacen_dag] Ingestão trimestral concluída com sucesso")
+
+        except (AirflowFailException, AirflowSkipException):
+            raise
+        except Exception as e:
+            logger.error("[bacen_dag] Erro inesperado na ingestão BACEN: %s", e)
+            raise AirflowException(
+                f"[bacen_dag] Erro inesperado na ingestão BACEN: {e}"
+            ) from e
+
+    fetch_and_store()
+
+
+dag_instance = bacen_financiamentos_imobiliarios_dag()

--- a/airflow_lappis/dags/data_ingest/bacen/bacen_financiamentos_imobiliarios_trimestral_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/bacen/bacen_financiamentos_imobiliarios_trimestral_ingest_dag.py
@@ -2,7 +2,11 @@ import logging
 from datetime import datetime, timedelta
 
 from airflow.decorators import dag, task
-from airflow.exceptions import AirflowException, AirflowFailException, AirflowSkipException
+from airflow.exceptions import (
+    AirflowException,
+    AirflowFailException,
+    AirflowSkipException,
+)
 
 from cliente_bacen import ClienteBacen
 from cliente_postgres import ClientPostgresDB
@@ -60,7 +64,9 @@ def bacen_financiamentos_imobiliarios_dag() -> None:
                 ano_atual, primeiro_mes_trimestre_atual, 1
             ) - timedelta(days=1)
 
-            primeiro_mes_trim_anterior = ((ultimo_dia_trim_anterior.month - 1) // 3) * 3 + 1
+            primeiro_mes_trim_anterior = (
+                (ultimo_dia_trim_anterior.month - 1) // 3
+            ) * 3 + 1
             primeiro_dia_trim_anterior = datetime(
                 ultimo_dia_trim_anterior.year, primeiro_mes_trim_anterior, 1
             )

--- a/airflow_lappis/dags/data_ingest/fgv/icst_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/fgv/icst_ingest_dag.py
@@ -1,0 +1,63 @@
+import logging
+from datetime import datetime, timedelta
+from airflow.decorators import dag, task
+from airflow.models import Variable
+from cliente_fgv import ClienteFGVDados
+from cliente_postgres import ClientPostgresDB
+from postgres_helpers import get_postgres_conn
+from schedule_loader import get_dynamic_schedule
+
+
+@dag(
+    schedule_interval=get_dynamic_schedule("icst_ingest_dag"),
+    start_date=datetime(2023, 1, 1),
+    catchup=False,
+    default_args={
+        "owner": "Gustavo",
+        "retries": 1,
+        "retry_delay": timedelta(minutes=5),
+    },
+    tags=["fgv", "icst", "construcao", "confianca"],
+)
+def icst_ingest_dag() -> None:
+    """
+    DAG para ingestão de dados históricos do ICST da FGV no PostgreSQL.
+    """
+
+    @task
+    def fetch_and_store_icst() -> None:
+        """
+        Baixa o CSV do ICST autenticado e faz upsert no Postgres.
+        """
+        logging.info("Iniciando processamento do ICST Histórico")
+
+        # Busca as credenciais de forma segura usando Variables do Airflow
+        email_fgv = Variable.get("dados_fgv_email")
+        senha_fgv = Variable.get("dados_fgv_password")
+
+        api = ClienteFGVDados(email=email_fgv, password=senha_fgv)
+        postgres_conn_str = get_postgres_conn()
+        db = ClientPostgresDB(postgres_conn_str)
+        tabela = "icst"
+
+        registros = api.fetch_icst_historico()
+
+        if registros:
+            logging.info(f"Inserindo {len(registros)} registros em fgv.{tabela}")
+
+            db.insert_data(
+                data=registros,
+                table_name=tabela,
+                conflict_fields=["mes"],
+                primary_key=["mes"],
+                schema="fgv",
+            )
+
+            logging.info(f"Ingestão da {tabela} concluída com sucesso.")
+        else:
+            logging.warning("Nenhum registro extraído para ICST Histórico da FGV.")
+
+    fetch_and_store_icst()
+
+
+dag_instance = icst_ingest_dag()

--- a/airflow_lappis/dags/data_ingest/fgv/incc_m_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/fgv/incc_m_ingest_dag.py
@@ -1,0 +1,55 @@
+import logging
+from airflow.decorators import dag, task
+from datetime import datetime, timedelta
+from schedule_loader import get_dynamic_schedule
+from postgres_helpers import get_postgres_conn
+from cliente_fgv import ClienteSinduscon
+from cliente_postgres import ClientPostgresDB
+
+
+@dag(
+    schedule_interval=get_dynamic_schedule("incc_m_ingest_dag"),
+    start_date=datetime(2023, 1, 1),
+    catchup=False,
+    default_args={
+        "owner": "Gustavo",
+        "retries": 1,
+        "retry_delay": timedelta(minutes=5),
+    },
+    tags=["fgv", "incc_m", "construcao", "custos"],
+)
+def incc_m_ingest_dag() -> None:
+    """DAG para ingestão de dados do INCC-M da FGV no PostgreSQL."""
+
+    @task
+    def fetch_and_store_incc() -> None:
+        """
+        Baixa o arquivo do INCC, trata os dados via Pandas e faz upsert do Postgres.
+        """
+        logging.info("Iniciando processamento do INCC-M")
+
+        api = ClienteSinduscon()
+        postgres_conn_str = get_postgres_conn()
+        db = ClientPostgresDB(postgres_conn_str)
+        tabela = "incc_m"
+
+        registros = api.fetch_and_transform_incc()
+
+        if registros:
+            logging.info(f"Inserindo {len(registros)} registros em fgv.{tabela}")
+
+            db.insert_data(
+                data=registros,
+                table_name=tabela,
+                conflict_fields=["mes"],
+                primary_key=["mes"],
+                schema="fgv",
+            )
+            logging.info(f"Ingestão de {tabela} concluída com sucesso.")
+        else:
+            logging.warning("Nenhum registro extraído para INCC-M da FGV.")
+
+    fetch_and_store_incc()
+
+
+dag_instance = incc_m_ingest_dag()

--- a/airflow_lappis/plugins/cliente_bacen.py
+++ b/airflow_lappis/plugins/cliente_bacen.py
@@ -1,0 +1,110 @@
+import logging
+from datetime import datetime
+from http import HTTPStatus
+from typing import Optional
+import pandas as pd
+from cliente_base import ClienteBase
+
+class ClienteBacen(ClienteBase):
+    BASE_URL = "https://api.bcb.gov.br"
+
+    def __init__(self) -> None:
+        super().__init__(
+            base_url=self.BASE_URL,
+            headers={"Accept": "application/json"},
+        )
+        logging.info(
+            f"[cliente_bacen.py] Initialized ClienteBacen with base_url: {self.base_url}"
+        )
+
+    @staticmethod
+    def _to_date(bcb_date: str) -> str:
+        return datetime.strptime(bcb_date, "%d/%m/%Y").strftime("%Y-%m-%d")
+
+    def _fetch_series(
+            self,
+            codigo: int,
+            data_inicial: str,
+            data_final: str,
+    ) -> Optional[pd.DataFrame]:
+        path = f"/dados/serie/bcdata.sgs.{codigo}/dados"
+        params = {
+            "formato": "json",
+            "dataInicial": data_inicial,
+            "dataFinal": data_final,
+        }
+
+        status, data = self.request("GET", path, params=params)
+
+        if status != HTTPStatus.OK or not data:
+            logging.error(
+                f"[cliente_bacen.py] Falha ao buscar a serie {codigo}."
+                f"HTTP {status}"
+            )
+            return None
+
+        df = pd.DataFrame(data)
+        df["data_referencia"] = df['data'].apply(self._to_date)
+        df["valor"] = pd.to_numeric(df["valor"], errors="coerce")
+
+        logging.info(
+            f"[cliente_bacen.py] Serie {codigo}: {len(df)} pontos retornados."
+        )
+        return df
+
+    def fetch_and_transform(
+        self,
+        series: dict[int, str],
+        data_inicial: str,
+        data_final: str,
+    ) -> Optional[pd.DataFrame]:
+        """
+        Busca todas as séries informadas e retorna um DataFrame flat
+        com uma linha por data e uma coluna por série.
+
+        Args:
+            series:       Dicionário {codigo_sgs: "nome_coluna"}.
+            data_inicial: Data inicial no formato 'dd/MM/yyyy'.
+            data_final:   Data final no formato 'dd/MM/yyyy'.
+
+        Returns:
+            DataFrame com colunas [data_referencia, <nome_coluna>, ...]
+            ou None em caso de falha total.
+        """
+        logging.info(
+            f"[cliente_bacen.py] Iniciando extração de "
+            f"{data_inicial} até {data_final} | "
+            f"Séries: {list(series.values())}"
+        )
+
+        frames: list[pd.DataFrame] = []
+
+        for codigo, nome_coluna in series.items():
+            df_serie = self._fetch_series(codigo, data_inicial, data_final)
+
+            if df_serie is None:
+                logging.warning(
+                    f"[cliente_bacen.py] Série {codigo} ({nome_coluna}) "
+                    f"retornou None — ignorando."
+                )
+                continue
+
+            df_serie = df_serie.rename(columns={"valor": nome_coluna})
+            frames.append(df_serie.set_index("data_referencia"))
+
+        if not frames:
+            logging.error(
+                "[cliente_bacen.py] Nenhuma série extraída com sucesso. "
+                "Verifique os códigos e a janela de datas."
+            )
+            return None
+
+        # Join de todos os DataFrames pelo índice (data_referencia)
+        df_final = pd.concat(frames, axis=1).reset_index()
+        df_final["dt_ingest"] = datetime.now().isoformat()
+
+        logging.info(
+            f"[cliente_bacen.py] Transformação concluída. "
+            f"{len(df_final)} registros | Colunas: {list(df_final.columns)}"
+        )
+        return df_final

--- a/airflow_lappis/plugins/cliente_bacen.py
+++ b/airflow_lappis/plugins/cliente_bacen.py
@@ -5,6 +5,7 @@ from typing import Optional
 import pandas as pd
 from cliente_base import ClienteBase
 
+
 class ClienteBacen(ClienteBase):
     BASE_URL = "https://api.bcb.gov.br"
 
@@ -22,10 +23,10 @@ class ClienteBacen(ClienteBase):
         return datetime.strptime(bcb_date, "%d/%m/%Y").strftime("%Y-%m-%d")
 
     def _fetch_series(
-            self,
-            codigo: int,
-            data_inicial: str,
-            data_final: str,
+        self,
+        codigo: int,
+        data_inicial: str,
+        data_final: str,
     ) -> Optional[pd.DataFrame]:
         path = f"/dados/serie/bcdata.sgs.{codigo}/dados"
         params = {
@@ -38,18 +39,15 @@ class ClienteBacen(ClienteBase):
 
         if status != HTTPStatus.OK or not data:
             logging.error(
-                f"[cliente_bacen.py] Falha ao buscar a serie {codigo}."
-                f"HTTP {status}"
+                f"[cliente_bacen.py] Falha ao buscar a serie {codigo}." f"HTTP {status}"
             )
             return None
 
         df = pd.DataFrame(data)
-        df["data_referencia"] = df['data'].apply(self._to_date)
+        df["data_referencia"] = df["data"].apply(self._to_date)
         df["valor"] = pd.to_numeric(df["valor"], errors="coerce")
 
-        logging.info(
-            f"[cliente_bacen.py] Serie {codigo}: {len(df)} pontos retornados."
-        )
+        logging.info(f"[cliente_bacen.py] Serie {codigo}: {len(df)} pontos retornados.")
         return df
 
     def fetch_and_transform(

--- a/airflow_lappis/plugins/cliente_fgv.py
+++ b/airflow_lappis/plugins/cliente_fgv.py
@@ -1,0 +1,710 @@
+import logging
+import io
+import urllib.parse
+import re
+import html
+from datetime import datetime
+from typing import Optional
+
+import pandas as pd
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.ssl_ import create_urllib3_context
+
+
+class LegacySSLAdapter(HTTPAdapter):
+    """
+    Adaptador customizado para baixar o nível de segurança do OpenSSL
+    e permitir conexão com servidores IIS legados (ASP.NET).
+    """
+
+    def init_poolmanager(self, *args, **kwargs):
+        context = create_urllib3_context()
+        context.set_ciphers("DEFAULT@SECLEVEL=1")
+        kwargs["ssl_context"] = context
+        return super(LegacySSLAdapter, self).init_poolmanager(*args, **kwargs)
+
+
+class ClienteSinduscon:
+    """
+    Cliente para extração de dados INCC-M da FGV no site da Sinduscon.
+
+    Fonte: https://sindusconpr.com.br/download/10984/1364
+    """
+
+    URL_INCC = "https://sindusconpr.com.br/download/10984/1364"
+
+    def __init__(self) -> None:
+        logging.info("[cliente_fgv.py] Initialized ClienteFGV")
+
+    def fetch_and_transform_incc(self) -> Optional[list[dict]]:
+        """
+        Baixa o arquivo XLSX do INCC-M, limpa os cabeçalhos e formata os dados.
+
+        Returns:
+            Lista de dicionários contendo os registros do índice ou None em caso de falha.
+        """
+        logging.info(f"[cliente_fgv.py] Baixando dados de: {self.URL_INCC}")
+
+        # User-Agent previne que alguns servidores bloqueiem
+        # requisições de bibliotecas python
+        headers = {
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " "AppleWebKit/537.36"
+            )
+        }
+
+        try:
+            response = requests.get(self.URL_INCC, headers=headers)
+            response.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            logging.error(f"[cliente_fgv.py] Erro ao baixar o arquivo da FGV: {e}")
+            return None
+
+        try:
+            # Lendo o Excel em memória
+            # Pula as 3 primeiras linhas de cabeçalho
+            df = pd.read_excel(
+                io.BytesIO(response.content),
+                skiprows=3,
+                usecols="A:E",
+                names=["mes", "indice", "var_mes", "var_ano", "var_12_meses"],
+            )
+
+            # Remove as linhas vazias ou o rodapé de "Fonte FGV"
+            df = df.dropna(subset=["mes"])
+            df = df[~df["mes"].astype(str).str.contains("Fonte", case=False, na=False)]
+
+            # # Adiciona data de ingestão
+            df["dt_ingest"] = datetime.now().isoformat()
+
+            # Converte valores pd.NA/NaN para None (NULL do Postgres)
+            df = df.where(pd.notnull(df), None)
+
+            registros = df.to_dict(orient="records")
+
+            logging.info(
+                f"[cliente_fgv.py] Transformação concluída. "
+                f"{len(registros)} registros preparados."
+            )
+
+            return registros
+
+        except Exception as e:
+            logging.error(f"[cliente_fgv.py] Erro ao processar arquivo com Pandas: {e}")
+            return None
+
+
+class ClienteFGVDados:
+    """
+    Cliente para extração autenticada de dados históricos (ICST) do portal FGVDados.
+    Lida com a autenticação OutSystems e a navegação no sistema legado ASP.NET.
+    """
+
+    def __init__(
+        self,
+        email: str,
+        password: str,
+    ) -> None:
+        self.email = email
+        self.password = password
+        self.session = requests.Session()
+        self.session.mount("https://extra-ibre.fgv.br", LegacySSLAdapter())
+        logging.info("[cliente_fgv.py] Initialized ClienteFGVDados")
+
+    def _obter_versoes_outsystems(self) -> dict:
+        """
+        Extrai dinamicamente moduleVersion, apiVersions e
+        URLs dos endpoints de login do OutSystems.
+
+        Estratégia:
+        1. moduleVersion vem do endpoint REST
+           /moduleservices/moduleversioninfo
+        2. apiVersions e URLs vêm do JS lazy-loaded
+           BL01_Login.mvc.js, onde o OutSystems registra
+           chamadas no formato:
+           callDataAction("...", "screenservices/...", "HASH", ...)
+        """
+        logging.info(
+            "[cliente_fgv.py] Buscando hashes"
+            " dinâmicas do OutSystems..."
+        )
+        url_base = (
+            "https://autenticacao-ibre.fgv.br"
+            "/ProdutosDigitais/"
+        )
+
+        # Fallbacks caso algo falhe
+        resultado = {
+            "moduleVersion": "vuthrRMgPWqGaqAin6KHTA",
+            "api_cloudflare": "OTGxLOOIYRPT4Yzxi6zCuA",
+            "api_login": "kEIaQNU5n93i9Q026f_dlQ",
+            "url_cloudflare": (
+                "screenservices/ProdutosDigitais/"
+                "Blocks/BL01_Login/"
+                "DataActionCheckUsarCloudFlare"
+            ),
+            "url_login": (
+                "screenservices/ProdutosDigitais/"
+                "Blocks/BL01_Login/"
+                "DataActionGetDadosLogin"
+            ),
+        }
+
+        # Session pode ter Accept: application/json,
+        # o que causa 406 ao baixar .js
+        headers_get = {"Accept": "*/*"}
+
+        # moduleVersion via REST
+        try:
+            res_ver = self.session.get(
+                url_base + "moduleservices/moduleversioninfo",
+                timeout=10,
+                headers=headers_get,
+            )
+            if res_ver.status_code == 200:
+                token = res_ver.json().get("versionToken", "")
+                if token:
+                    resultado["moduleVersion"] = token
+        except Exception as e:
+            logging.warning(
+                "[cliente_fgv.py] Falha ao buscar"
+                f" moduleversioninfo: {e}"
+            )
+
+        # apiVersions e URLs do BL01_Login.mvc.js
+        try:
+            url_js = (
+                url_base
+                + "scripts/ProdutosDigitais"
+                ".Blocks.BL01_Login.mvc.js"
+            )
+            res_js = self.session.get(
+                url_js, timeout=10, headers=headers_get
+            )
+            if res_js.status_code == 200:
+                js = res_js.text
+
+                # Sufixo do DataAction -> chaves no resultado
+                acoes = {
+                    "DataActionCheckUsarCloudFlare": (
+                        "api_cloudflare",
+                        "url_cloudflare",
+                    ),
+                    "DataActionGET_UsarCloudFlare": (
+                        "api_cloudflare",
+                        "url_cloudflare",
+                    ),
+                    "DataActionGetDadosLogin": (
+                        "api_login",
+                        "url_login",
+                    ),
+                    "DataActionGET_Dados": (
+                        "api_login",
+                        "url_login",
+                    ),
+                }
+
+                regex_call = (
+                    r'callDataAction\(\s*"[^"]*"\s*,\s*'
+                    r'"(screenservices/[^"]*'
+                    r'/(DataAction\w+))"\s*,\s*'
+                    r'"([^"]+)"'
+                )
+                for m in re.finditer(regex_call, js):
+                    url_path = m.group(1)
+                    action_name = m.group(2)
+                    api_hash = m.group(3)
+                    if action_name in acoes:
+                        k_hash, k_url = acoes[action_name]
+                        resultado[k_hash] = api_hash
+                        resultado[k_url] = url_path
+        except Exception as e:
+            logging.warning(
+                "[cliente_fgv.py] Falha ao buscar"
+                f" BL01_Login.mvc.js: {e}"
+            )
+
+        logging.info(
+            "[cliente_fgv.py] Hashes:"
+            f" Module={resultado['moduleVersion'][:8]}..."
+            f" | CF={resultado['api_cloudflare'][:8]}..."
+            f" | Login={resultado['api_login'][:8]}..."
+        )
+        return resultado
+
+    @staticmethod
+    def _extrair_estados(html_text: str) -> dict:
+        """Extrai campos ocultos exigidos pela arquitetura ASP.NET WebForms."""
+        vs = re.search(r'id="__VIEWSTATE"\s+value="(.*?)"', html_text)
+        vsg = re.search(r'id="__VIEWSTATEGENERATOR"\s+value="(.*?)"', html_text)
+        ev = re.search(r'id="__EVENTVALIDATION"\s+value="(.*?)"', html_text)
+        return {
+            "__VIEWSTATE": vs.group(1) if vs else "",
+            "__VIEWSTATEGENERATOR": vsg.group(1) if vsg else "",
+            "__EVENTVALIDATION": ev.group(1) if ev else "",
+        }
+
+    @staticmethod
+    def _extrair_estados_delta(delta_text: str) -> dict:
+        """Extrai campos ocultos de respostas parciais (AJAX) do UpdatePanel."""
+        estados = {}
+        partes = delta_text.split("|")
+        i = 0
+        while i + 3 < len(partes):
+            try:
+                int(partes[i])
+            except ValueError:
+                i += 1
+                continue
+
+            eh_hidden = partes[i + 1] == "hiddenField"
+            campos_validos = (
+                "__VIEWSTATE",
+                "__VIEWSTATEGENERATOR",
+                "__EVENTVALIDATION",
+            )
+
+            if eh_hidden and partes[i + 2] in campos_validos:
+                estados[partes[i + 2]] = partes[i + 3]
+            i += 4
+        return estados
+    
+    def _autenticar(self, hashes_dinamicas: dict) -> Optional[str]:
+        """
+        Executa o fluxo de login no portal OutSystems e prepara a sessão
+        para transição aos sistemas ASP.NET legados.
+        """
+        logging.info("[cliente_fgv.py]  Inicializando autenticação FGV...")
+        self.session.headers.update(
+            {
+                "User-Agent": (
+                    "Mozilla/5.0 (X11; Linux x86_64; rv:149.0) "
+                    "Gecko/20100101 Firefox/149.0"
+                ),
+                "Content-Type": "application/json; charset=UTF-8",
+                "Accept": "application/json",
+                "OutSystems-Client-Type": "Web",
+                "Origin": "https://autenticacao-ibre.fgv.br",
+                "Referer": "https://autenticacao-ibre.fgv.br/ProdutosDigitais/",
+            }
+        )
+
+        # Autenticação OutSystems
+        self.session.get("https://autenticacao-ibre.fgv.br/ProdutosDigitais/")
+        self.session.headers.update({"X-CSRFToken": ""})
+    
+        url_cf = (
+            "https://autenticacao-ibre.fgv.br/ProdutosDigitais/"
+            + hashes_dinamicas["url_cloudflare"]
+        )
+
+        payload_cf = {
+            "versionInfo": {
+                "moduleVersion": hashes_dinamicas["moduleVersion"],
+                "apiVersion": hashes_dinamicas["api_cloudflare"],
+            },
+            "viewName": "MainFlow.Login",
+            "screenData": {
+                "variables": {
+                    "DSLogin": "",
+                    "DSPassword": "",
+                    "Prompt_Login": "ex: seu login ou email@email.com",
+                    "Prompt_Senha": "digite a tua senha",
+                    "MSG_Erro": "",
+                    "MSG_AtivacaoCadastro": "",
+                    "MSG_ErroCodigo": "",
+                    "LoadingBotaoEntrar": False,
+                    "LoadingBotaoValidar": False,
+                    "FLG_AtivacaoCadastro": False,
+                    "FLG_ExibirSenha": False,
+                    "FLG_PopupAtivarConta": False,
+                    "FLG_VerificarCodigo": True,
+                    "WidgetIdFlare": "",
+                    "VL_TentativasLogin": 0,
+                    "CD_01": "",
+                    "CD_02": "",
+                    "CD_03": "",
+                    "CD_04": "",
+                    "FLG_ativarConta": False,
+                    "_fLG_ativarContaInDataFetchStatus": 1,
+                    "token": "",
+                    "_tokenInDataFetchStatus": 1,
+                    "Email": "",
+                    "_emailInDataFetchStatus": 1,
+                }
+            },
+            "clientVariables": {"RL_Produtos": "", "NM_Usuario": ""},
+        }
+
+        self.session.post(url_cf, json=payload_cf)
+
+        cookie_nr2users = self.session.cookies.get("nr2Users")
+        if not cookie_nr2users:
+            logging.error("[cliente_fgv.py] Falha ao capturar token (nr2Users).")
+            return None
+
+        token_unquoted = urllib.parse.unquote(cookie_nr2users)
+        token_csrf = token_unquoted.split("crf=")[1].split(";")[0]
+        self.session.headers.update({"X-CSRFToken": token_csrf})
+
+        url_login = (
+            "https://autenticacao-ibre.fgv.br/ProdutosDigitais/"
+            + hashes_dinamicas["url_login"]
+        )
+
+        payload_login = {
+            "versionInfo": {
+                "moduleVersion": hashes_dinamicas["moduleVersion"],
+                "apiVersion": hashes_dinamicas["api_login"],
+            },
+            "viewName": "MainFlow.Login",
+            "screenData": {
+                "variables": {
+                    "DSLogin": self.email,
+                    "DSPassword": self.password,
+                    "Prompt_Login": "",
+                    "Prompt_Senha": "",
+                    "MSG_Erro": "",
+                    "MSG_AtivacaoCadastro": "",
+                    "MSG_ErroCodigo": "",
+                    "LoadingBotaoEntrar": True,
+                    "LoadingBotaoValidar": False,
+                    "FLG_AtivacaoCadastro": False,
+                    "FLG_ExibirSenha": False,
+                    "FLG_PopupAtivarConta": False,
+                    "FLG_VerificarCodigo": True,
+                    "WidgetIdFlare": "b4-b4-CfTurnstile",
+                    "VL_TentativasLogin": 0,
+                    "CD_01": "",
+                    "CD_02": "",
+                    "CD_03": "",
+                    "CD_04": "",
+                    "FLG_ativarConta": False,
+                    "_fLG_ativarContaInDataFetchStatus": 1,
+                    "token": "",
+                    "_tokenInDataFetchStatus": 1,
+                    "Email": "",
+                    "_emailInDataFetchStatus": 1,
+                }
+            },
+            "clientVariables": {"RL_Produtos": "", "NM_Usuario": ""},
+        }
+
+        res_login = self.session.post(url_login, json=payload_login)
+        dados_resposta = res_login.json()
+
+        if not dados_resposta.get("data", {}).get("FLG_Sucesso"):
+            logging.error("[cliente_fgv.py] Credenciais rejeitadas/login falhou.")
+            return None
+
+        url_redir = dados_resposta["data"]["URL_Gratuito"]
+        logging.info("[cliente_fgv.py] Acesso autorizado. Migrando para ASP.NET.")
+
+        headers_to_remove = [
+            "Content-Type",
+            "Accept",
+            "OutSystems-Client-Type",
+            "Origin",
+            "Referer",
+            "X-CSRFToken",
+        ]
+
+        # Limpeza de headers modernos para transição
+        for h in headers_to_remove:
+            self.session.headers.pop(h, None)
+        
+        return url_redir
+
+    def _buscar_serie_icst(self, url_redir: str) -> bool:
+        """
+        Acessa a página inicial do sistema legado, busca a série 'ICST'
+        e a seleciona contornando a validação de eventos do ASP.NET.
+        """
+
+        res_default = self.session.get(url_redir)
+        estados = self._extrair_estados(res_default.text)
+        url_base_default = "https://extra-ibre.fgv.br/IBRE/sitefgvdados/Default.aspx"
+
+        headers_ajax = {
+            "X-Requested-With": "XMLHttpRequest",
+            "X-MicrosoftAjax": "Delta=true",
+            "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+            "Cache-Control": "no-cache",
+            "Origin": "https://extra-ibre.fgv.br",
+            "Referer": url_base_default,
+        }
+
+        # Fluxo de Busca e Seleção (Bypass Event Validation)
+        logging.info("[cliente_fgv.py] Executando busca paramétrica...")
+        res_search = self.session.post(
+            url_base_default,
+            data={
+                "ctl00$smg": "ctl00$updpBuscarSeries|ctl00$butBuscarSeries",
+                "ctl00$drpFiltro": "E",
+                "ctl00$txtBuscarSeries": "ICST",
+                "__EVENTTARGET": "",
+                "__EVENTARGUMENT": "",
+                "__VIEWSTATE": estados["__VIEWSTATE"],
+                "__VIEWSTATEGENERATOR": estados["__VIEWSTATEGENERATOR"],
+                "__VIEWSTATEENCRYPTED": "",
+                "__ASYNCPOST": "true",
+                "ctl00$butBuscarSeries": "OK",
+            },
+            headers=headers_ajax,
+        )
+
+        delta_estados = self._extrair_estados_delta(res_search.text)
+        if delta_estados.get("__VIEWSTATE"):
+            estados.update(delta_estados)
+
+        if "ICST" not in res_search.text:
+            logging.error("[cliente_fgv.py] Série ICST não encontrada na busca.")
+            return False
+
+        self.session.post(
+            url_base_default,
+            data={
+                "ctl00$smg": "ctl00$updpBuscarSeries|ctl00$butBuscarSeriesOK",
+                "ctl00$drpFiltro": "E",
+                "ctl00$txtBuscarSeries": "ICST",
+                "ctl00$dlsSerie$ctl00$chkSerieEscolhida": "on",
+                "ctl00$dlsSerie$ctl01$chkSerieEscolhida": "on",
+                "__EVENTTARGET": "",
+                "__EVENTARGUMENT": "",
+                "__VIEWSTATE": estados["__VIEWSTATE"],
+                "__VIEWSTATEGENERATOR": estados["__VIEWSTATEGENERATOR"],
+                "__VIEWSTATEENCRYPTED": "",
+                "__ASYNCPOST": "true",
+                "ctl00$butBuscarSeriesOK": "OK",
+            },
+            headers=headers_ajax,
+        )
+        
+        return True
+
+    def _configurar_consulta(self) -> bool:
+        """
+        Navega para a página de consulta, seleciona a opção de série histórica
+        e submete o formulário para preparar o grid de visualização.
+        """
+
+        # Configuração da Visualização
+        logging.info("[cliente_fgv.py] Configurando parâmetros históricos...")
+        url_consulta = "https://extra-ibre.fgv.br/IBRE/sitefgvdados/consulta.aspx"
+        res_consulta = self.session.get(url_consulta)
+        estados = self._extrair_estados(res_consulta.text)
+
+        if "ICST" not in res_consulta.text:
+            logging.error("[cliente_fgv.py] Séries não persistidas na sessão.")
+            return False
+
+        headers_ajax_consulta = {
+            "X-Requested-With": "XMLHttpRequest",
+            "X-MicrosoftAjax": "Delta=true",
+            "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+            "Cache-Control": "no-cache",
+            "Origin": "https://extra-ibre.fgv.br",
+            "Referer": url_consulta,
+        }
+
+        res_radio = self.session.post(
+            url_consulta,
+            data={
+                "ctl00$smg": (
+                    "ctl00$cphConsulta$updpOpcoes|" "ctl00$cphConsulta$rbtSerieHistorica"
+                ),
+                "ctl00$drpFiltro": "E",
+                "ctl00$txtBuscarSeries": "",
+                "ctl00$cphConsulta$rblConsultaHierarquia": "COMPARATIVA",
+                "ctl00$cphConsulta$cpeLegenda_ClientState": "false",
+                "ctl00$cphConsulta$chkEscolhida": "on",
+                "ctl00$cphConsulta$dlsSerie$ctl00$chkSerieEscolhida": "on",
+                "ctl00$cphConsulta$dlsSerie$ctl01$chkSerieEscolhida": "on",
+                "ctl00$cphConsulta$gnResultado": "rbtSerieHistorica",
+                "ctl00$cphConsulta$txtMes": "__/__/____",
+                "ctl00$cphConsulta$mkeMes_ClientState": "",
+                "ctl00$cphConsulta$txtPeriodoInicio": "__/__/____",
+                "ctl00$cphConsulta$mkePeriodoInicio_ClientState": "",
+                "ctl00$cphConsulta$txtPeriodoFim": "__/__/____",
+                "ctl00$cphConsulta$mkePeriodoFim_ClientState": "",
+                "ctl00$txtBAPalavraChave": "",
+                "ctl00$rblTipoTexto": "E",
+                "ctl00$txtBAColuna": "",
+                "ctl00$txtBAIncluida": "",
+                "ctl00$txtBAAtualizada": "",
+                "__EVENTTARGET": "ctl00$cphConsulta$rbtSerieHistorica",
+                "__EVENTARGUMENT": "",
+                "__LASTFOCUS": "",
+                "__VIEWSTATE": estados["__VIEWSTATE"],
+                "__VIEWSTATEGENERATOR": estados["__VIEWSTATEGENERATOR"],
+                "__VIEWSTATEENCRYPTED": "",
+                "__ASYNCPOST": "true",
+            },
+            headers=headers_ajax_consulta,
+        )
+
+        delta_estados = self._extrair_estados_delta(res_radio.text)
+        if delta_estados.get("__VIEWSTATE"):
+            estados.update(delta_estados)
+
+        payload_viz = {
+            "ctl00$smg": (
+                "ctl00$updpAreaConsulta|" "ctl00$cphConsulta$butVisualizarResultado"
+            ),
+            "__EVENTTARGET": "",
+            "__EVENTARGUMENT": "",
+            "__LASTFOCUS": "",
+            "__VIEWSTATE": estados["__VIEWSTATE"],
+            "__VIEWSTATEGENERATOR": estados["__VIEWSTATEGENERATOR"],
+            "__VIEWSTATEENCRYPTED": "",
+            "ctl00$drpFiltro": "E",
+            "ctl00$txtBuscarSeries": "",
+            "ctl00$cphConsulta$rblConsultaHierarquia": "COMPARATIVA",
+            "ctl00$cphConsulta$cpeLegenda_ClientState": "false",
+            "ctl00$cphConsulta$chkEscolhida": "on",
+            "ctl00$cphConsulta$dlsSerie$ctl00$chkSerieEscolhida": "on",
+            "ctl00$cphConsulta$dlsSerie$ctl01$chkSerieEscolhida": "on",
+            "ctl00$cphConsulta$gnResultado": "rbtSerieHistorica",
+            "ctl00$cphConsulta$txtMes": "__/__/____",
+            "ctl00$cphConsulta$mkeMes_ClientState": "",
+            "ctl00$cphConsulta$txtPeriodoInicio": "__/__/____",
+            "ctl00$cphConsulta$mkePeriodoInicio_ClientState": "",
+            "ctl00$cphConsulta$txtPeriodoFim": "__/__/____",
+            "ctl00$cphConsulta$mkePeriodoFim_ClientState": "",
+            "ctl00$txtBAPalavraChave": "",
+            "ctl00$rblTipoTexto": "E",
+            "ctl00$txtBAColuna": "",
+            "ctl00$txtBAIncluida": "",
+            "ctl00$txtBAAtualizada": "",
+            "__ASYNCPOST": "true",
+            "ctl00$cphConsulta$butVisualizarResultado": "Visualizar e salvar",
+        }
+        if estados.get("__EVENTVALIDATION"):
+            payload_viz["__EVENTVALIDATION"] = estados["__EVENTVALIDATION"]
+
+        self.session.post(url_consulta, data=payload_viz, headers=headers_ajax_consulta)
+    
+        return True
+
+    def _baixar_e_parsear_csv(self) -> Optional[list[dict]]:
+        """
+        Acessa o frame de visualização, extrai as variáveis de estado do
+        DevExpress e emite a requisição final para download e parse do CSV.
+        """
+        url_consulta = "https://extra-ibre.fgv.br/IBRE/sitefgvdados/consulta.aspx"
+        url_visualiza = (
+            "https://extra-ibre.fgv.br/IBRE/sitefgvdados/visualizaconsulta.aspx"
+        )
+
+        # Preparação do grid de download
+        self.session.get(url_visualiza, headers={"Referer": url_consulta})
+
+        url_frame = (
+            "https://extra-ibre.fgv.br/IBRE/sitefgvdados/" "VisualizaConsultaFrame.aspx"
+        )
+        res_frame = self.session.get(url_frame, headers={"Referer": url_visualiza})
+
+        if "ICST" not in res_frame.text:
+            logging.error("[cliente_fgv.py] Componentes DevExpress falharam.")
+            return None
+
+        estados_frame = self._extrair_estados(res_frame.text)
+
+        payload_download = {
+            "__EVENTTARGET": "lbtSalvarCSV",
+            "__EVENTARGUMENT": "",
+            "__VIEWSTATE": estados_frame["__VIEWSTATE"],
+            "__VIEWSTATEGENERATOR": estados_frame["__VIEWSTATEGENERATOR"],
+        }
+        if estados_frame.get("__EVENTVALIDATION"):
+            payload_download["__EVENTVALIDATION"] = estados_frame["__EVENTVALIDATION"]
+
+        # Campos opcionais do DevExpress grid
+        regexes_dx = [
+            ("xgdvConsulta", r'name="xgdvConsulta"[^>]*value="(.*?)"'),
+            ("DXScript", r'name="DXScript"[^>]*value="(.*?)"'),
+            ("DXCss", r'name="DXCss"[^>]*value="(.*?)"'),
+        ]
+
+        for campo, regex in regexes_dx:
+            match = re.search(regex, res_frame.text)
+            if match:
+                payload_download[campo] = html.unescape(match.group(1))
+
+        # Download do CSV
+        logging.info("[cliente_fgv.py] Emitindo solicitação final de extração...")
+        res_csv = self.session.post(
+            url_frame,
+            data=payload_download,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Accept": (
+                    "text/html,application/xhtml+xml,application/xml;" "q=0.9,*/*;q=0.8"
+                ),
+                "Origin": "https://extra-ibre.fgv.br",
+                "Referer": url_frame,
+            },
+        )
+
+        content_type = res_csv.headers.get("Content-Type", "").lower()
+        is_valid_type = (
+            "text/csv" in content_type or "application/octet-stream" in content_type
+        )
+
+        if res_csv.status_code == 200 and is_valid_type:
+            try:
+                df = pd.read_csv(
+                    io.BytesIO(res_csv.content),
+                    sep=";",
+                    encoding="latin1",
+                    header=0,
+                    names=["mes", "icst_com_ajuste_sazonal", "icst_sem_ajuste_sazonal"],
+                )
+
+                # Adiciona data de ingestão
+                df["dt_ingest"] = datetime.now().isoformat()
+
+                # Converte valores pd.NA/NaN para None (NULL do Postgres)
+                df = df.where(pd.notnull(df), None)
+
+                registros = df.to_dict(orient="records")
+
+                logging.info(
+                    f"[cliente_fgv.py] Extração concluída. "
+                    f"DataFrame construído com {len(df)} registros."
+                )
+                return registros
+            except Exception as e:
+                logging.error(f"[cliente_fgv.py] Falha no parser do Pandas: {e}")
+                return None
+        else:
+            logging.error(
+                f"[cliente_fgv.py] Falha na extração. "
+                f"HTTP {res_csv.status_code} | Type: {content_type}"
+            )
+            return None
+
+    def fetch_icst_historico(self) -> Optional[list[dict]]:
+        """
+        Orquestrador do fluxo completo de autenticação e raspagem do CSV
+        da série histórica (ICST).
+
+        Returns:
+            Lista de dicionários contendo dados brutos em sucesso,
+            ou None em falha.
+        """
+        hashes_dinamicas = self._obter_versoes_outsystems()
+
+        url_redir = self._autenticar(hashes_dinamicas)
+        if not url_redir:
+            return None
+
+        if not self._buscar_serie_icst(url_redir):
+            return None
+
+        if not self._configurar_consulta():
+            return None
+
+        return self._baixar_e_parsear_csv()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ dbt-postgres==1.7.13
 imap-tools==1.10.0
 zeep==4.3.1
 apache-airflow-providers-microsoft-mssql==3.7.2
+openpyxl>=3.1.0


### PR DESCRIPTION
## Descrição

Implementa a ingestão das séries temporais do BACEN SGS para financiamentos imobiliários, consumindo a API REST pública sem autenticação.

### Arquivos adicionados
- `airflow_lappis/plugins/cliente_bacen.py`
- `airflow_lappis/dags/data_ingest/bacen/bacen_financiamentos_imobiliarios_historico_ingest_dag.py`
- `airflow_lappis/dags/data_ingest/bacen/bacen_financiamentos_imobiliarios_trimestral_ingest_dag.py`

### Séries ingeridas

| Código | Coluna | Segmento |
|---|---|---|
| 20704 | pf_concessoes_rs_mi | PF |
| 20774 | pf_taxa_juros_aa | PF |
| 21151 | pf_inadimplencia_pct | PF |
| 20692 | pj_concessoes_rs_mi | PJ |
| 20763 | pj_taxa_juros_aa | PJ |
| 21139 | pj_inadimplencia_pct | PJ |

### Decisões técnicas
- Cliente genérico — recebe `{codigo_sgs: "nome_coluna"}`, sem conhecimento das séries. Novas séries do BACEN podem ser ingeridas criando uma nova DAG sem modificar o cliente
- DataFrame flat com uma linha por mês — sem coluna `segmento`, colunas prefixadas por `pf_` e `pj_`
- DAG histórica com `schedule_interval=None` — execução manual única desde 01/03/2011
- DAG trimestral com schedule dinâmico — puxa o trimestre anterior completo
- Tratamento de exceções do Airflow: `AirflowFailException` para falha na API, `AirflowSkipException` quando BACEN ainda não publicou o trimestre

### Tabela destino
`bacen.financiamentos_imobiliarios`
