### PR TITLE
feat: automatiza setup local do Airflow com make dev e validação

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,27 @@
 export PYTHONPATH := $(CURDIR)/airflow_lappis
 export MYPYPATH := $(CURDIR):$(CURDIR)/airflow_lappis/dags:$(CURDIR)/airflow_lappis/helpers:$(CURDIR)/airflow_lappis/plugins
 
+AIRFLOW_SERVICE ?= airflow
+AIRFLOW_LOCAL_ORGAO ?= ipea
+AIRFLOW_LOCAL_DB_HOST ?= postgres
+AIRFLOW_LOCAL_DB_NAME ?= postgres
+AIRFLOW_LOCAL_DB_USER ?= postgres
+AIRFLOW_LOCAL_DB_PASSWORD ?= postgres
+AIRFLOW_LOCAL_DB_PORT ?= 5432
+
 setup:
 	@if ! command -v poetry >/dev/null 2>&1; then \
 		echo "Poetry não encontrado. Instale antes com pipx install poetry==1.8.5"; \
 		exit 1; \
+	fi
+	@if [ ! -f .env ]; then \
+		if [ -f local.env ]; then \
+			cp local.env .env; \
+			echo ".env criado a partir de local.env"; \
+		else \
+			echo "local.env não encontrado. Crie o .env manualmente."; \
+			exit 1; \
+		fi; \
 	fi
 	poetry self add poetry-plugin-export || true
 	poetry config virtualenvs.in-project false
@@ -12,6 +29,9 @@ setup:
 	poetry install --no-root --with dev
 	poetry export --without-hashes --format=requirements.txt > requirements.generated.txt
 	bash setup-git-hooks.sh
+	docker compose up -d --build
+	$(MAKE) dev
+	$(MAKE) dev-check
 
 format:
 	poetry run black .
@@ -31,3 +51,21 @@ lint-ci:
 
 test:
 	poetry run pytest tests
+
+dev:
+	@docker compose ps --status running $(AIRFLOW_SERVICE) >/dev/null 2>&1 || (echo "Serviço '$(AIRFLOW_SERVICE)' não está em execução. Rode: docker compose up -d" && exit 1)
+	@echo "Aguardando Airflow/DB ficarem prontos..."
+	@docker compose exec -T $(AIRFLOW_SERVICE) sh -c 'for i in $$(seq 1 30); do airflow db init >/dev/null 2>&1 && exit 0; sleep 2; done; echo "Airflow DB não ficou pronto a tempo para inicializar."; exit 1'
+	@docker compose exec -T $(AIRFLOW_SERVICE) airflow variables set airflow_orgao '$(AIRFLOW_LOCAL_ORGAO)'
+	@docker compose exec -T $(AIRFLOW_SERVICE) airflow variables set airflow_variables '{"ipea":{"codigos_ug":[113601,113602]},"unb":{"codigos_ug":[154040]},"ibama":{"codigos_ug":[440001,440048,440050]},"mgi":{"codigos_ug":[201082]}}'
+	@docker compose exec -T $(AIRFLOW_SERVICE) airflow variables set dynamic_schedules '{"empenhos_tesouro_ingest_dag":{"type":"cron","value":"0 13 * * 1-6"},"nc_tesouro_ingest_dag":{"type":"cron","value":"0 13 * * 1-6"},"pf_tesouro_ingest_dag":{"type":"cron","value":"0 13 * * 1-6"},"visao_orcamentaria_ingest":{"type":"cron","value":"0 13 * * 1-6"}}'
+	@docker compose exec -T $(AIRFLOW_SERVICE) sh -c "printf '%s\n' '{\"postgres_default\":{\"conn_type\":\"postgres\",\"host\":\"$(AIRFLOW_LOCAL_DB_HOST)\",\"schema\":\"$(AIRFLOW_LOCAL_DB_NAME)\",\"login\":\"$(AIRFLOW_LOCAL_DB_USER)\",\"password\":\"$(AIRFLOW_LOCAL_DB_PASSWORD)\",\"port\":$(AIRFLOW_LOCAL_DB_PORT)}}' > /tmp/airflow-connections.json && airflow connections import --overwrite /tmp/airflow-connections.json && rm -f /tmp/airflow-connections.json"
+	@echo "Ambiente local do Airflow configurado com sucesso."
+
+dev-check:
+	@docker compose ps --status running $(AIRFLOW_SERVICE) >/dev/null 2>&1 || (echo "Serviço '$(AIRFLOW_SERVICE)' não está em execução. Rode: docker compose up -d" && exit 1)
+	@docker compose exec -T $(AIRFLOW_SERVICE) airflow variables get airflow_orgao >/dev/null
+	@docker compose exec -T $(AIRFLOW_SERVICE) airflow variables get airflow_variables >/dev/null
+	@docker compose exec -T $(AIRFLOW_SERVICE) airflow variables get dynamic_schedules >/dev/null
+	@docker compose exec -T $(AIRFLOW_SERVICE) airflow connections get postgres_default >/dev/null
+	@echo "Validação concluída: variables e connection do Airflow estão configuradas."


### PR DESCRIPTION
### Contexto
O setup local do Airflow exigia etapas manuais no painel (Variables e Connection), gerando retrabalho e risco de inconsistência entre ambientes de desenvolvimento.
### Ambiente de validação
- Sistema operacional utilizado: **Ubuntu 24**.
### O que foi feito
- Adicionado fluxo automatizado no `Makefile` para configuração local do Airflow.
- Criado `make dev` para:
  - garantir inicialização do metadata DB do Airflow;
  - configurar variables necessárias (`airflow_orgao`, `airflow_variables`, `dynamic_schedules`);
  - atualizar a connection `postgres_default` com parâmetros locais padrão.
- Criado `make dev-check` para validar se variables e connection foram aplicadas.
- Ajustado `make setup` para:
  - criar `.env` a partir de `local.env` quando necessário;
  - subir os containers (`docker compose up -d --build`);
  - encadear `make dev` e `make dev-check`.
### Benefícios
- Reduz setup manual no Airflow UI.
- Deixa o ambiente local mais reproduzível e idempotente.
- Diminui tempo de onboarding e chance de erro de configuração.
### Como testar
1. Executar `make setup`.
2. Verificar sucesso das etapas `dev` e `dev-check`.
3. Acessar o Airflow e confirmar:
   - Variables criadas;
   - connection `postgres_default` configurada para ambiente local.
### Observações
- Valores padrão mantidos para ambiente local:
  - host: `postgres`
  - database: `postgres`
  - user: `postgres`
  - password: `postgres`
  - port: `5432`

Closes #255