### PR TITLE
feat(ibge): ingestão Quilombolas — alfabetização e características dos domicílios

### DIFF
--- a/airflow_lappis/dags/data_ingest/ibge/quilombolas_alfabetizacao_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/ibge/quilombolas_alfabetizacao_ingest_dag.py
@@ -1,0 +1,168 @@
+"""
+DAG de ingestão — Censo 2022: Quilombolas, alfabetização e características dos domicílios.
+
+Fonte FTP:
+/Censos/Censo_Demografico_2022/Quilombolas_alfabetizacao_e_caracteristicas_dos_domicílios_Resultados_do_universo/
+"""
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any
+
+import yaml
+from airflow.decorators import dag, task
+from airflow.models import Variable
+
+from cliente_ibge import ClienteIBGE
+from cliente_postgres import ClientPostgresDB
+from postgres_helpers import get_postgres_conn
+from quilombolas_parser import (
+    INDICES_FTP,
+    SUBPASTAS_DADOS,
+    extrair_chunks_de_excel,
+    parsear_arquivo_indice,
+    preparar_registros_insercao,
+)
+from schedule_loader import get_dynamic_schedule
+
+SCHEMA_DESTINO = "censo_demografico"
+DATABASE_FTP = (
+    "Quilombolas_alfabetizacao_e_caracteristicas_dos_domicílios_Resultados_do_universo"
+)
+
+
+def _obter_database_ftp() -> str:
+    config_str = Variable.get(
+        "ibge_quilombolas_config",
+        default_var=f'{{"database": "{DATABASE_FTP}"}}',
+    )
+    return yaml.safe_load(config_str).get("database", DATABASE_FTP)
+
+
+def _chunk_para_payload(chunk: Any) -> dict[str, Any]:
+    return {
+        "table_name": chunk.table_name,
+        "table_comment": chunk.table_comment,
+        "col_comments": chunk.col_comments,
+        "records": preparar_registros_insercao(chunk),
+        "primary_key": chunk.primary_key,
+    }
+
+
+def _inserir_payloads(db: ClientPostgresDB, payloads: list[dict[str, Any]]) -> list[str]:
+    tabelas: list[str] = []
+    for payload in payloads:
+        pk = payload["primary_key"]
+        db.insert_data(
+            data=payload["records"],
+            table_name=payload["table_name"],
+            schema=SCHEMA_DESTINO,
+            primary_key=pk,
+            conflict_fields=pk,
+        )
+        db.apply_comments(
+            schema=SCHEMA_DESTINO,
+            table_name=payload["table_name"],
+            table_comment=payload.get("table_comment"),
+            column_comments=payload.get("col_comments"),
+        )
+        tabelas.append(payload["table_name"])
+        logging.info(
+            "Tabela criada/atualizada com comentários: %s.%s",
+            SCHEMA_DESTINO,
+            payload["table_name"],
+        )
+    return tabelas
+
+
+@dag(
+    schedule_interval=get_dynamic_schedule("quilombolas_censo_dag"),
+    start_date=datetime(2026, 1, 1),
+    catchup=False,
+    default_args={
+        "owner": "Lucas Guimaraes",
+        "retries": 1,
+        "retry_delay": timedelta(minutes=5),
+    },
+    tags=["quilombolas", "censo_demografico", "ibge", "alfabetizacao"],
+)
+def quilombolas_alfabetizacao_censo_dag() -> None:
+    """Extrai dados quilombolas do Censo 2022 via FTP e carrega em censo_demografico."""
+
+    @task
+    def listar_arquivos_dados() -> list[dict[str, str]]:
+        logging.info("[Task 1] Listando arquivos de dados no FTP...")
+        cliente = ClienteIBGE(database=_obter_database_ftp())
+        arquivos = cliente.listar_arquivos_em_subpastas(
+            list(SUBPASTAS_DADOS),
+            formato_preferido="xlsx",
+        )
+        logging.info("%d arquivo(s) de dados encontrado(s).", len(arquivos))
+        return arquivos
+
+    @task
+    def listar_arquivos_indices() -> list[dict[str, str]]:
+        logging.info("[Task 1b] Listando arquivos de índice no FTP...")
+        indices = ClienteIBGE(database=_obter_database_ftp()).listar_arquivos_texto(
+            INDICES_FTP
+        )
+        logging.info("%d arquivo(s) de índice encontrado(s).", len(indices))
+        return indices
+
+    @task
+    def extrair_dados_excel(entrada: dict[str, str]) -> list[dict[str, Any]]:
+        subcaminho = entrada["subcaminho"]
+        arquivo = entrada["arquivo"]
+        logging.info("[Task 2] Extraindo %s/%s", subcaminho, arquivo)
+
+        buffer = ClienteIBGE(database=_obter_database_ftp()).obter_conteudo_arquivo(
+            arquivo, subcaminho=subcaminho
+        )
+        if not buffer:
+            raise ValueError(f"Falha ao baixar {subcaminho}/{arquivo}")
+
+        chunks = extrair_chunks_de_excel(buffer, arquivo, subcaminho)
+        return [_chunk_para_payload(c) for c in chunks]
+
+    @task
+    def extrair_indice(entrada: dict[str, str]) -> list[dict[str, Any]]:
+        subcaminho = entrada["subcaminho"]
+        arquivo = entrada["arquivo"]
+        logging.info("[Task 2b] Extraindo índice %s/%s", subcaminho, arquivo)
+
+        conteudo = ClienteIBGE(database=_obter_database_ftp()).obter_conteudo_texto(
+            arquivo, subcaminho=subcaminho
+        )
+        if not conteudo:
+            raise ValueError(f"Falha ao baixar índice {subcaminho}/{arquivo}")
+
+        chunk = parsear_arquivo_indice(conteudo, subcaminho)
+        return [_chunk_para_payload(chunk)]
+
+    @task
+    def inserir_chunks(payloads: list[dict[str, Any]]) -> list[str]:
+        if not payloads:
+            return []
+        db = ClientPostgresDB(get_postgres_conn())
+        return _inserir_payloads(db, payloads)
+
+    @task
+    def consolidar_resultado(
+        tabelas_dados: list[list[str]], tabelas_indices: list[list[str]]
+    ) -> str:
+        total = sum(len(t) for t in tabelas_dados) + sum(len(t) for t in tabelas_indices)
+        return f"Processadas {total} tabelas no schema {SCHEMA_DESTINO}"
+
+    lista_dados = listar_arquivos_dados()
+    lista_indices = listar_arquivos_indices()
+
+    payloads_excel = extrair_dados_excel.expand(entrada=lista_dados)
+    payloads_indices = extrair_indice.expand(entrada=lista_indices)
+
+    tabelas_dados = inserir_chunks.expand(payloads=payloads_excel)
+    tabelas_indices = inserir_chunks.expand(payloads=payloads_indices)
+
+    consolidar_resultado(tabelas_dados, tabelas_indices)
+
+
+quilombolas_alfabetizacao_censo_dag()

