### PR TITLE
feat: Adição de metadados de Fornecedores (CNPJ, Tipo e Nome) aos modelos de Contratos (Silver/Gold)

### DIFF
--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/gold/contratos_comparativo_mensal.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/gold/contratos_comparativo_mensal.sql
@@ -29,7 +29,7 @@ with
     preenchimento as (select contrato_id, mes_ref from {{ ref("preenchimento_meses") }}),
 
     contratos as (
-        select id, numero, dt_ingest as dt_ingest_contratos
+        select id, numero, fornecedor_cnpj_cpf_idgener, fornecedor_tipo, fornecedor_nome, dt_ingest as dt_ingest_contratos
         from {{ ref("contratos") }}
     ),
 
@@ -63,6 +63,9 @@ select
     ccm.siafi_restos_a_pagar,
     ccm.siafi_restos_a_pagar_pago,
     c.numero,
+    c.fornecedor_cnpj_cpf_idgener,
+    c.fornecedor_tipo,
+    c.fornecedor_nome,
     greatest(ccm.dt_ingest::timestamptz, c.dt_ingest_contratos::timestamptz) as dt_ingest
 from comparativo_mensal as ccm
 left join contratos as c on ccm.contrato_id = c.id

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/gold/contratos_somatorio.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/gold/contratos_somatorio.sql
@@ -1,5 +1,9 @@
 select
     contrato_id,
+    numero,
+    fornecedor_cnpj_cpf_idgener,
+    fornecedor_tipo,
+    fornecedor_nome,
     sum(comprasgov_valor_cronograma) as total_cronograma,
     sum(comprasgov_valor_faturas) as total_faturas,
     sum(comprasgov_saldo_contratual_disponivel) as total_saldo_disponivel,
@@ -15,4 +19,4 @@ select
     max(dt_ingest) as dt_ingest
 
 from {{ ref("contratos_comparativo_mensal") }}
-group by contrato_id
+group by contrato_id, numero, fornecedor_cnpj_cpf_idgener, fornecedor_tipo, fornecedor_nome

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/gold/schema.yml
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/gold/schema.yml
@@ -88,6 +88,15 @@ models:
       - name: numero
         description: >
           Número do contrato no sistema ComprasGov.
+      - name: fornecedor_cnpj_cpf_idgener
+        description: >
+          CNPJ, CPF ou identificador genérico do fornecedor do contrato.
+      - name: fornecedor_tipo
+        description: >
+          Tipo do fornecedor do contrato.
+      - name: fornecedor_nome
+        description: >
+          Nome ou razão social do fornecedor associado ao contrato.
       - name: mes_ref
         description: >
           Mês de referência da informação financeira, preenchido para todos os meses entre o início e fim do contrato.
@@ -125,6 +134,18 @@ models:
       - name: contrato_id
         description: >
           Identificador único do contrato.
+      - name: numero
+        description: >
+          Número do contrato no sistema ComprasGov.
+      - name: fornecedor_cnpj_cpf_idgener
+        description: >
+          CNPJ, CPF ou identificador genérico do fornecedor do contrato.
+      - name: fornecedor_tipo
+        description: >
+          Tipo do fornecedor do contrato.
+      - name: fornecedor_nome
+        description: >
+          Nome ou razão social do fornecedor associado ao contrato.
       - name: total_cronograma
         description: >
           Soma de todos os valores programados no cronograma do contrato.

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/contratos_empenhos.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/contratos_empenhos.sql
@@ -209,7 +209,10 @@ with
     contratos as (
         select
             id,
+            fornecedor_tipo,
             fornecedor_nome,
+            fornecedor_cnpj_cpf_idgener,
+            numero,
             unidades_requisitantes,
             objeto,
             vigencia_inicio,
@@ -234,7 +237,10 @@ select
     ce.despesas_empenhadas,
     ce.despesas_liquidadas,
     ce.despesas_pagas,
+    cc.fornecedor_tipo,
     cc.fornecedor_nome,
+    cc.fornecedor_cnpj_cpf_idgener,
+    cc.numero,
     cc.unidades_requisitantes,
     cc.objeto,
     cc.vigencia_inicio,

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/contratos_estagios.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/contratos_estagios.sql
@@ -98,19 +98,29 @@ with
         union
         select *
         from joined_table_3
+    ),
+
+    contratos as (
+        select id, numero, fornecedor_cnpj_cpf_idgener, fornecedor_tipo, fornecedor_nome, dt_ingest as dt_ingest_contratos
+        from {{ ref("contratos") }}
     )
 
 --
 select
-    contrato_id,
-    mes_lancamento,
-    sum(valor_empenhado) as valor_empenhado,
-    sum(valor_liquidado) as valor_liquidado,
-    sum(valor_pago) as valor_pago,
-    sum(restos_a_pagar) as restos_a_pagar,
-    sum(restos_a_pagar_pago) as restos_a_pagar_pago,
-    max(dt_ingest) as dt_ingest
-from result_table
-where contrato_id is not null
-group by 1, 2
-order by contrato_id, mes_lancamento
+    r.contrato_id,
+    c.numero,
+    c.fornecedor_cnpj_cpf_idgener,
+    c.fornecedor_tipo,
+    c.fornecedor_nome,
+    r.mes_lancamento,
+    sum(r.valor_empenhado) as valor_empenhado,
+    sum(r.valor_liquidado) as valor_liquidado,
+    sum(r.valor_pago) as valor_pago,
+    sum(r.restos_a_pagar) as restos_a_pagar,
+    sum(r.restos_a_pagar_pago) as restos_a_pagar_pago,
+    greatest(max(r.dt_ingest), max(c.dt_ingest_contratos)) as dt_ingest
+from result_table r
+left join contratos c on r.contrato_id = c.id
+where r.contrato_id is not null
+group by 1, 2, 3, 4, 5, 6
+order by r.contrato_id, r.mes_lancamento

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/contratos_faturas.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/contratos_faturas.sql
@@ -5,6 +5,8 @@ with
         select
             id::int as contrato_id,
             fornecedor_cnpj_cpf_idgener,
