### PR TITLE
Feat/resumo orcamentario ted

### DIFF
--- a/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/gold/schema.yml
+++ b/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/gold/schema.yml
@@ -1,0 +1,103 @@
+version: 2
+
+models:
+
+  - name: ted_resumo_orcamentario
+    description: >
+      Tabela gold de consolidação orçamentária e financeira por Plano de Ação TED do MIR.
+      Agrega em uma única linha por (plano_acao, num_transf) os valores provenientes de
+      quatro fontes distintas: o valor total pactuado no plano (TransfereGov), os créditos
+      orçamentários descentralizados via Notas de Crédito (SIAFI), os empenhos registrados
+      nas Notas de Empenho (SIAFI) e os recursos financeiros liberados via Programações
+      Financeiras (SIAFI + TransfereGov). As quatro dimensões são combinadas via FULL JOIN
+      para garantir que nenhum registro seja perdido mesmo que exista em apenas uma fonte.
+      O campo ted_beneficiario_emitente é sempre 'nao_indicado' pois a fonte bronze
+      planos_acao_ted não disponibiliza essa informação para o MIR.
+    meta:
+      tags:
+        - gold
+    columns:
+      - name: plano_acao
+        description: >
+          Identificador único do Plano de Ação no TransfereGov. Chave primária junto com num_transf.
+      - name: num_transf
+        description: >
+          Número da transferência TED — o elo entre os sistemas SIAFI e TransfereGov.
+          É o campo que conecta NCs, NEs e PFs do SIAFI ao Plano de Ação correspondente.
+      - name: sigla_unidade_descentralizada
+        description: >
+          Sigla da unidade receptora dos recursos, conforme cadastrado no Plano de Ação do TransfereGov.
+      - name: ted_beneficiario_emitente
+        description: >
+          Indica se a unidade do Plano de Ação é beneficiária ou emitente da TED.
+          Sempre 'nao_indicado' para o MIR, pois a fonte bronze não disponibiliza esse campo.
+      - name: valor_firmado
+        description: >
+          Valor total pactuado no Plano de Ação (vl_total_plano_acao), conforme o registro
+          mais recente no TransfereGov. Representa o compromisso financeiro acordado.
+      - name: orcamento_recebido
+        description: >
+          Soma dos valores de Notas de Crédito recebidas (eventos que não são 300301/300307),
+          representando o crédito orçamentário efetivamente descentralizado para o MIR.
+      - name: orcamento_devolvido
+        description: >
+          Soma dos valores de Notas de Crédito de eventos 300301 e 300307,
+          representando crédito orçamentário devolvido ao órgão concedente.
+      - name: empenhado
+        description: >
+          Soma dos valores positivos de despesas_empenhadas — empenhos formalizados,
+          excluindo anulações.
+      - name: empenho_anulado
+        description: >
+          Soma dos valores absolutos das despesas_empenhadas negativas — empenhos
+          cancelados ou revertidos após a emissão.
+      - name: despesas_pagas_exercicio
+        description: >
+          Total de despesas pagas no exercício corrente, proveniente do campo
+          despesas_pagas das Notas de Empenho.
+      - name: despesas_pagas_rap
+        description: >
+          Total de despesas pagas via Restos a Pagar (exercícios anteriores),
+          proveniente de restos_a_pagar_pagos das Notas de Empenho.
+      - name: restos_a_pagar
+        description: >
+          Valor total inscrito como Restos a Pagar — despesas empenhadas e não
+          pagas até o encerramento do exercício fiscal.
+      - name: despesas_liquidada
+        description: >
+          Soma das despesas liquidadas — despesas com bens ou serviços
+          efetivamente entregues e atestados.
+      - name: financeiro_recebido
+        description: >
+          Soma dos valores de Programações Financeiras com ação 'TRANSFERENCIA',
+          representando os recursos financeiros efetivamente recebidos pelo MIR.
+      - name: financeiro_devolvido
+        description: >
+          Soma dos valores de Programações Financeiras com ação 'DEVOLUCAO',
+          representando recursos financeiros devolvidos ao concedente.
+      - name: financeiro_cancelado
+        description: >
+          Soma dos valores de Programações Financeiras com ação 'CANCELAMENTO',
+          representando programações canceladas antes de seu processamento.
+      - name: dt_ingest
+        description: >
+          Timestamp mais recente de ingestão entre todas as fontes que compõem o registro
+          (planos_acao_ted, nc_plano_acao, empenhos_por_plano_acao, pf_unificado).
+          Indica quando os dados foram atualizados pela última vez (UTC-3).
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.ted_resumo_orcamentario'
+          nome_coluna: 'plano_acao'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.ted_resumo_orcamentario'
+          nome_coluna: 'valor_firmado'
+          tipo_esperado: 'numeric'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.ted_resumo_orcamentario'
+          nome_coluna: 'empenhado'
+          tipo_esperado: 'numeric'
+      - verificacao_tipagem:
+          nome_tabela: 'siafi_dbt.ted_resumo_orcamentario'
+          nome_coluna: 'dt_ingest'
+          tipo_esperado: 'timestamp with time zone'

