### PR TITLE
fix: sources realocado corretamente corrige cosmos bug

### DIFF
--- a/airflow_lappis/dags/dbt/mir/models/sources.yml
+++ b/airflow_lappis/dags/dbt/mir/models/sources.yml
@@ -28,11 +28,12 @@ sources:
     tables:
       - name: senadores
       - name: legislaturas
+      - name: senadores_historico
+
   - name: dados_abertos
     schema: dados_abertos
     tables:
       - name: logo_partidos
-      - name: senadores_historico
 
   - name: transfere_gov
     schema: transfere_gov


### PR DESCRIPTION
## Descrição

Este PR corrige a localização da tabela `senadores_historico` no arquivo:

```yaml
airflow_lappis/dags/dbt/mir/models/sources.yml
```

A tabela foi removida da source`dados_abertos` e adicionada corretamente à source `senado_federal`.