### PR TITLE
feat: sufix argumento opcional

### DIFF
--- a/airflow_lappis/dags/data_ingest/tesouro_gerencial/mir/ne_tesouro_mir_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/tesouro_gerencial/mir/ne_tesouro_mir_ingest_dag.py
@@ -152,8 +152,9 @@ with DAG(
             creds["email"],
             creds["password"],
             creds["sender_email"],
-            EMAIL_SUBJECT,
+            None,
             target_date=target_date,
+            subject_suffix=EMAIL_SUBJECT,
         )
 
         if not zip_payloads:

--- a/airflow_lappis/plugins/cliente_email.py
+++ b/airflow_lappis/plugins/cliente_email.py
@@ -65,23 +65,37 @@ def fetch_email_with_zip(
     email: str,
     password: str,
     sender_email: str,
-    subject: str,
+    subject: Optional[str],
     target_date: Optional[date] = None,
+    subject_suffix: Optional[str] = None,
 ) -> List[bytes]:
     """Busca e-mails da data alvo (ou dia atual) e retorna os anexos ZIP."""
+    if not subject and not subject_suffix:
+        raise ValueError("subject ou subject_suffix precisa ser informado.")
+
     query_date = target_date or datetime.now(pytz.timezone("America/Sao_Paulo")).date()
     zip_payloads: List[bytes] = []
     with MailBox(imap_server).login(email, password) as mailbox:
         # bulk=True: single IMAP FETCH command for all messages (avoids overquota)
-        for msg in mailbox.fetch(
-            AND(date=query_date, from_=sender_email, subject=subject),
-            bulk=True,
-        ):
-            for attachment in msg.attachments:
-                if attachment.filename.lower().endswith(".zip"):
-                    zip_payloads.append(cast(bytes, attachment.payload))
+        if subject_suffix:
+            for msg in mailbox.fetch(
+                AND(date=query_date, from_=sender_email),
+                bulk=True,
+            ):
+                msg_subject = msg.subject or ""
+                if msg_subject.endswith(subject_suffix):
+                    for attachment in msg.attachments:
+                        if attachment.filename.lower().endswith(".zip"):
+                            zip_payloads.append(cast(bytes, attachment.payload))
+        else:
+            for msg in mailbox.fetch(
+                AND(date=query_date, from_=sender_email, subject=subject),
+                bulk=True,
+            ):
+                for attachment in msg.attachments:
+                    if attachment.filename.lower().endswith(".zip"):
+                        zip_payloads.append(cast(bytes, attachment.payload))
     return zip_payloads
-
 
 
 def fetch_email_with_csv(
@@ -92,7 +106,9 @@ def fetch_email_with_csv(
     csv_payloads: List[bytes] = []
     with MailBox(imap_server).login(email, password) as mailbox:
         # bulk=True: single IMAP FETCH command for all messages (avoids overquota)
-        for msg in mailbox.fetch(AND(date=today, from_=sender_email, subject=subject), bulk=True):
+        for msg in mailbox.fetch(
+            AND(date=today, from_=sender_email, subject=subject), bulk=True
+        ):
             for attachment in msg.attachments:
                 file_name = (attachment.filename or "").lower()
                 if file_name.endswith(".csv"):


### PR DESCRIPTION
## Descrição

Adiciona suporte ao parâmetro opcional `subject_suffix` na função `fetch_email_with_zip`, permitindo buscar e-mails cujo assunto termine com um determinado sufixo, além da busca exata já existente.

## Alterações realizadas

* Adicionado parâmetro opcional `subject_suffix` em `fetch_email_with_zip`
* Implementada lógica alternativa de busca utilizando `msg.subject.endswith(subject_suffix)`
* Mantida compatibilidade com o comportamento anterior quando `subject_suffix` não é informado
* Atualizada chamada em `ne_tesouro_mir_ingest_dag.py` para utilizar o novo parâmetro
* Ajustado formatting no método `fetch_email_with_csv`

## Motivação

Alguns e-mails possuem variações no assunto, impossibilitando a busca utilizando correspondência exata. Com essa alteração, a ingestão passa a suportar assuntos dinâmicos mantendo o filtro por sufixo.

## Impacto

* Não há quebra de compatibilidade
* Fluxos existentes continuam funcionando normalmente
* Melhora a robustez da captura de anexos ZIP via IMAP