--- a/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/gold/schema.yml
+++ b/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/gold/schema.yml
@@ -11,8 +11,6 @@ models:
       nas Notas de Empenho (SIAFI) e os recursos financeiros liberados via Programações
       Financeiras (SIAFI + TransfereGov). As quatro dimensões são combinadas via FULL JOIN
       para garantir que nenhum registro seja perdido mesmo que exista em apenas uma fonte.
-      O campo ted_beneficiario_emitente é sempre 'nao_indicado' pois a fonte bronze
-      planos_acao_ted não disponibiliza essa informação para o MIR.
     meta:
       tags:
         - gold
@@ -27,10 +25,6 @@ models:
       - name: sigla_unidade_descentralizada
         description: >
           Sigla da unidade receptora dos recursos, conforme cadastrado no Plano de Ação do TransfereGov.
-      - name: ted_beneficiario_emitente
-        description: >
-          Indica se a unidade do Plano de Ação é beneficiária ou emitente da TED.
-          Sempre 'nao_indicado' para o MIR, pois a fonte bronze não disponibiliza esse campo.
       - name: valor_firmado
         description: >
           Valor total pactuado no Plano de Ação (vl_total_plano_acao), conforme o registro
@@ -84,6 +78,25 @@ models:
           Timestamp mais recente de ingestão entre todas as fontes que compõem o registro
           (planos_acao_ted, nc_plano_acao, empenhos_por_plano_acao, pf_unificado).
           Indica quando os dados foram atualizados pela última vez (UTC-3).
+      - name: sigla_unidade_responsavel_acompanhamento
+        description: >
+          Sigla da unidade responsável pelo acompanhamento do programa, proveniente
+          de programas_ted (TransfereGov).
+      - name: tx_nome_institucional_programa
+        description: >
+          Nome institucional do programa ao qual o Plano de Ação está vinculado,
+          proveniente de programas_ted (TransfereGov).
+      - name: tx_objetivo_programa
+        description: >
+          Descrição do objetivo do programa, proveniente de programas_ted (TransfereGov).
+      - name: programa_governo
+        description: >
+          Código do programa de governo conforme classificação orçamentária SIAFI,
+          proveniente de nc_plano_acao.
+      - name: programa_governo_descricao
+        description: >
+          Descrição do programa de governo conforme classificação orçamentária SIAFI,
+          proveniente de nc_plano_acao.
     tests:
       - verificacao_tipagem:
           nome_tabela: 'siafi_dbt.ted_resumo_orcamentario'

