### PR TITLE
fix(pessoas_dbt): corrige chave do join com dados_uorg de sigla para cpf

### DIFF
--- a/airflow_lappis/dags/data_ingest/sgac/projetos_sgac_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/sgac/projetos_sgac_ingest_dag.py
@@ -11,6 +11,7 @@ from cliente_postgres import ClientPostgresDB
 from postgres_helpers import get_postgres_conn
 import pandas as pd
 import io
+import os
 
 # Configurações básicas da DAG
 default_args = {
@@ -112,7 +113,7 @@ with DAG(
     dag_id="email_projetos_sgac_ingest",
     default_args=default_args,
     description="Processa anexos do email de dados do SGAC e insere no db",
-    schedule_interval=get_dynamic_schedule("email_projetos_sgac_ingest"),
+    schedule_interval=get_dynamic_schedule("email_projetos_sgac_ingest", default="15 12 * * *"),
     start_date=datetime(2023, 12, 1),
     catchup=False,
     tags=["email", "projetos", "sgac"],
@@ -145,7 +146,12 @@ with DAG(
             logging.info(
                 "CSV processado com sucesso. Dados encontrados: %s", total_linhas
             )
-            return csv_data
+            
+            file_path = f"/tmp/sgac_email_data_{context['run_id']}.csv"
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(csv_data)
+                
+            return file_path
         except Exception as e:
             logging.error("Erro no processamento dos emails: %s", str(e))
             raise
@@ -154,15 +160,16 @@ with DAG(
         """Insere no Postgres os dados retornados pela task de processamento do e-mail."""
         try:
             task_instance: Any = context["ti"]
-            csv_data: Any = task_instance.xcom_pull(task_ids="process_emails")
+            file_path: Any = task_instance.xcom_pull(task_ids="process_emails")
 
-            if not csv_data:
+            if not file_path or not os.path.exists(file_path):
                 logging.warning("Nenhum dado para inserir no banco.")
                 return
 
-            df = pd.read_csv(io.StringIO(csv_data))
+            df = pd.read_csv(file_path)
             if df.empty:
                 logging.warning("CSV recebido sem registros para insercao.")
+                os.remove(file_path)
                 return
 
             data = df.to_dict(orient="records")
@@ -183,6 +190,7 @@ with DAG(
                 schema="sgac",
             )
             logging.info("Dados inseridos com sucesso no banco de dados.")
+            os.remove(file_path)
         except Exception as e:
             logging.error("Erro ao inserir dados no banco: %s", str(e))
             raise

--- a/airflow_lappis/dags/data_ingest/sgac/projetos_sgac_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/sgac/projetos_sgac_ingest_dag.py
@@ -12,6 +12,7 @@ from postgres_helpers import get_postgres_conn
 import pandas as pd
 import io
 import os
+import tempfile
 
 # Configurações básicas da DAG
 default_args = {
@@ -147,8 +148,8 @@ with DAG(
                 "CSV processado com sucesso. Dados encontrados: %s", total_linhas
             )
             
-            file_path = f"/tmp/sgac_email_data_{context['run_id']}.csv"
-            with open(file_path, "w", encoding="utf-8") as f:
+            fd, file_path = tempfile.mkstemp(prefix="sgac_email_data_", suffix=".csv")
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
                 f.write(csv_data)
                 
             return file_path
@@ -158,9 +159,10 @@ with DAG(
 
     def insert_data_to_db(**context: Dict[str, Any]) -> None:
         """Insere no Postgres os dados retornados pela task de processamento do e-mail."""
+        file_path = None
         try:
             task_instance: Any = context["ti"]
-            file_path: Any = task_instance.xcom_pull(task_ids="process_emails")
+            file_path = task_instance.xcom_pull(task_ids="process_emails")
 
             if not file_path or not os.path.exists(file_path):
                 logging.warning("Nenhum dado para inserir no banco.")
@@ -169,7 +171,6 @@ with DAG(
             df = pd.read_csv(file_path)
             if df.empty:
                 logging.warning("CSV recebido sem registros para insercao.")
-                os.remove(file_path)
                 return
 
             data = df.to_dict(orient="records")
@@ -190,10 +191,12 @@ with DAG(
                 schema="sgac",
             )
             logging.info("Dados inseridos com sucesso no banco de dados.")
-            os.remove(file_path)
         except Exception as e:
             logging.error("Erro ao inserir dados no banco: %s", str(e))
             raise
+        finally:
+            if file_path and os.path.exists(file_path):
+                os.remove(file_path)
 
     #tarefa 1: processar os e-mails e extrair o CSV
     process_emails_task = PythonOperator(

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/gold/contratos_comparativo_mensal.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/gold/contratos_comparativo_mensal.sql
@@ -29,7 +29,7 @@ with
     preenchimento as (select contrato_id, mes_ref from {{ ref("preenchimento_meses") }}),
 
     contratos as (
-        select id, numero, dt_ingest as dt_ingest_contratos
+        select id, numero, fornecedor_cnpj_cpf_idgener, fornecedor_tipo, fornecedor_nome, dt_ingest as dt_ingest_contratos
         from {{ ref("contratos") }}
     ),
 
@@ -63,6 +63,9 @@ select
     ccm.siafi_restos_a_pagar,
     ccm.siafi_restos_a_pagar_pago,
     c.numero,
+    c.fornecedor_cnpj_cpf_idgener,
+    c.fornecedor_tipo,
+    c.fornecedor_nome,
     greatest(ccm.dt_ingest::timestamptz, c.dt_ingest_contratos::timestamptz) as dt_ingest
 from comparativo_mensal as ccm
 left join contratos as c on ccm.contrato_id = c.id

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/gold/contratos_somatorio.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/gold/contratos_somatorio.sql
@@ -1,5 +1,9 @@
 select
     contrato_id,
+    numero,
+    fornecedor_cnpj_cpf_idgener,
+    fornecedor_tipo,
+    fornecedor_nome,
     sum(comprasgov_valor_cronograma) as total_cronograma,
     sum(comprasgov_valor_faturas) as total_faturas,
     sum(comprasgov_saldo_contratual_disponivel) as total_saldo_disponivel,
@@ -15,4 +19,4 @@ select
     max(dt_ingest) as dt_ingest
 
 from {{ ref("contratos_comparativo_mensal") }}
-group by contrato_id
+group by contrato_id, numero, fornecedor_cnpj_cpf_idgener, fornecedor_tipo, fornecedor_nome

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/gold/schema.yml
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/gold/schema.yml
@@ -88,6 +88,15 @@ models:
       - name: numero
         description: >
           Número do contrato no sistema ComprasGov.
+      - name: fornecedor_cnpj_cpf_idgener
+        description: >
+          CNPJ, CPF ou identificador genérico do fornecedor do contrato.
+      - name: fornecedor_tipo
+        description: >
+          Tipo do fornecedor do contrato.
+      - name: fornecedor_nome
+        description: >
+          Nome ou razão social do fornecedor associado ao contrato.
       - name: mes_ref
         description: >
           Mês de referência da informação financeira, preenchido para todos os meses entre o início e fim do contrato.
@@ -125,6 +134,18 @@ models:
       - name: contrato_id
         description: >
           Identificador único do contrato.
+      - name: numero
+        description: >
+          Número do contrato no sistema ComprasGov.
+      - name: fornecedor_cnpj_cpf_idgener
+        description: >
+          CNPJ, CPF ou identificador genérico do fornecedor do contrato.
+      - name: fornecedor_tipo
+        description: >
+          Tipo do fornecedor do contrato.
+      - name: fornecedor_nome
+        description: >
+          Nome ou razão social do fornecedor associado ao contrato.
       - name: total_cronograma
         description: >
           Soma de todos os valores programados no cronograma do contrato.

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/contratos_empenhos.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/contratos_empenhos.sql
@@ -209,7 +209,10 @@ with
     contratos as (
         select
             id,
+            fornecedor_tipo,
             fornecedor_nome,
+            fornecedor_cnpj_cpf_idgener,
+            numero,
             unidades_requisitantes,
             objeto,
             vigencia_inicio,
@@ -234,7 +237,10 @@ select
     ce.despesas_empenhadas,
     ce.despesas_liquidadas,
     ce.despesas_pagas,
+    cc.fornecedor_tipo,
     cc.fornecedor_nome,
+    cc.fornecedor_cnpj_cpf_idgener,
+    cc.numero,
     cc.unidades_requisitantes,
     cc.objeto,
     cc.vigencia_inicio,

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/contratos_estagios.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/contratos_estagios.sql
@@ -98,19 +98,29 @@ with
         union
         select *
         from joined_table_3
+    ),
+
+    contratos as (
+        select id, numero, fornecedor_cnpj_cpf_idgener, fornecedor_tipo, fornecedor_nome, dt_ingest as dt_ingest_contratos
+        from {{ ref("contratos") }}
     )
 
 --
 select
-    contrato_id,
-    mes_lancamento,
-    sum(valor_empenhado) as valor_empenhado,
-    sum(valor_liquidado) as valor_liquidado,
-    sum(valor_pago) as valor_pago,
-    sum(restos_a_pagar) as restos_a_pagar,
-    sum(restos_a_pagar_pago) as restos_a_pagar_pago,
-    max(dt_ingest) as dt_ingest
-from result_table
-where contrato_id is not null
-group by 1, 2
-order by contrato_id, mes_lancamento
+    r.contrato_id,
+    c.numero,
+    c.fornecedor_cnpj_cpf_idgener,
+    c.fornecedor_tipo,
+    c.fornecedor_nome,
+    r.mes_lancamento,
+    sum(r.valor_empenhado) as valor_empenhado,
+    sum(r.valor_liquidado) as valor_liquidado,
+    sum(r.valor_pago) as valor_pago,
+    sum(r.restos_a_pagar) as restos_a_pagar,
+    sum(r.restos_a_pagar_pago) as restos_a_pagar_pago,
+    greatest(max(r.dt_ingest), max(c.dt_ingest_contratos)) as dt_ingest
+from result_table r
+left join contratos c on r.contrato_id = c.id
+where r.contrato_id is not null
+group by 1, 2, 3, 4, 5, 6
+order by r.contrato_id, r.mes_lancamento

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/contratos_faturas.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/contratos_faturas.sql
@@ -5,6 +5,8 @@ with
         select
             id::int as contrato_id,
             fornecedor_cnpj_cpf_idgener,
+            fornecedor_tipo,
+            fornecedor_nome,
             processo as processo_contrato,
             numero as numero_contrato,
             objeto as objeto_contrato,
@@ -21,6 +23,8 @@ select
     c.numero_contrato,
     c.processo_contrato as contrato_processo,
     c.fornecedor_cnpj_cpf_idgener,
+    c.fornecedor_tipo,
+    c.fornecedor_nome,
     c.objeto_contrato,
     c.unidades_requisitantes,
     f.tipolistafatura_id,

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/cronogramas_faturas_mensal.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/cronogramas_faturas_mensal.sql
@@ -74,7 +74,24 @@ with
             greatest(dt_ingest_pago, dt_ingest_pendente) AS dt_ingest
         from joined_table
         order by contrato_id, mes_ref
+    ),
+
+    contratos as (
+        select id::text as contrato_id, numero, fornecedor_cnpj_cpf_idgener, fornecedor_tipo, fornecedor_nome, dt_ingest
+        from {{ ref("contratos") }}
     )
 
-select *
-from joined_ajustado
+select 
+    ja.contrato_id,
+    ja.mes_ref,
+    ja.valor_cronograma,
+    ja.valor_faturas_pagas,
+    ja.valor_faturas_pendentes,
+    ja.saldo_contratual_disponivel,
+    c.numero,
+    c.fornecedor_cnpj_cpf_idgener,
+    c.fornecedor_tipo,
+    c.fornecedor_nome,
+    greatest(ja.dt_ingest::timestamp with time zone, c.dt_ingest::timestamp with time zone) as dt_ingest
+from joined_ajustado ja
+left join contratos c using (contrato_id)

--- a/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/schema.yml
+++ b/airflow_lappis/dags/dbt/ipea/models/contratos_dbt/silver/schema.yml
@@ -58,6 +58,12 @@ models:
       - name: fornecedor_nome
         description: >
           Nome do fornecedor associado ao contrato.
+      - name: fornecedor_cnpj_cpf_idgener
+        description: >
+          CNPJ, CPF ou identificador genérico do fornecedor do contrato.
+      - name: numero
+        description: >
+          Número do contrato no sistema ComprasGov.
       - name: unidades_requisitantes
         description: >
           Unidades requisitantes associadas ao contrato.
@@ -87,6 +93,18 @@ models:
       - name: contrato_id
         description: >
           Identificador único do contrato relacionado aos estágios.
+      - name: numero
+        description: >
+          Número do contrato no sistema ComprasGov.
+      - name: fornecedor_cnpj_cpf_idgener
+        description: >
+          CNPJ, CPF ou identificador genérico do fornecedor do contrato.
+      - name: fornecedor_tipo
+        description: >
+          Tipo do fornecedor do contrato.
+      - name: fornecedor_nome
+        description: >
+          Nome ou razão social do fornecedor associado ao contrato.
       - name: mes_lancamento
         description: >
           Mês em que o estágio da despesa foi registrado no SIAFI.
@@ -164,6 +182,12 @@ models:
       - name: fornecedor_cnpj_cpf_idgener
         description: >
           CNPJ, CPF ou identificador genérico do fornecedor do contrato.
+      - name: fornecedor_tipo
+        description: >
+          Tipo do fornecedor do contrato.
+      - name: fornecedor_nome
+        description: >
+          Nome ou razão social do fornecedor associado ao contrato.
       - name: objeto_contrato
         description: >
           Descrição do objeto contratado.
@@ -270,6 +294,18 @@ models:
       - name: contrato_id
         description: >
           Identificador único do contrato.
+      - name: numero
+        description: >
+          Número do contrato no sistema ComprasGov.
+      - name: fornecedor_cnpj_cpf_idgener
+        description: >
+          CNPJ, CPF ou identificador genérico do fornecedor do contrato.
+      - name: fornecedor_tipo
+        description: >
+          Tipo do fornecedor do contrato.
+      - name: fornecedor_nome
+        description: >
+          Nome ou razão social do fornecedor associado ao contrato.
       - name: mes_ref
         description: >
           Mês de referência dos valores programados e faturados.

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/distribuicao_mapa_uf.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/distribuicao_mapa_uf.sql
@@ -7,7 +7,7 @@ with
             df.cpf, du.uf_uorg, du.nome_municipio_uorg, df.nome_situacao_funcional,
             greatest(df.dt_ingest, du.dt_ingest) as dt_ingest
         from {{ ref("dados_funcionais") }} df
-        inner join {{ ref("dados_uorg") }} du on df.sigla_uorg_exercicio = du.sigla_uorg
+        inner join {{ ref("dados_uorg") }} du on df.cpf = du.cpf
         where du.uf_uorg is not null
     ),
 

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/distribuicao_situacao_funcional.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/distribuicao_situacao_funcional.sql
@@ -22,7 +22,7 @@ with
             du.nome_municipio_uorg,
             greatest(df.dt_ingest, du.dt_ingest) as dt_ingest_max
         from {{ ref("dados_funcionais") }} df
-        inner join {{ ref("dados_uorg") }} du on df.sigla_uorg_exercicio = du.sigla_uorg
+        inner join {{ ref("dados_uorg") }} du on df.cpf = du.cpf
     )
 
 select

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/hierarquia.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/hierarquia.sql
@@ -187,7 +187,7 @@ with
             du.nome_municipio_uorg,
             du.dt_ingest as dt_ingest_dados_uorg
         from hierarquia_enriquecida as ph
-        inner join {{ ref("dados_uorg") }} as du on ph.siglaunidade = du.sigla_uorg
+        inner join {{ ref("dados_uorg") }} as du on ph.cpf = du.cpf
         order by caminho_unidade, hierarquia_cargo
     ),
 

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/tabela_servidores_agregada.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/tabela_servidores_agregada.sql
@@ -13,7 +13,7 @@ with
             greatest(df.dt_ingest, dp.dt_ingest, du.dt_ingest) as dt_ingest
         from {{ ref("dados_funcionais") }} df
         inner join {{ ref("dados_pessoais") }} dp on df.cpf = dp.cpf
-        inner join {{ ref("dados_uorg") }} du on df.sigla_uorg_exercicio = du.sigla_uorg
+        inner join {{ ref("dados_uorg") }} du on df.cpf = du.cpf
         where
             df.nome_cargo is not null
             and dp.nome_sexo is not null

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/silver/dados_funcionais_enriquecidos.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/silver/dados_funcionais_enriquecidos.sql
@@ -86,4 +86,6 @@ select distinct
     du.nome_municipio_uorg,
     greatest(df.dt_ingest, du.dt_ingest) as dt_ingest
 from {{ ref("dados_funcionais") }} as df
-inner join {{ ref("dados_uorg") }} as du on df.sigla_uorg_exercicio = du.sigla_uorg
+-- INNER JOIN: exclui servidores sem uorg ativa (ex: aposentados, cedidos a outros órgãos).
+-- Esses servidores existem em dados_funcionais mas não possuem entrada em dados_uorg.
+inner join {{ ref("dados_uorg") }} as du on df.cpf = du.cpf

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/silver/servidores_completos.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/silver/servidores_completos.sql
@@ -57,7 +57,7 @@ with
     servidores_enriquecidos as (
         select distinct ph.*, du.nome_municipio_uorg, du.dt_ingest as dt_ingest_du
         from hierarquia_enriquecida ph
-        inner join {{ ref("dados_uorg") }} du on ph.siglaunidade = du.sigla_uorg
+        inner join {{ ref("dados_uorg") }} du on ph.cpf = du.cpf
         order by caminho_unidade, hierarquia_cargo
     )
 


### PR DESCRIPTION
**O que foi alterado:**

- 6 modelos do pessoas_dbt usavam sigla_uorg_exercicio = sigla_uorg como chave de join com dados_uorg. Como dados_uorg tem 1 linha por CPF e 88 siglas distintas, o join por sigla causava multiplicação de linhas, gerando duplicações nos resultados.

- A correção substitui a chave pelo cpf em todos os modelos afetados