### PR TITLE
feat: adequações de modelos DBT conforme apontamentos do CEAG

### DIFF
--- a/airflow_lappis/dags/dbt/mir/models/emendas_dbt/bronze/tg_emendas.sql
+++ b/airflow_lappis/dags/dbt/mir/models/emendas_dbt/bronze/tg_emendas.sql
@@ -24,8 +24,14 @@ with
 			localizador_gasto::text as localizador_gasto,
 			localizador_gasto_descricao::text as localizador_gasto_descricao,
 			regiao_pt::text as regiao_pt,
-			uf_pt::text as uf_pt,
-			uf_pt_descricao::text as uf_pt_descricao,
+			case
+    			when uf_pt = '-8' then regiao_pt
+    			else uf_pt
+			end as uf_pt,
+			case
+    			when uf_pt_descricao = 'SEM INFORMACAO' then regiao_pt
+    			else uf_pt_descricao
+			end::text as uf_pt_descricao,
 			municipio_pt::text as municipio_pt,
 			ne_ccor::text as ne_ccor,
 			ne_num_processo::text as ne_num_processo,

--- a/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/silver/empenhos_por_plano_acao.sql
+++ b/airflow_lappis/dags/dbt/mir/models/empenhos_ted_dbt/silver/empenhos_por_plano_acao.sql
@@ -534,13 +534,15 @@ SELECT
     COALESCE(ert.nc, r.nc) AS nc,
     COALESCE(ert.num_transf, r.num_transf) AS num_transf,
     -- método calculado dinamicamente
+    /*
     CASE
         WHEN (ert.nc IS NULL AND r.nc IS NOT NULL)
           OR (ert.num_transf IS NULL AND r.num_transf IS NOT NULL)
         THEN 'metodo 9'
         ELSE ert.metodo
     END AS metodo,
-    complemento_ted, num_ted, metodo_ted, numero_base, ano_raw, ano_normalizado, ano_oficial,
+    */
+    complemento_ted, num_ted, numero_base, ano_raw, ano_normalizado, ano_oficial,
     numero_ted_normalizado
     FROM union_metodo_7_8 ert
     LEFT JOIN ids_agregados_num_ted_normalizado r USING (orgao_id,numero_ted_normalizado)


### PR DESCRIPTION
## Descrição

Este PR implementa ajustes solicitados pela equipe do CEAG relacionados à estruturação dos dados consumidos pelo BI e indicadores, contemplando correções que podem ser realizadas diretamente nos modelos DBT.

### Alterações realizadas

#### 1. Tratamento de registros sem UF identificada

No modelo `tg_emendas`, foi ajustada a identificação geográfica para os casos em que a UF vem com valor `-8`:

- Quando `uf_pt = '-8'`, o campo passa a assumir o valor de `regiao_pt`.
- Quando `uf_pt_descricao = 'SEM INFORMACAO'`, o campo passa a assumir o valor de `regiao_pt`.

Objetivo: evitar registros sem identificação territorial útil para análises e agregações nos painéis.

#### 2. Remoção de colunas operacionais relacionadas a métodos

No modelo `empenhos_por_plano_acao`, foram removidos da camada de saída os campos:

- `metodo`
- `metodo_ted`

Além disso, foi removida a lógica de cálculo dinâmico do campo `metodo`, por se tratar de informação operacional sem utilização nos indicadores e visualizações do BI.

Objetivo: simplificar o conjunto de dados disponibilizado para consumo analítico e reduzir exposição de colunas intermediárias sem uso nos painéis.

### Impacto esperado

- Melhor identificação regional de registros sem UF válida.
- Redução de valores classificados como "sem informação" em análises territoriais.
- Simplificação dos datasets disponibilizados para o BI.