--- a/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/gold/ted_resumo_orcamentario.sql
+++ b/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/gold/ted_resumo_orcamentario.sql
@@ -1,0 +1,131 @@
+{{ config(materialized="table") }}
+
+with
+	planos_acao_deduplicado as (
+		select
+			id_plano_acao,
+			sq_instrumento as num_transf,
+			sigla_unidade_descentralizada,
+			vl_total_plano_acao,
+			dt_ingest as dt_ingest_plano_acao
+		from (
+			select
+				pa.*,
+				row_number() over (
+					partition by pa.id_plano_acao
+					order by pa.dt_ingest desc
+				) as rn
+			from {{ ref("planos_acao_ted") }} pa
+		) pa_filtrado
+		where rn = 1
+	),
+
+	valor_firmado_tb as (
+		select
+			id_plano_acao as plano_acao,
+			num_transf,
+			vl_total_plano_acao as valor_firmado,
+			sigla_unidade_descentralizada,
+			dt_ingest_plano_acao as dt_ingest_vf
+		from planos_acao_deduplicado
+	),
+
+	valores_orcamentos_tb as (
+		select
+			id_plano_acao as plano_acao,
+			nc_transferencia as num_transf,
+			sum(
+				case
+					when nc_evento in ('300301', '300307') then 0
+					else valor_celula
+				end
+			) as orcamento_recebido,
+			sum(
+				case
+					when nc_evento in ('300301', '300307') then valor_celula
+					else 0
+				end
+			) as orcamento_devolvido,
+			max(dt_ingest) as dt_ingest_vo
+		from {{ ref("nc_plano_acao") }}
+		where ptres not in ('-9')
+		group by id_plano_acao, nc_transferencia
+	),
+
+	valores_empenhados_tb as (
+		select
+			plano_acao,
+			num_transf,
+			sum(
+				case when despesas_empenhadas > 0 then despesas_empenhadas else 0 end
+			) as empenhado,
+			sum(
+				case when despesas_empenhadas < 0 then -despesas_empenhadas else 0 end
+			) as empenho_anulado,
+			sum(despesas_pagas) as despesas_pagas_exercicio,
+			sum(restos_a_pagar_pagos) as despesas_pagas_rap,
+			sum(restos_a_pagar_inscritos) as restos_a_pagar,
+			sum(despesas_liquidadas) as despesas_liquidada,
+			max(dt_ingest) as dt_ingest_ve
+		from {{ ref("empenhos_por_plano_acao") }}
+		group by plano_acao, num_transf
+	),
+
+	valores_financeiro_tb as (
+		select
+			id_plano_acao as plano_acao,
+			pf_inscricao as num_transf,
+			sum(
+				case
+					when substring(pf_acao_descricao, '(\w+) ') = 'TRANSFERENCIA'
+					then pf_valor_linha
+					else 0
+				end
+			) as financeiro_recebido,
+			sum(
+				case
+					when substring(pf_acao_descricao, '(\w+) ') = 'DEVOLUCAO'
+					then pf_valor_linha
+					else 0
+				end
+			) as financeiro_devolvido,
+			sum(
+				case
+					when substring(pf_acao_descricao, '(\w+) ') = 'CANCELAMENTO'
+					then pf_valor_linha
+					else 0
+				end
+			) as financeiro_cancelado,
+			max(dt_ingest) as dt_ingest_vfin
+		from {{ ref("pf_unificado") }}
+		group by id_plano_acao, pf_inscricao
+	),
+
+	join_parcial as (
+		select
+			*,
+			greatest(vo.dt_ingest_vo, ve.dt_ingest_ve, vfin.dt_ingest_vfin) as dt_ingest_jp
+		from valores_orcamentos_tb vo
+		full join valores_empenhados_tb ve using (plano_acao, num_transf)
+		full join valores_financeiro_tb vfin using (plano_acao, num_transf)
+	)
+
+select
+	plano_acao,
+	num_transf,
+	valor_firmado,
+	orcamento_recebido,
+	orcamento_devolvido,
+	empenhado,
+	empenho_anulado,
+	despesas_pagas_exercicio,
+	despesas_pagas_rap,
+	restos_a_pagar,
+	despesas_liquidada,
+	financeiro_recebido,
+	financeiro_devolvido,
+	financeiro_cancelado,
+	greatest(vf.dt_ingest_vf, jp.dt_ingest_jp) as dt_ingest
+from valor_firmado_tb vf
+full join join_parcial jp using (plano_acao, num_transf)
+where (plano_acao is not null) or (num_transf is not null)

--- a/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/gold/ted_resumo_orcamentario.sql
+++ b/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/gold/ted_resumo_orcamentario.sql
@@ -4,6 +4,7 @@ with
 	planos_acao_deduplicado as (
 		select
 			id_plano_acao,
+			id_programa,
 			sq_instrumento as num_transf,
 			sigla_unidade_descentralizada,
 			vl_total_plano_acao,
@@ -18,6 +19,16 @@ with
 			from {{ ref("planos_acao_ted") }} pa
 		) pa_filtrado
 		where rn = 1
+	),
+
+	programas_tb as (
+		select
+			pad.id_plano_acao,
+			prog.sigla_unidade_responsavel_acompanhamento,
+			prog.tx_nome_institucional_programa,
+			prog.tx_objetivo_programa
+		from planos_acao_deduplicado pad
+		left join {{ ref("programas_ted") }} prog using (id_programa)
 	),
 
 	valor_firmado_tb as (
@@ -46,6 +57,8 @@ with
 					else 0
 				end
 			) as orcamento_devolvido,