--- a/airflow_lappis/dags/dbt/ipea/models/sources.yml
+++ b/airflow_lappis/dags/dbt/ipea/models/sources.yml
@@ -156,3 +156,10 @@ sources:
     - name: mulheres_tabela_15_br_gr_uf_mu
     - name: mulheres_tabela_16_br_gr_uf_mu
     - name: mulheres_tabela_17_br_gr_uf_mu
+    # Quilombolas — alfabetização e características dos domicílios (prefixo Q_A_C_D_)
+    - name: Q_A_C_D_apendice_01
+    - name: Q_A_C_D_indice_tabelas_de_resultados
+    - name: Q_A_C_D_indice_tabelas_selecionadas
+    - name: Q_A_C_D_tabela_de_resultado_01
+    - name: Q_A_C_D_tabela_de_resultado_02
+    - name: Q_A_C_D_tabela_complementar_01

--- a/airflow_lappis/helpers/quilombolas_parser.py
+++ b/airflow_lappis/helpers/quilombolas_parser.py
@@ -108,18 +108,33 @@ def _identificar_chunks_horizontais(df_aba: pd.DataFrame) -> list[pd.DataFrame]:
     return chunks
 
 
-def _localizar_linha_titulo(df_raw: pd.DataFrame) -> int | None:
-    padrao = re.compile(
-        r"(tabela|ap[eê]ndice|apendice)\s+(complementar|de resultado)?\s*\d+",
-        re.IGNORECASE,
+def _texto_eh_linha_titulo(texto: str) -> bool:
+    """Detecta linha de título IBGE sem regex sujeito a backtracking (ReDoS)."""
+    lower = texto.lower().lstrip()
+    prefixos = (
+        "tabela complementar",
+        "tabela de resultado",
+        "tabela de resultados",
+        "tabela",
+        "apêndice",
+        "apendice",
     )
+    for prefixo in prefixos:
+        if not lower.startswith(prefixo):
+            continue
+        sufixo = lower[len(prefixo) :].lstrip()
+        return bool(sufixo) and sufixo[0].isdigit()
+    return False
+
+
+def _localizar_linha_titulo(df_raw: pd.DataFrame) -> int | None:
     for idx in range(len(df_raw)):
         texto = " ".join(
             str(v).strip()
             for v in df_raw.iloc[idx].tolist()
             if str(v).strip().lower() not in VALORES_NULOS
         )
-        if padrao.search(texto):
+        if _texto_eh_linha_titulo(texto):
             return idx
     return None
 
@@ -357,24 +372,46 @@ def extrair_chunks_de_excel(
     return chunks
 
 
+_TIPOS_INDICE: tuple[tuple[str, str], ...] = (
+    ("cartograma", "Cartograma"),
+    ("tabela", "Tabela"),
+    ("apêndice", "Apêndice"),
+    ("apendice", "Apêndice"),
+)
+
+
+def _parsear_linha_indice(linha: str) -> tuple[str, str, str] | None:
+    """Extrai tipo, número e descrição de uma linha de índice (sem ReDoS)."""
+    lower = linha.lower()
+    for chave, rotulo in _TIPOS_INDICE:
+        if not lower.startswith(chave):
+            continue
+        resto = linha[len(chave) :].lstrip()
+        numero_match = re.match(r"[0-9]+", resto)
+        if not numero_match:
+            return None
+        numero = numero_match.group(0)
+        descricao = resto[numero_match.end() :].lstrip()
+        if descricao and descricao[0] in "-–:":
+            descricao = descricao[1:].lstrip()
+        return rotulo, numero, descricao or linha
+    return None
+
+
 def parsear_arquivo_indice(conteudo: str, subpasta: str) -> ChunkProcessado:
     """Converte arquivo de índice TXT em tabela estruturada."""
     linhas = [ln.strip() for ln in conteudo.splitlines() if ln.strip()]
     registros: list[dict[str, str]] = []
     for idx, linha in enumerate(linhas, start=1):
-        match = re.match(
-            r"^(Tabela|Cartograma|Ap[eê]ndice)\s*(\d+)\s*[-–]?\s*(.*)$",
-            linha,
-            re.IGNORECASE,
-        )
-        if match:
-            tipo, numero, descricao = match.groups()
+        parsed = _parsear_linha_indice(linha)
+        if parsed:
+            tipo, numero, descricao = parsed
             registros.append(
                 {
                     "ordem": str(idx),
-                    "tipo": tipo.strip(),
-                    "numero": numero.strip(),
-                    "descricao": descricao.strip() or linha,
+                    "tipo": tipo,
+                    "numero": numero,
+                    "descricao": descricao,
                     "linha_original": linha,
                 }
             )

--- a/airflow_lappis/helpers/quilombolas_parser.py
+++ b/airflow_lappis/helpers/quilombolas_parser.py
@@ -1,0 +1,422 @@
+"""
+Parsing e limpeza dos arquivos do Censo 2022 — Quilombolas:
+alfabetização e características dos domicílios (universo).
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import re
+import unicodedata
+from dataclasses import dataclass, field
+
+import pandas as pd
+
+PREFIXO_TABELA = "Q_A_C_D_"
+MAX_COL_LEN = 63
+VALORES_NULOS = frozenset({"nan", "none", ""})
+
+SUBPASTAS_DADOS = ("Apendices", "Tabelas_de_resultados", "Tabelas_selecionadas")
+INDICES_FTP: list[tuple[str, str]] = [
+    ("Tabelas_de_resultados", "indice_de_tabelas_de_resultados.txt"),
+    ("Tabelas_selecionadas", "indice_de_tabelas_seleciondas.txt"),
+]
+
+
+@dataclass
+class ChunkProcessado:
+    """Resultado do processamento de um bloco tabular."""
+
+    df: pd.DataFrame
+    table_name: str
+    table_comment: str
+    primary_key: list[str] = field(default_factory=list)
+    col_comments: dict[str, str] = field(default_factory=dict)
+    arquivo: str = ""
+    subcaminho: str = ""
+    sheet_name: str = ""
+
+
+def _remover_acentos(texto: str) -> str:
+    return "".join(
+        c for c in unicodedata.normalize("NFD", texto) if unicodedata.category(c) != "Mn"
+    )
+
+
+def normalizar_nome_coluna(nome: str, idx: int) -> str:
+    """Converte descrição original em identificador PostgreSQL."""
+    sem_acento = _remover_acentos(str(nome))
+    limpo = re.sub(
+        r"[^\w%]",
+        "",
+        sem_acento.lower()
+        .replace("%", "_porcentagem")
+        .replace(" ", "_")
+        .replace("-", "_"),
+    )
+    if not limpo or limpo == "none":
+        return f"coluna_{idx}"
+    if len(limpo) > MAX_COL_LEN:
+        limpo = limpo[:MAX_COL_LEN]
+    return limpo
+
+
+def deduplicar_colunas(colunas: list[str]) -> list[str]:
+    contagem: dict[str, int] = {}
+    resultado: list[str] = []
+    for col in colunas:
+        if col not in contagem:
+            contagem[col] = 0
+            resultado.append(col)
+            continue
+        contagem[col] += 1
+        sufixo = f"_{contagem[col]}"
+        if len(col) + len(sufixo) > MAX_COL_LEN:
+            base = col[: MAX_COL_LEN - len(sufixo)]
+        else:
+            base = col
+        resultado.append(f"{base}{sufixo}")
+    return resultado
+
+
+def construir_nome_tabela(arquivo: str, sufixo: str = "") -> str:
+    """Gera nome no padrão Q_A_C_D_[nome_da_tabela]."""
+    stem = arquivo.rsplit(".", maxsplit=1)[0]
+    nome = re.sub(r"[^\w]", "_", _remover_acentos(stem).lower())
+    nome = re.sub(r"_+", "_", nome).strip("_")
+    return f"{PREFIXO_TABELA}{nome}{sufixo}"
+
+
+def construir_nome_tabela_indice(subpasta: str) -> str:
+    slug = re.sub(r"[^\w]", "_", _remover_acentos(subpasta).lower())
+    slug = re.sub(r"_+", "_", slug).strip("_")
+    return f"{PREFIXO_TABELA}indice_{slug}"
+
+
+def _identificar_chunks_horizontais(df_aba: pd.DataFrame) -> list[pd.DataFrame]:
+    cols_vazias = [
+        i for i, col in enumerate(df_aba.columns) if df_aba[col].isnull().all()
+    ]
+    pontos = [-1] + cols_vazias + [len(df_aba.columns)]
+    chunks: list[pd.DataFrame] = []
+    for i in range(len(pontos) - 1):
+        chunk = df_aba.iloc[:, pontos[i] + 1 : pontos[i + 1]].copy()
+        chunk = chunk.dropna(axis=1, how="all").dropna(axis=0, how="all")
+        if not chunk.empty and len(chunk.columns) > 1:
+            chunks.append(chunk.reset_index(drop=True))
+    return chunks
+
+
+def _localizar_linha_titulo(df_raw: pd.DataFrame) -> int | None:
+    padrao = re.compile(
+        r"(tabela|ap[eê]ndice|apendice)\s+(complementar|de resultado)?\s*\d+",
+        re.IGNORECASE,
+    )
+    for idx in range(len(df_raw)):
+        texto = " ".join(
+            str(v).strip()
+            for v in df_raw.iloc[idx].tolist()
+            if str(v).strip().lower() not in VALORES_NULOS
+        )
+        if padrao.search(texto):
+            return idx
+    return None
+
+
+_PALAVRAS_CABECALHO_DIM = frozenset(
+    {
+        "estado",
+        "codigo",
+        "código",
+        "sigla",
+        "nome",
+        "territorio",
+        "território",
+        "unidade",
+        "status",
+        "simbolo",
+        "símbolo",
+        "significado",
+        "legenda",
+    }
+)
+
+
+def _eh_linha_cabecalho_dimensao(linha: pd.Series) -> bool:
+    textos = [
+        str(v).strip().lower()
+        for v in linha.tolist()
+        if str(v).strip().lower() not in VALORES_NULOS
+    ]
+    if len(textos) < 2:
+        return False
+    return any(
+        any(palavra in texto for palavra in _PALAVRAS_CABECALHO_DIM) for texto in textos
+    )
+
+
+def _detectar_inicio_dados(df_raw: pd.DataFrame, idx_titulo: int | None) -> int | None:
+    mascara_num = df_raw.apply(
+        lambda r: pd.to_numeric(r, errors="coerce").notna().sum() > 1, axis=1
+    )
+    if mascara_num.any():
+        return int(mascara_num.idxmax())
+
+    inicio_busca = (idx_titulo + 1) if idx_titulo is not None else 0
+    for idx in range(inicio_busca, len(df_raw)):
+        linha = df_raw.iloc[idx]
+        textos = [
+            str(v).strip()
+            for v in linha.tolist()
+            if str(v).strip().lower() not in VALORES_NULOS
+        ]
+        if len(textos) < 2:
+            continue
+        joined = " ".join(textos)
+        if re.search(r"fonte:|nota:|legenda", joined, re.IGNORECASE):
+            continue
+        if _eh_linha_cabecalho_dimensao(linha) and idx + 1 < len(df_raw):
+            return idx + 1
+        return idx
+    return None
+
+
+def _extrair_comentario_tabela(df_raw: pd.DataFrame, idx_titulo: int | None) -> str:
+    if idx_titulo is None:
+        return ""
+    texto = " ".join(
+        str(v).strip()
+        for v in df_raw.iloc[idx_titulo].tolist()
+        if str(v).strip().lower() not in VALORES_NULOS
+    )
+    if " - " in texto:
+        return texto.split(" - ", maxsplit=1)[-1].strip()
+    return texto.strip()
+
+
+def _construir_cabecalho_flat(
+    df_raw: pd.DataFrame, idx_titulo: int | None, idx_dados: int
+) -> pd.DataFrame:
+    inicio = (idx_titulo + 1) if idx_titulo is not None else 0
+    fim_cab = idx_dados
+    if idx_dados > 0 and _eh_linha_cabecalho_dimensao(df_raw.iloc[idx_dados - 1]):
+        fim_cab = idx_dados
+    cab = df_raw.iloc[inicio:fim_cab].copy().ffill(axis=1)
+    linhas_validas = []
+    for row_idx in range(len(cab)):
+        valores = [
+            str(v).strip()
+            for v in cab.iloc[row_idx].tolist()
+            if str(v).strip().lower() not in VALORES_NULOS
+        ]
+        if valores:
+            linhas_validas.append(row_idx)
+    return cab.iloc[linhas_validas] if linhas_validas else cab.iloc[0:0]
+
+
+def _extrair_nome_coluna_flat(cabecalho: pd.DataFrame, col_idx: int) -> str:
+    pedacos: list[str] = []
+    for row_idx in range(len(cabecalho)):
+        val = str(cabecalho.iloc[row_idx, col_idx]).strip()
+        if val.lower() in VALORES_NULOS:
+            continue
+        row_vals = cabecalho.iloc[row_idx].dropna().astype(str).str.strip()
+        unicos = [v for v in row_vals.unique() if v.lower() not in VALORES_NULOS]
+        if len(unicos) > 1:
+            pedacos.append(val.split(" - ")[-1].strip())
+        elif len(unicos) == 1 and len(row_vals) == 1:
+            pedacos.append(val.split(" - ")[-1].strip())
+    return "_".join(pedacos) if pedacos else f"coluna_{col_idx}"
+
+
+_COLUNAS_AUDITORIA = frozenset({"dt_ingest", "nome_fonte", "subcaminho_fonte"})
+
+
+def _colunas_dados(df: pd.DataFrame) -> list[str]:
+    return [c for c in df.columns if c not in _COLUNAS_AUDITORIA]
+
+
+def resolver_chave_primaria(df: pd.DataFrame) -> list[str]:
+    """
+    Define a menor chave composta (prefixo à esquerda) que identifica cada linha.
+
+    Nas tabelas IBGE as dimensões ficam à esquerda e as medidas à direita; usar
+    só as 3 primeiras colunas falha quando há vários territórios por UF.
+    """
+    cols = _colunas_dados(df)
+    if not cols:
+        return [df.columns[0]]
+    if len(cols) == 1:
+        return cols
+
+    for n in range(1, len(cols) + 1):
+        subset = cols[:n]
+        if df.drop_duplicates(subset=subset).shape[0] == len(df):
+            return subset
+
+    return cols
+
+
+def _limpar_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    if df.empty:
+        return df
+    col_dim = df.columns[0]
+    df = df.dropna(subset=[col_dim])
+    df = df[
+        ~df[col_dim]
+        .astype(str)
+        .str.contains(r"Fonte:|Nota:|Legenda", case=False, na=False)
+    ]
+    return df.drop_duplicates()
+
+
+def processar_chunk_excel(
+    df_raw: pd.DataFrame,
+    arquivo: str,
+    subcaminho: str,
+    sheet_name: str,
+    sufixo: str = "",
+) -> ChunkProcessado | None:
+    """Aplica flattening de cabeçalhos IBGE e prepara metadados de comentários."""
+    idx_titulo = _localizar_linha_titulo(df_raw)
+    idx_dados = _detectar_inicio_dados(df_raw, idx_titulo)
+    if idx_dados is None:
+        logging.warning(
+            "[quilombolas_parser] Sem dados tabulares em %s / %s", arquivo, sheet_name
+        )
+        return None
+
+    cabecalho = _construir_cabecalho_flat(df_raw, idx_titulo, idx_dados)
+    nomes_originais = [
+        _extrair_nome_coluna_flat(cabecalho, i) for i in range(len(df_raw.columns))
+    ]
+    nomes_norm = deduplicar_colunas(
+        [normalizar_nome_coluna(n, i) for i, n in enumerate(nomes_originais)]
+    )
+
+    df = df_raw.iloc[idx_dados:].copy()
+    df.columns = nomes_norm
+    col_comments = {
+        norm: orig
+        for norm, orig in zip(nomes_norm, nomes_originais, strict=True)
+        if norm != orig or orig
+    }
+    df = _limpar_dataframe(df)
+
+    colunas_fantasma = [c for c in df.columns if c.startswith("coluna_")]
+    if colunas_fantasma:
+        df = df.drop(columns=colunas_fantasma)
+        col_comments = {
+            k: v for k, v in col_comments.items() if k not in colunas_fantasma
+        }
+
+    if df.empty or len(df.columns) == 0:
+        return None
+
+    return ChunkProcessado(
+        df=df,
+        table_name=construir_nome_tabela(arquivo, sufixo=sufixo),
+        table_comment=_extrair_comentario_tabela(df_raw, idx_titulo),
+        primary_key=resolver_chave_primaria(df),
+        col_comments=col_comments,
+        arquivo=arquivo,
+        subcaminho=subcaminho,
+        sheet_name=sheet_name,
+    )
+
+
+def extrair_chunks_de_excel(
+    buffer: io.BytesIO,
+    arquivo: str,
+    subcaminho: str,
+) -> list[ChunkProcessado]:
+    """Processa todas as abas e blocos horizontais de um arquivo Excel."""
+    excel_file = pd.ExcelFile(buffer)
+    abas_validas = [
+        a
+        for a in excel_file.sheet_names
+        if "gráfico" not in a.lower()
+        and "grafico" not in a.lower()
+        and "nota" not in a.lower()
+    ]
+    if not abas_validas:
+        abas_validas = [excel_file.sheet_names[0]]
+
+    chunks: list[ChunkProcessado] = []
+    for sheet_name in abas_validas:
+        df_aba = excel_file.parse(sheet_name, header=None)
+        partes = _identificar_chunks_horizontais(df_aba)
+        for idx, df_raw in enumerate(partes):
+            sufixo = f"_parte_{idx + 1}" if len(partes) > 1 else ""
+            resultado = processar_chunk_excel(
+                df_raw, arquivo, subcaminho, sheet_name, sufixo=sufixo
+            )
+            if resultado:
+                chunks.append(resultado)
+    return chunks
+
+
+def parsear_arquivo_indice(conteudo: str, subpasta: str) -> ChunkProcessado:
+    """Converte arquivo de índice TXT em tabela estruturada."""
+    linhas = [ln.strip() for ln in conteudo.splitlines() if ln.strip()]
+    registros: list[dict[str, str]] = []
+    for idx, linha in enumerate(linhas, start=1):
+        match = re.match(
+            r"^(Tabela|Cartograma|Ap[eê]ndice)\s*(\d+)\s*[-–]?\s*(.*)$",
+            linha,
+            re.IGNORECASE,
+        )
+        if match:
+            tipo, numero, descricao = match.groups()
+            registros.append(
+                {
+                    "ordem": str(idx),
+                    "tipo": tipo.strip(),
+                    "numero": numero.strip(),
+                    "descricao": descricao.strip() or linha,
+                    "linha_original": linha,
+                }
+            )
+        else:
+            registros.append(
+                {
+                    "ordem": str(idx),
+                    "tipo": "",
+                    "numero": "",
+                    "descricao": linha,
+                    "linha_original": linha,
+                }
+            )
+
+    df = pd.DataFrame(registros)
+    return ChunkProcessado(
+        df=df,
+        table_name=construir_nome_tabela_indice(subpasta),
+        table_comment=f"Índice de tabelas — {subpasta.replace('_', ' ')}",
+        primary_key=["ordem"],
+        col_comments={
+            "ordem": "Ordem da linha no arquivo de índice",
+            "tipo": "Tipo do item (Tabela, Cartograma, Apêndice)",
+            "numero": "Número do item no índice",
+            "descricao": "Descrição original do item",
+            "linha_original": "Texto original da linha no arquivo de índice",
+        },
+        arquivo=f"indice_{subpasta.lower()}.txt",
+        subcaminho=subpasta,
+        sheet_name="indice",
+    )
+
+
+def preparar_registros_insercao(chunk: ChunkProcessado) -> list[dict[str, str]]:
+    """Adiciona colunas de auditoria, deduplica pela PK e serializa para inserção."""
+    from datetime import datetime
+
+    df = chunk.df.copy()
+    pk = chunk.primary_key or resolver_chave_primaria(df)
+    df = df.drop_duplicates(subset=pk, keep="last")
+    df["dt_ingest"] = datetime.now().isoformat()
+    df["nome_fonte"] = chunk.arquivo
+    df["subcaminho_fonte"] = chunk.subcaminho
+    return df.astype(str).to_dict(orient="records")
+

--- a/airflow_lappis/plugins/cliente_ibge.py
+++ b/airflow_lappis/plugins/cliente_ibge.py
@@ -20,7 +20,7 @@ class ClienteIBGE(ClienteBase):
         logging.info("[cliente_ibge] Inicializando conexão FTP com: %s", self.host)
 
     @contextmanager
-    def _conectar(self):
+    def _conectar(self, subcaminho: str = ""):
         """
         Abre uma conexão FTP com o servidor público do IBGE.
 
@@ -28,7 +28,7 @@ class ClienteIBGE(ClienteBase):
             with self._conectar() as ftp:
                 ftp.nlst()
         """
-        full_path = f"{self.BASE_DIR.rstrip('/')}/{self.database.lstrip('/')}"
+        full_path = self._caminho_remoto(subcaminho)
         ftp = FTP(timeout=30)  # NOSONAR
         try:
             ftp.connect(self.host)
@@ -58,12 +58,113 @@ class ClienteIBGE(ClienteBase):
             logging.error("[cliente_ibge] Erro ao listar arquivos: %s", exc)
             return []
 
-    def obter_conteudo_arquivo(self, nome_arquivo: str) -> io.BytesIO | None:
+    def _caminho_remoto(self, subcaminho: str = "") -> str:
+        base = f"{self.BASE_DIR.rstrip('/')}/{self.database.lstrip('/')}"
+        if not subcaminho:
+            return base
+        return f"{base}/{subcaminho.strip('/')}"
+
+    def listar_arquivos_em_subpastas(
+        self,
+        subpastas: list[str],
+        extensoes: tuple[str, ...] = (".xlsx", ".xls", ".csv"),
+        formato_preferido: str | None = "xlsx",
+    ) -> list[dict[str, str]]:
+        """
+        Lista arquivos alvo em subpastas relativas ao diretório do tema.
+
+        Retorna lista de dicts com chaves ``subcaminho`` e ``arquivo``.
+        Quando ``formato_preferido`` é informado, prioriza arquivos dessa
+        subpasta (ex.: ``xlsx`` em vez de ``ods``).
+        """
+        resultado: list[dict[str, str]] = []
+        try:
+            with self._conectar() as ftp:
+                base = self._caminho_remoto()
+                for subpasta in subpastas:
+                    caminho = f"{base}/{subpasta.strip('/')}"
+                    if formato_preferido:
+                        caminho = f"{caminho}/{formato_preferido}"
+                    try:
+                        ftp.cwd(caminho)
+                    except Exception as exc:
+                        logging.warning(
+                            "[cliente_ibge] Subpasta inacessível '%s': %s",
+                            caminho,
+                            exc,
+                        )
+                        continue
+
+                    for nome in ftp.nlst():
+                        if nome in (".", ".."):
+                            continue
+                        if nome.endswith(extensoes):
+                            resultado.append(
+                                {
+                                    "subcaminho": (
+                                        f"{subpasta.strip('/')}/{formato_preferido}"
+                                        if formato_preferido
+                                        else subpasta.strip("/")
+                                    ),
+                                    "arquivo": nome,
+                                }
+                            )
+
+            logging.info(
+                "[cliente_ibge] %d arquivo(s) em subpastas: %s",
+                len(resultado),
+                subpastas,
+            )
+            return resultado
+
+        except Exception as exc:
+            logging.error("[cliente_ibge] Erro ao listar subpastas: %s", exc)
+            return []
+
+    def listar_arquivos_texto(
+        self, entradas: list[tuple[str, str]]
+    ) -> list[dict[str, str]]:
+        """
+        Lista arquivos de texto (índices) em subpastas.
+
+        ``entradas`` é uma lista de tuplas ``(subpasta, nome_arquivo)``.
+        """
+        encontrados: list[dict[str, str]] = []
+        try:
+            with self._conectar() as ftp:
+                base = self._caminho_remoto()
+                for subpasta, nome_arquivo in entradas:
+                    caminho = f"{base}/{subpasta.strip('/')}"
+                    try:
+                        ftp.cwd(caminho)
+                        if nome_arquivo in ftp.nlst():
+                            encontrados.append(
+                                {
+                                    "subcaminho": subpasta.strip("/"),
+                                    "arquivo": nome_arquivo,
+                                }
+                            )
+                    except Exception as exc:
+                        logging.warning(
+                            "[cliente_ibge] Índice não encontrado em '%s': %s",
+                            caminho,
+                            exc,
+                        )
+            return encontrados
+        except Exception as exc:
+            logging.error("[cliente_ibge] Erro ao listar índices: %s", exc)
+            return []
+
+    def obter_conteudo_arquivo(
+        self, nome_arquivo: str, subcaminho: str = ""
+    ) -> io.BytesIO | None:
         """Baixa um arquivo do FTP diretamente para memória."""
         buffer = io.BytesIO()
         try:
-            with self._conectar() as ftp:
-                logging.info("[cliente_ibge] Baixando: %s", nome_arquivo)
+            with self._conectar(subcaminho=subcaminho) as ftp:
+                logging.info(
+                    "[cliente_ibge] Baixando: %s/%s", subcaminho or ".", nome_arquivo
+                )
                 ftp.retrbinary(f"RETR {nome_arquivo}", buffer.write)
 
             buffer.seek(0)
@@ -72,3 +173,18 @@ class ClienteIBGE(ClienteBase):
         except Exception as exc:
             logging.error("[cliente_ibge] Erro ao baixar '%s': %s", nome_arquivo, exc)
             return None
+
+    def obter_conteudo_texto(
+        self, nome_arquivo: str, subcaminho: str = ""
+    ) -> str | None:
+        """Baixa um arquivo de texto do FTP e retorna o conteúdo decodificado."""
+        buffer = self.obter_conteudo_arquivo(nome_arquivo, subcaminho=subcaminho)
+        if not buffer:
+            return None
+        raw = buffer.read()
+        for encoding in ("utf-8", "latin-1", "cp1252"):
+            try:
+                return raw.decode(encoding)
+            except UnicodeDecodeError:
+                continue
+        return raw.decode("latin-1", errors="replace")

--- a/airflow_lappis/plugins/cliente_postgres.py
+++ b/airflow_lappis/plugins/cliente_postgres.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from contextlib import contextmanager
 from typing import Any, Dict, List, Optional, Tuple
 import psycopg2
@@ -17,6 +18,11 @@ class ClientPostgresDB:
     @staticmethod
     def _get_column_type(value: Any) -> str:
         return ClientPostgresDB.TYPE_MAP.get(type(value), "TEXT")
+
+    @staticmethod
+    def _unique_index_name(table_name: str, columns: List[str]) -> str:
+        raw = f"uq_{table_name}_{'_'.join(columns)}"
+        return re.sub(r"[^\w]", "_", raw)[:63]
 
     def _flatten_data(self, data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         return list(
@@ -123,6 +129,10 @@ class ClientPostgresDB:
             column_probe, table_name, primary_key=primary_key, schema=schema, conn=conn
         )
         self.alter_table(column_probe, table_name, schema=schema, conn=conn)
+        if conflict_fields:
+            self.ensure_unique_constraint(
+                schema, table_name, conflict_fields, conn=conn
+            )
 
         values = [tuple(item.get(col) for col in columns) for item in flattened_data]
 
@@ -356,6 +366,57 @@ class ClientPostgresDB:
                     for row in rows
                 ]
 
+    def ensure_unique_constraint(
+        self,
+        schema: str,
+        table_name: str,
+        columns: List[str],
+        conn=None,
+    ) -> None:
+        """
+        Garante índice UNIQUE para ON CONFLICT quando a tabela já existia
+        sem a PK composta correta (CREATE TABLE IF NOT EXISTS não altera constraints).
+        """
+        if not columns:
+            return
+
+        index_name = self._unique_index_name(table_name, columns)
+        cols_sql = ", ".join(columns)
+        query = (
+            f"CREATE UNIQUE INDEX IF NOT EXISTS {index_name} "
+            f"ON {schema}.{table_name} ({cols_sql});"
+        )
+
+        def _execute(connection):
+            with connection.cursor() as cursor:
+                try:
+                    cursor.execute(query)
+                    logging.info(
+                        "[cliente_postgres.py] Unique index %s on %s.%s (%s)",
+                        index_name,
+                        schema,
+                        table_name,
+                        cols_sql,
+                    )
+                except psycopg2.Error as err:
+                    logging.error(
+                        "[cliente_postgres.py] Failed to create unique index on "
+                        "%s.%s: %s",
+                        schema,
+                        table_name,
+                        err,
+                    )
+                    raise RuntimeError(
+                        f"Failed to ensure unique constraint on {schema}.{table_name}"
+                    ) from err
+
+        if conn is not None:
+            _execute(conn)
+        else:
+            with self._connect() as new_conn:
+                _execute(new_conn)
+                new_conn.commit()
+
     def execute_non_query(self, query: str) -> None:
         logging.info(f"[cliente_postgres.py] Executando non-query: {query}")
         with self._connect() as conn:
@@ -369,6 +430,30 @@ class ClientPostgresDB:
                         f"[cliente_postgres.py] Erro ao executar non-query. Erro: {e}"
                     )
                     raise RuntimeError("Erro ao executar comando SQL sem retorno") from e
+
+    def apply_comments(
+        self,
+        schema: str,
+        table_name: str,
+        table_comment: str | None = None,
+        column_comments: dict[str, str] | None = None,
+    ) -> None:
+        """Aplica COMMENT ON TABLE e COMMENT ON COLUMN no PostgreSQL."""
+        queries: list[str] = []
+        tabela = f"{schema}.{table_name}"
+
+        if table_comment:
+            desc = table_comment.replace("'", "''")
+            queries.append(f"COMMENT ON TABLE {tabela} IS '{desc}';")
+
+        for coluna, descricao in (column_comments or {}).items():
+            if not descricao:
+                continue
+            desc = descricao.replace("'", "''")
+            queries.append(f"COMMENT ON COLUMN {tabela}.{coluna} IS '{desc}';")
+
+        for query in queries:
+            self.execute_non_query(query)
 
     def get_dashboard_kpis(self) -> Dict[str, int]:
         query = "SELECT kpi, valor FROM pessoas.kpis_servidores"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ disable_error_code = ["arg-type", "attr-defined"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
+pythonpath = ["airflow_lappis", "airflow_lappis/helpers", "airflow_lappis/plugins"]
 
 [tool.sqlfmt]
 line_length = 90

--- a/tests/test_quilombolas_parser.py
+++ b/tests/test_quilombolas_parser.py
@@ -1,0 +1,139 @@
+import pandas as pd
+
+from quilombolas_parser import (
+    PREFIXO_TABELA,
+    construir_nome_tabela,
+    construir_nome_tabela_indice,
+    deduplicar_colunas,
+    normalizar_nome_coluna,
+    parsear_arquivo_indice,
+    preparar_registros_insercao,
+    processar_chunk_excel,
+    resolver_chave_primaria,
+)
+
+
+def test_construir_nome_tabela_prefixo() -> None:
+    assert construir_nome_tabela("Tabela_de_resultado_02.xlsx") == (
+        f"{PREFIXO_TABELA}tabela_de_resultado_02"
+    )
+
+
+def test_construir_nome_tabela_indice() -> None:
+    assert construir_nome_tabela_indice("Tabelas_de_resultados") == (
+        f"{PREFIXO_TABELA}indice_tabelas_de_resultados"
+    )
+
+
+def test_normalizar_nome_coluna_remove_acentos() -> None:
+    nome = normalizar_nome_coluna("Taxa de alfabetização (%)", 0)
+    assert "alfabetizacao" in nome
+    assert "porcentagem" in nome
+
+
+def test_deduplicar_colunas() -> None:
+    assert deduplicar_colunas(["total", "total", "total"]) == [
+        "total",
+        "total_1",
+        "total_2",
+    ]
+
+
+def test_parsear_arquivo_indice() -> None:
+    conteudo = (
+        "Tabela 1 - População residente - Brasil - 2022\n"
+        "Tabela 2 - População por UF - 2022\n"
+    )
+    chunk = parsear_arquivo_indice(conteudo, "Tabelas_de_resultados")
+    assert chunk.table_name == f"{PREFIXO_TABELA}indice_tabelas_de_resultados"
+    assert len(chunk.df) == 2
+    assert chunk.df.iloc[0]["numero"] == "1"
+    assert "População residente" in chunk.df.iloc[0]["descricao"]
+
+
+def test_processar_chunk_excel_apendice() -> None:
+    """Simula layout do Apêndice 1 (tabela textual sem valores numéricos)."""
+    linhas = [
+        ["Censo Demográfico 2022", None],
+        ["Quilombolas: tema", None],
+        ["Apêndice 1 - Territórios citados - Brasil - 2022", None],
+        ["Estado", "Território Quilombola"],
+        ["PA", "Cuxiu"],
+        ["PA", "Guajarauna"],
+    ]
+    df_raw = pd.DataFrame(linhas)
+    chunk = processar_chunk_excel(
+        df_raw, "Apendice_01.xlsx", "Apendices/xlsx", "Apendice 1"
+    )
+    assert chunk is not None
+    assert chunk.table_name == f"{PREFIXO_TABELA}apendice_01"
+    assert list(chunk.df.columns)[0] == "estado"
+    assert len(chunk.df) == 2
+    assert chunk.table_comment.startswith("Territórios")
+
+
+def test_resolver_chave_primaria_territorios_por_uf() -> None:
+    """Vários territórios na mesma UF exigem PK além das 3 primeiras colunas."""
+    df = pd.DataFrame(
+        [
+            ["Titulado", "11", "RO", "Rondônia", "11001", "TQ A", "100", "50"],
+            ["Titulado", "11", "RO", "Rondônia", "11280", "TQ B", "200", "80"],
+        ],
+        columns=[
+            "status_fundiario",
+            "unidade_da_federacao_codigo",
+            "unidade_da_federacao_sigla",
+            "unidade_da_federacao_nome",
+            "territorio_quilombola_codigo",
+            "territorio_quilombola_nome",
+            "populacao_residente_total",
+            "populacao_residente_quilombola",
+        ],
+    )
+    pk = resolver_chave_primaria(df)
+    assert "territorio_quilombola_codigo" in pk
+    assert len(pk) <= 5
+    assert df.drop_duplicates(subset=pk).shape[0] == len(df)
+
+
+def test_preparar_registros_deduplica_por_pk() -> None:
+    from quilombolas_parser import ChunkProcessado
+
+    chunk = ChunkProcessado(
+        df=pd.DataFrame(
+            [["PA", "Cuxiu"], ["PA", "Cuxiu"]],
+            columns=["estado", "territorio_quilombola"],
+        ),
+        table_name=f"{PREFIXO_TABELA}apendice_01",
+        table_comment="teste",
+        primary_key=["estado", "territorio_quilombola"],
+    )
+    registros = preparar_registros_insercao(chunk)
+    assert len(registros) == 1
+
+
+def test_processar_chunk_excel_cabecalho_triplo() -> None:
+    """Simula cabeçalho hierárquico de tabela complementar."""
+    linhas = [
+        ["Censo Demográfico 2022"] * 3,
+        ["Quilombolas: tema"] * 3,
+        [None] * 3,
+        ["Tabela complementar 1 - Alfabetização por região - 2022"] * 3,
+        [None] * 3,
+        ["Região", "População 15+", "População 15+"],
+        [None, "Total", "Quilombolas"],
+        [None, None, None],
+        ["Brasil", "100", "10"],
+        ["Norte", "50", "5"],
+    ]
+    df_raw = pd.DataFrame(linhas)
+    chunk = processar_chunk_excel(
+        df_raw,
+        "Tabela_complementar_01.xlsx",
+        "Tabelas_selecionadas/xlsx",
+        "Tabela complementar 1",
+    )
+    assert chunk is not None
+    assert "regiao" in chunk.df.columns[0]
+    assert len(chunk.df) == 2
+    assert "total" in chunk.col_comments.get(chunk.df.columns[1], "").lower()

--- a/tests/test_quilombolas_parser.py
+++ b/tests/test_quilombolas_parser.py
@@ -51,6 +51,27 @@ def test_parsear_arquivo_indice() -> None:
     assert "População residente" in chunk.df.iloc[0]["descricao"]
 
 
+def test_parsear_arquivo_indice_sem_hifen() -> None:
+    """Índice IBGE pode usar espaços duplos em vez de hífen."""
+    conteudo = "Tabela  3  População por sexo - 2022\n"
+    chunk = parsear_arquivo_indice(conteudo, "Tabelas_selecionadas")
+    assert chunk.df.iloc[0]["numero"] == "3"
+    assert "População por sexo" in chunk.df.iloc[0]["descricao"]
+
+
+def test_localizar_linha_titulo_tabela_complementar() -> None:
+    from quilombolas_parser import _localizar_linha_titulo
+
+    df = pd.DataFrame(
+        [
+            ["Censo Demográfico 2022"],
+            ["Tabela complementar 1 - Alfabetização - 2022"],
+            ["Brasil", "100"],
+        ]
+    )
+    assert _localizar_linha_titulo(df) == 1
+
+
 def test_processar_chunk_excel_apendice() -> None:
     """Simula layout do Apêndice 1 (tabela textual sem valores numéricos)."""
     linhas = [


### PR DESCRIPTION
## Descrição

Implementa o pipeline de extração dos dados do **Censo Demográfico 2022 — Quilombolas: alfabetização e características dos domicílios (resultados do universo)**, conforme issue de escopo.

Os arquivos são obtidos via **FTP** (`ftp.ibge.gov.br`), processados com parser específico para o layout IBGE (cabeçalhos duplos/triplos) e carregados no PostgreSQL no schema **`censo_demografico`**, com nomenclatura **`Q_A_C_D_[nome_da_tabela]`**.

A implementação segue o padrão da DAG `mulheres_ingest_dag`, reutilizando `ClienteIBGE` e `ClientPostgresDB`, com tasks mapeadas dinamicamente (`expand`) por arquivo.

### Fonte de dados

```
/Censos/Censo_Demografico_2022/Quilombolas_alfabetizacao_e_caracteristicas_dos_domicílios_Resultados_do_universo/
```

URL: https://ftp.ibge.gov.br/Censos/Censo_Demografico_2022/Quilombolas_alfabetizacao_e_caracteristicas_dos_domic%c3%adlios_Resultados_do_universo/

### Escopo de extração

| Alvo | Conteúdo ingerido | Exemplo de tabela |
|------|-------------------|-------------------|
| **Apêndices** | `Apendices/xlsx/*.xlsx` | `Q_A_C_D_apendice_01` |
| **Tabelas de resultados** | `Tabelas_de_resultados/xlsx/*.xlsx` + índice TXT | `Q_A_C_D_tabela_de_resultado_02`, `Q_A_C_D_indice_tabelas_de_resultados` |
| **Tabelas selecionadas** | `Tabelas_selecionadas/xlsx/*.xlsx` + índice TXT | `Q_A_C_D_tabela_complementar_01`, `Q_A_C_D_indice_tabelas_selecionadas` |

- **51 arquivos** `.xlsx` de dados + **2 arquivos** de índice (`.txt`)
- Formato **ODS** ignorado (prioridade `xlsx`)
- **Cartogramas** (PDF/JPG) **fora do escopo** — não são dados tabulares

### Critérios de aceitação (DoD)

- [x] Dados obtidos via protocolo **FTP**
- [x] Inserção no schema **`censo_demografico`**
- [x] **Flattening** de cabeçalhos duplos/triplos IBGE
- [x] **`COMMENT ON TABLE`** e **`COMMENT ON COLUMN`** com descrições originais
- [x] Reuso do **cliente FTP** (`ClienteIBGE`)
- [x] Métodos de **parsing e limpeza** específicos (`quilombolas_parser.py`)

### Arquivos alterados

**Novos**
| Arquivo | Descrição |
|---------|-----------|
| `airflow_lappis/dags/data_ingest/ibge/quilombolas_alfabetizacao_ingest_dag.py` | DAG `quilombolas_alfabetizacao_censo_dag` |
| `airflow_lappis/helpers/quilombolas_parser.py` | Flattening, PK, índices, nomenclatura `Q_A_C_D_` |
| `tests/test_quilombolas_parser.py` | 9 testes unitários |

**Modificados**
| Arquivo | Descrição |
|---------|-----------|
| `airflow_lappis/plugins/cliente_ibge.py` | `listar_arquivos_em_subpastas`, `listar_arquivos_texto`, download por `subcaminho` |
| `airflow_lappis/plugins/cliente_postgres.py` | `apply_comments`, `ensure_unique_constraint` |
| `airflow_lappis/dags/dbt/ipea/models/sources.yml` | Sources de exemplo `Q_A_C_D_*` |
| `pyproject.toml` | `pythonpath` do pytest para helpers/plugins |

### Detalhes técnicos

**Parser (`quilombolas_parser.py`)**
- Ignora linhas de metadado do Censo (título, tema) na composição dos nomes de coluna
- Flattening hierárquico com `ffill` horizontal e junção por `_`
- PK composta: menor prefixo de colunas à esquerda que identifica cada linha (ex.: território + código quando há várias UFs)
- Deduplicação por PK antes do upsert
- Índices TXT parseados em tabela estruturada (`ordem`, `tipo`, `numero`, `descricao`, `linha_original`)

**Postgres**
- Upsert idempotente (`ON CONFLICT DO UPDATE`)
- `ensure_unique_constraint`: cria índice UNIQUE para PK composta quando a tabela já existia sem constraint correta
- Metadados de auditoria: `dt_ingest`, `nome_fonte`, `subcaminho_fonte`

**DAG**
- Owner: **Lucas Guimaraes**
- Tags: `quilombolas`, `censo_demografico`, `ibge`, `alfabetizacao`
- Variable: `ibge_quilombolas_config` (chave `database` → pasta FTP do tema)

```mermaid
flowchart TB
    subgraph ftp [FTP IBGE]
        A[Apendices/xlsx]
        R[Tabelas_de_resultados/xlsx]
        S[Tabelas_selecionadas/xlsx]
        IR[indice_de_tabelas_de_resultados.txt]
        IS[indice_de_tabelas_seleciondas.txt]
    end

    subgraph dag [quilombolas_alfabetizacao_censo_dag]
        L1[listar_arquivos_dados]
        L2[listar_arquivos_indices]
        E1[extrair_dados_excel]
        E2[extrair_indice]
        I[inserir_chunks]
        C[consolidar_resultado]
    end

    subgraph pg [PostgreSQL]
        DB[(censo_demografico.Q_A_C_D_*)]
    end

    A --> L1
    R --> L1
    S --> L1
    IR --> L2
    IS --> L2
    L1 --> E1 --> I
    L2 --> E2 --> I
    I --> DB
    I --> C
```

### Configuração

| Parâmetro | Valor |
|-----------|--------|
| DAG ID | `quilombolas_alfabetizacao_censo_dag` |
| Connection Airflow | `postgres_default` |
| Variable | `ibge_quilombolas_config` → `{"database": "Quilombolas_alfabetizacao_e_caracteristicas_dos_domicílios_Resultados_do_universo"}` |
| Schedule (opcional) | `dynamic_schedules["quilombolas_censo_dag"]` |

---

## Test plan

### Automatizado

```bash
poetry run pytest tests/test_quilombolas_parser.py -v
```

### Manual — Airflow

- [x] Ambiente com `make dev` (connection `postgres_default` configurada)
- [x] DAG `quilombolas_alfabetizacao_censo_dag` visível e sem erros de import
- [x] Trigger manual → todas as tasks `inserir_chunks` e `consolidar_resultado` em sucesso
- [x] Reexecução da DAG confirma idempotência (sem duplicar linhas)

### Manual — PostgreSQL

```sql
-- Listar tabelas criadas
SELECT table_name
FROM information_schema.tables
WHERE table_schema = 'censo_demografico'
  AND table_name LIKE 'Q_A_C_D_%'
ORDER BY table_name;

-- Comentários (exemplo)
SELECT obj_description('censo_demografico.q_a_c_d_tabela_de_resultado_02'::regclass);

SELECT cols.column_name, pg_catalog.col_description(c.oid, cols.ordinal_position)
FROM information_schema.columns cols
JOIN pg_class c ON c.relname = cols.table_name
JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = cols.table_schema
WHERE cols.table_schema = 'censo_demografico'
  AND cols.table_name = 'q_a_c_d_tabela_de_resultado_02'
LIMIT 10;

-- Amostra de volume
SELECT COUNT(*) FROM censo_demografico."Q_A_C_D_tabela_de_resultado_01";  -- ~496
SELECT COUNT(*) FROM censo_demografico."Q_A_C_D_indice_tabelas_de_resultados"; -- 14
```

### Troubleshooting

Se uma task `inserir_chunks` falhar após execução parcial com schema antigo:

```sql
DROP TABLE IF EXISTS censo_demografico."Q_A_C_D_<nome_da_tabela>";
```

Depois: clear + retry da task ou nova execução da DAG.

---

Closes #116

---

## Notas para o revisor

- Não há models dbt de transformação — apenas **sources** declarados para consumo posterior.
- Tabelas com blocos horizontais no Excel geram sufixo `_parte_N` no nome.
- O pipeline **Mulheres** (`mulheres_ingest_dag`) permanece inalterado; extensões em `ClienteIBGE` e `ClientPostgresDB` são retrocompatíveis.