+            fornecedor_tipo,
+            fornecedor_nome,
             processo as processo_contrato,
             numero as numero_contrato,
             objeto as objeto_contrato,
@@ -21,6 +23,8 @@ select
     c.numero_contrato,
     c.processo_contrato as contrato_processo,
     c.fornecedor_cnpj_cpf_idgener,
+    c.fornecedor_tipo,
+    c.fornecedor_nome,
     c.objeto_contrato,
     c.unidades_requisitantes,
     f.tipolistafatura_id,

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/cronogramas_faturas_mensal.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/cronogramas_faturas_mensal.sql
@@ -74,7 +74,24 @@ with
             greatest(dt_ingest_pago, dt_ingest_pendente) AS dt_ingest
         from joined_table
         order by contrato_id, mes_ref
+    ),
+
+    contratos as (
+        select id::text as contrato_id, numero, fornecedor_cnpj_cpf_idgener, fornecedor_tipo, fornecedor_nome, dt_ingest
+        from {{ ref("contratos") }}
     )
 
-select *
-from joined_ajustado
+select 
+    ja.contrato_id,
+    ja.mes_ref,
+    ja.valor_cronograma,
+    ja.valor_faturas_pagas,
+    ja.valor_faturas_pendentes,
+    ja.saldo_contratual_disponivel,
+    c.numero,
+    c.fornecedor_cnpj_cpf_idgener,
+    c.fornecedor_tipo,
+    c.fornecedor_nome,
+    greatest(ja.dt_ingest::timestamp with time zone, c.dt_ingest::timestamp with time zone) as dt_ingest
+from joined_ajustado ja
+left join contratos c using (contrato_id)

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/schema.yml
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/schema.yml
@@ -58,6 +58,12 @@ models:
       - name: fornecedor_nome
         description: >
           Nome do fornecedor associado ao contrato.
+      - name: fornecedor_cnpj_cpf_idgener
+        description: >
+          CNPJ, CPF ou identificador genérico do fornecedor do contrato.
+      - name: numero
+        description: >
+          Número do contrato no sistema ComprasGov.
       - name: unidades_requisitantes
         description: >
           Unidades requisitantes associadas ao contrato.
@@ -87,6 +93,18 @@ models:
       - name: contrato_id
         description: >
           Identificador único do contrato relacionado aos estágios.
+      - name: numero
+        description: >
+          Número do contrato no sistema ComprasGov.
+      - name: fornecedor_cnpj_cpf_idgener
+        description: >
+          CNPJ, CPF ou identificador genérico do fornecedor do contrato.
+      - name: fornecedor_tipo
+        description: >
+          Tipo do fornecedor do contrato.
+      - name: fornecedor_nome
+        description: >
+          Nome ou razão social do fornecedor associado ao contrato.
       - name: mes_lancamento
         description: >
           Mês em que o estágio da despesa foi registrado no SIAFI.
@@ -164,6 +182,12 @@ models:
       - name: fornecedor_cnpj_cpf_idgener
         description: >
           CNPJ, CPF ou identificador genérico do fornecedor do contrato.
+      - name: fornecedor_tipo
+        description: >
+          Tipo do fornecedor do contrato.
+      - name: fornecedor_nome
+        description: >
+          Nome ou razão social do fornecedor associado ao contrato.
       - name: objeto_contrato
         description: >
           Descrição do objeto contratado.
@@ -270,6 +294,18 @@ models:
       - name: contrato_id
         description: >
           Identificador único do contrato.
+      - name: numero
+        description: >
+          Número do contrato no sistema ComprasGov.
+      - name: fornecedor_cnpj_cpf_idgener
+        description: >
+          CNPJ, CPF ou identificador genérico do fornecedor do contrato.
+      - name: fornecedor_tipo
+        description: >
+          Tipo do fornecedor do contrato.
+      - name: fornecedor_nome
+        description: >
+          Nome ou razão social do fornecedor associado ao contrato.
       - name: mes_ref
         description: >
           Mês de referência dos valores programados e faturados.


### PR DESCRIPTION
Descrição:
- Este PR inclui as informações de fornecedores (fornecedor_cnpj_cpf_idgener, fornecedor_tipo e fornecedor_nome) nas camadas Silver e Gold do dbt

O que foi feito:

- Adição das colunas e ajuste de chaves nos modelos Silver: contratos_faturas, cronogramas_faturas_mensal, contratos_empenhos e contratos_estagios.
- Adição das colunas nos modelos Gold: contratos_comparativo_mensal e contratos_somatorio.
- Inserção das descrições nos arquivos schema.yml.

Modelos testados localmente e compilados com sucesso.