+			max(programa_governo) as programa_governo,
+			max(programa_governo_descricao) as programa_governo_descricao,
 			max(dt_ingest) as dt_ingest_vo
 		from {{ ref("nc_plano_acao") }}
 		where ptres not in ('-9')
@@ -113,6 +126,7 @@ with
 select
 	plano_acao,
 	num_transf,
+	sigla_unidade_descentralizada,
 	valor_firmado,
 	orcamento_recebido,
 	orcamento_devolvido,
@@ -125,7 +139,13 @@ select
 	financeiro_recebido,
 	financeiro_devolvido,
 	financeiro_cancelado,
-	greatest(vf.dt_ingest_vf, jp.dt_ingest_jp) as dt_ingest
+	greatest(vf.dt_ingest_vf, jp.dt_ingest_jp) as dt_ingest,
+	prog.sigla_unidade_responsavel_acompanhamento,
+	prog.tx_nome_institucional_programa,
+	prog.tx_objetivo_programa,
+	jp.programa_governo,
+	jp.programa_governo_descricao
 from valor_firmado_tb vf
 full join join_parcial jp using (plano_acao, num_transf)
+left join programas_tb prog on plano_acao = prog.id_plano_acao
 where (plano_acao is not null) or (num_transf is not null)

--- a/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/views/num_transf_n_plano_acao.sql
+++ b/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/views/num_transf_n_plano_acao.sql
@@ -29,8 +29,38 @@ with
                 order by case when plano_acao is not null then 1 else 2 end
             ) as rn
         from joined
+    ),
+
+    via_nc as (
+        select num_transf, plano_acao
+        from ranked
+        where rn = 1
+    ),
+
+    via_sq_instrumento as (
+        select
+            sq_instrumento as num_transf,
+            id_plano_acao::text as plano_acao
+        from {{ ref("planos_acao_ted") }}
+        where sq_instrumento is not null
+    ),
+
+    unificado as (
+        select * from via_nc
+        union
+        select * from via_sq_instrumento
+    ),
+
+    final as (
+        select
+            *,
+            row_number() over (
+                partition by num_transf
+                order by case when plano_acao is not null then 1 else 2 end
+            ) as rn
+        from unificado
     )
 
 select num_transf, plano_acao
-from ranked
+from final
 where rn = 1

--- a/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/views/schema.yml
+++ b/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/views/schema.yml
@@ -4,25 +4,34 @@ models:
 
   - name: num_transf_n_plano_acao
     description: >
-      View de mapeamento entre o número de transferência do SIAFI (num_transf / nc_transferencia)
+      View de mapeamento entre o número de transferência do SIAFI (num_transf)
       e o identificador do Plano de Ação do TransfereGov (plano_acao / id_plano_acao).
       É a ponte central que conecta os dois sistemas.
 
-      O cruzamento é feito via Notas de Crédito: o SIAFI registra a NC com nc_transferencia
-      e o TransfereGov registra a mesma NC com id_plano_acao. A correspondência é feita
-      pela chave composta (nc, ug_emitente).
+      O mapeamento é construído por dois caminhos complementares, depois unificados via UNION:
+
+      1. Via NC: cruza nc_tesouro_mir (SIAFI) com transfere_gov.notas_de_credito pela chave
+         composta (nc, ug_emitente). Quando a mesma Nota de Crédito aparece nos dois sistemas,
+         o id_plano_acao do TransfereGov é associado ao nc_transferencia do SIAFI.
+
+      2. Via sq_instrumento: lê planos_acao_ted diretamente, onde o campo sq_instrumento
+         já contém o num_transf. Captura planos que ainda não têm NC emitida ou cujas NCs
+         não cruzam pelo caminho 1.
+
+      Quando o mesmo num_transf aparece nos dois caminhos com plano_acao distintos,
+      um row_number prioriza o registro com plano_acao não-nulo.
     meta:
       tags:
         - view
     columns:
       - name: num_transf
         description: >
-          Número da transferência TED conforme registrado no SIAFI (nc_transferencia).
-          Chave de entrada — é o identificador que NCs, NEs e PFs usam para referenciar
-          uma transferência específica.
+          Número da transferência TED conforme registrado no SIAFI (nc_transferencia)
+          ou no TransfereGov (sq_instrumento). Chave de entrada usada por NCs, NEs e PFs
+          para referenciar uma transferência específica.
       - name: plano_acao
         description: >
-          Identificador do Plano de Ação no TransfereGov (id_plano_acao), obtido via
-          cruzamento da NC entre SIAFI e TransfereGov. Pode ser nulo quando a NC do SIAFI
-          não possui correspondência no TransfereGov. Tipo text na view — consumidores
-          devem fazer cast para integer conforme necessário.
+          Identificador do Plano de Ação no TransfereGov (id_plano_acao). Pode ser nulo
+          quando o num_transf do SIAFI não possui correspondência em nenhum dos dois caminhos
+          de cruzamento. Tipo text na view — consumidores devem fazer cast para integer
+          conforme necessário.


### PR DESCRIPTION
- **Criação da camada gold `ted_resumo_orcamentario`**: Tabela de consolidação orçamentária e financeira por Plano de Ação TED do MIR.
- **Extensão da view `num_transf_n_plano_acao`**: Adicionado segundo caminho de mapeamento via `sq_instrumento`.
- **Correção do `schema.yml` gold**: Ajuste para refletir as colunas reais do modelo e remoção de campos obsoletos.

## [Diagrama](https://mermaid.live/edit#pako:eNrtWN2K20YUfhUxIbBLJ1uNJOtvoeBZ28sWsyEo3ULlRUyksVdEnnFH0ibdZaFXfYDSFyi9bZ8ib5In6ciSNbIdCrloI0GFsa2j0ej7zv_RI4h5QoEPlhl_F98RUWivJ1rfjwWrf58_12acFTTX6PuCCkbyngMOUHiSp2SZLhaM0Ugi56Xgp7c9RmyEJ4UgLF9SQaMVv5fINxlhPI9ITPoEvUVsfgKx4CtB1iTvlapbxFbHK-KdV0TrVJzetmtstWazHITnOJ-wg0S-E3W4uXvcNoWgeR-Zdbh5x9wYL0geJTSKBU3Sgit-gzk6eRULzh5oR4ZRSNcbyu5k5O88tKBJSxIbYScv7F8ywzYAtxf6zh9b4X4cKip2qKLvdgCmxE7YDTpFxA13oSZlHcPfpPTdcDw1L99Iv9rcaTdX0-_DBfj45-8aK9cN4YhFW5_cuqSmndxLbqcLsBeYSSpoXKScaa9x7-lWx831hSR6n5KIxUcFQ_v25dW1dpiKqrzKhcZi7SutXMmzj7_82lET1JSWDrRzE7xqHpb_GKUsL0S5pqzecT_az44W_OND_l0dfXd9JWHL75fX2-qfcpE-kA4CjX34Q36V2Rbobz9_7kfelZMPfyXE_w8oHlhfe_Him4qhNgx3DV4NBzBlybAq9RBbiyDN7qloW6k5qoptydJlGpOE9745COZGBViFuupj52ZVVBUVdcFSzZPMxPs3d1RzybNkOLa8RKFM_JFsIco1j7iISZX6icy2g259m1cKVfmqu2A1vW8zGUZqOK4Fhpo9a4GpRrtaYKk5rhbYakyqBc5QNBS4NWB3-Db-uplyKlNXfa_q_7cUZa1VA9-hBNe2l-VtL4I7O-7nuWZPme5UC76TDMXyc9Qgbh2-quqNaBgcsN3gNbsz0k6mht1GYh0TtYZfe-UY0PHTqugcePUlGgonbCrAnQrdCDuV-UhiHUiGaM5pXqQZz3eSOCN5PqFLrZoHY6ot0yzzn5mOhUYIytGMv6X-Mxs7hqvDmGdc-M9m3mw8w1-KQgv4Te2ONWDHNUf6rAWMrZGpey3g6cy8cI4Z145db4Cm5nikNjCxa8zs3QYTPB3Ppl-c8apu9RrGyJwhowV8MXbHutVh7F2YRxvc1y9qGsbEoIi0G1jjyVTZGOOZM9H_H1E-x0Sy2YOBAQMTBhYMbBg4MHChbAPq0DrvIWKMIDYgNiG2ILYhdqDsMOrAOu-hfudSwXOp4blUsUzGdQCf99gjZI1ZdUplLZQdIZQ9IKz6gyoiz3vs2N0DQLASaQL8QpQUgjUVa1Kdgsdq9QIUd3RNF8CXfxMi3i7Agj3JezaE_cD5eneb4OXqDvhLkuXyrNwkpKCTlFSv-tsllCVUXPCSFcBHCG33AP4jeA981zpDHvIMz0W2retoBMFPwDf0M0d3LHfk2cgxPMdwniB42D5VP3M9pFumYY0czzBd13v6G9hsm7w)
---

## 1. Nova Tabela: `ted_resumo_orcamentario` (Gold)

Esta tabela agrega em uma única linha por `(plano_acao, num_transf)` quatro dimensões financeiras de fontes distintas. Foi utilizado **FULL JOIN** para garantir a integridade dos dados, mesmo que o registro exista em apenas uma das fontes.

### Detalhamento das CTEs

| CTE | Fonte | Descrição / Campos Gerados |
| :--- | :--- | :--- |
| **planos_acao_deduplicado** | `planos_acao_ted` | Deduplica por `id_plano_acao` (mais recente). Extrai `sq_instrumento` como `num_transf`, `sigla_unidade_descentralizada` e `valor_firmado`. |
| **programas_tb** | `planos_acao_deduplicado` + `programas_ted` | Gera: `sigla_unidade_responsavel_acompanhamento`, `tx_nome_institucional_programa` e `tx_objetivo_programa`. |
| **valor_firmado_tb** | `planos_acao_deduplicado` | `valor_firmado`: Valor total pactuado no Plano de Ação. |
| **valores_orcamentos_tb** | `nc_plano_acao` | Orçamentos recebidos/devolvidos (filtrando eventos e excluindo PTRES -9). Gera `programa_governo`. |
| **valores_empenhados_tb** | `empenhos_por_plano_acao` | Valores empenhados, anulados, liquidados e pagos (Exercício e RAP). |
| **valores_financeiro_tb** | `pf_unificado` | Financeiro recebido, devolvido e cancelado (via `pf_unificado`). |
| **join_parcial** | *Join de valores* | Consolida Orçamento + Empenho + Financeiro via FULL JOIN. |

> **Lógica Final:** `valor_firmado_tb` FULL JOIN `join_parcial` LEFT JOIN `programas_tb`.
> **Filtro:** Mantém registros onde `plano_acao` ou `num_transf` não são nulos.

---

## 2. Extensão da View: `num_transf_n_plano_acao`

Adição do caminho `via_sq_instrumento` para o mapeamento `num_transf` → `plano_acao`.

* **Cenário Anterior:** Dependia exclusivamente da `via_nc` (cruzamento de notas de crédito com SIAFI).
* **Novo Cenário:** Realiza um `UNION` com a leitura direta do `sq_instrumento`. Isso permite capturar planos que ainda não possuem NC emitida, sq_instrumento = numero_transferencia.
* **Tratamento de Conflitos:** Utilização de `ROW_NUMBER` para priorizar registros com `plano_acao` preenchido em caso de duplicidade no `num_transf`.

---

## 3. Correção: `gold/schema.yml`

- **Remoção:** Coluna `ted_beneficiario_emitente` (campo inexistente no modelo final).
- **Inclusão:** Adicionadas 5 colunas faltantes para documentação e testes:
    - `sigla_unidade_responsavel_acompanhamento`
    - `tx_nome_institucional_programa`
    - `tx_objetivo_programa`
    - `programa_governo`
    - `programa_governo_descricao`

---

## 4. Linhagem de Dados

```text
siafi.ne_tesouro ─────────────► empenhos_tesouro_ted ────────► empenhos_por_plano_acao ──┐
                                                                                         │
siafi.nc_tesouro_mir ─┐                                                                  │
siafi.pf_ptres ───────┴───────► nc_unificado ─┐                                          │
                                              ├──────────────► num_transf_n_plano_acao ──┤
transfere_gov.notas_de_credito ───────────────┘                                          │
                                              ┌──────────────► nc_plano_acao ────────────┤
[nc_unificado + num_transf_n_plano_acao] ─────┘                                          ├───► ted_resumo_orcamentario
                                                                                         │
siafi.pf_tesouro ─────────────┐                                                          │
transfere_gov.pf_transfere ───┴──────────────────────────────► pf_unificado ─────────────┤
                                                                                         │
transfere_gov.planos_acao ───────────────────────────────────► planos_acao_ted ──────────┤
                                                                                         │
transfere_gov.programas ─────────────────────────────────────► programas_ted ────────────┘