### PR TITLE
docs: padroniza protocolo de revisão de pull requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# Revisores por dominio do repositorio
+#
+# Para que estas regras bloqueiem merge sem aprovacao do dominio correto,
+# a branch main deve exigir "Require review from Code Owners".
+
+# DAGs, modelos dbt e documentacao tecnica de dados
+/airflow_lappis/dags/ @GovHub-br/developers
+/airflow_lappis/templates/ @GovHub-br/developers
+
+# Plugins, helpers e componentes compartilhados de infraestrutura da aplicacao
+/airflow_lappis/plugins/ @GovHub-br/infra
+/airflow_lappis/helpers/ @GovHub-br/infra
+
+# Configuracao do GitHub, CI/CD e documentacao de contribuicao
+/.github/ @GovHub-br/infra
+
+# Configuracoes de build, ambiente e execucao local
+/Dockerfile @GovHub-br/infra
+/Dockerfile.superset @GovHub-br/infra
+/docker-compose.yml @GovHub-br/infra
+/Makefile @GovHub-br/infra
+/pyproject.toml @GovHub-br/infra
+/requirements.txt @GovHub-br/infra
+/setup-git-hooks.sh @GovHub-br/infra
+
+# Documentacao geral do projeto
+/README.md @GovHub-br/developers @GovHub-br/infra

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,9 +7,9 @@
 /airflow_lappis/dags/ @GovHub-br/developers
 /airflow_lappis/templates/ @GovHub-br/developers
 
-# Plugins, helpers e componentes compartilhados de infraestrutura da aplicacao
-/airflow_lappis/plugins/ @GovHub-br/infra
-/airflow_lappis/helpers/ @GovHub-br/infra
+# Plugins, helpers e componentes compartilhados da aplicacao
+/airflow_lappis/plugins/ @GovHub-br/developers
+/airflow_lappis/helpers/ @GovHub-br/developers
 
 # Configuracao do GitHub, CI/CD e documentacao de contribuicao
 /.github/ @GovHub-br/infra

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Obrigado por considerar contribuir com o **Gov Hub BR**! O GovHub BR é uma plat
 - [Configurando o Ambiente Local](#configurando-o-ambiente-local)
 - [Convenções de Branch e Commit](#convenções-de-branch-e-commit)
 - [Fluxo de Pull Request](#fluxo-de-pull-request)
+- [Protocolo de Aprovação de Pull Requests](#protocolo-de-aprovação-de-pull-requests)
 - [Como Pegar ou Atribuir Issues](#como-pegar-ou-atribuir-issues)
 - [Processo de Code Review](#processo-de-code-review)
 - [Executando os Testes](#executando-os-testes)
@@ -22,7 +23,7 @@ Obrigado por considerar contribuir com o **Gov Hub BR**! O GovHub BR é uma plat
 
 ## Código de Conduta
 
-Por favor, leia nosso [Código de Conduta](CODE_OF_CONDUCT.md). Ele está em vigor o tempo todo e esperamos que seja respeitado por todos que contribuem para este projeto. Comportamentos inadequados não serão tolerados.
+Esperamos que todas as pessoas contribuam com respeito, colaboração e responsabilidade. Comportamentos inadequados, ofensivos ou discriminatórios não serão tolerados.
 
 ---
 
@@ -34,6 +35,8 @@ Por favor, leia nosso [Código de Conduta](CODE_OF_CONDUCT.md). Ele está em vig
 │   ├── actions/
 │   ├── TEMPLATES/
 │   ├── workflows/
+│   ├── PULL_REQUEST_TEMPLATE.md
+│   ├── MERGE_REQUEST_PROTOCOL.md
 │   └── CONTRIBUTING.md        # Este arquivo
 ├── airflow_lappis/
 │   ├── dags/
@@ -121,7 +124,12 @@ Os mesmos prefixos são usados tanto no nome da branch quanto na mensagem de com
 | `fix` | Correção de bug ou inconsistência de dados |
 | `docs` | Alterações apenas em documentação |
 | `refactor` | Refatoração sem mudança de comportamento |
+| `perf` | Melhoria de desempenho |
+| `test` | Adição ou correção de testes |
+| `build` | Mudanças em dependências ou sistema de build |
 | `ci` | Mudanças em CI/CD ou infraestrutura |
+| `chore` | Ajustes que não afetam código-fonte ou testes |
+| `style` | Formatação que não afeta lógica |
 
 **Branch:** `<tipo>/<descricao-curta>`
 
@@ -165,17 +173,27 @@ git rebase upstream/main
 git push origin feat/integracao-siafi-despesas
 ```
 
-Em seguida, abra um Pull Request no GitHub apontando para a branch `main` do repositório principal. O modelo de PR está disponível em `.github/TEMPLATES/PULL_REQUEST_TEMPLATE.md` e será preenchido automaticamente ao abrir um PR.
+Em seguida, abra um Pull Request no GitHub apontando para a branch `main` do repositório principal. O modelo de PR está disponível em `.github/PULL_REQUEST_TEMPLATE.md` e será preenchido automaticamente ao abrir um PR.
+
+As regras obrigatórias de abertura, revisão, aprovação e merge estão documentadas no [Protocolo de Aprovação de Pull Requests](MERGE_REQUEST_PROTOCOL.md).
 
 ### Checklist antes de abrir o PR
 
 - [ ] As alterações funcionam corretamente no ambiente local
 - [ ] Os testes passam (`make test`)
 - [ ] O lint não aponta erros (`make lint`)
-- [ ] A branch está atualizada com `upstream/main`
+- [ ] A branch está atualizada com `upstream/main` ou `origin/main`
 - [ ] O título segue o padrão Conventional Commits
 - [ ] A issue relacionada está referenciada (`Closes #<número>`)
 - [ ] Documentação atualizada, se aplicável
+
+---
+
+## Protocolo de Aprovação de Pull Requests
+
+O fluxo formal de revisão e aprovação está definido no [Protocolo de Aprovação de Pull Requests](MERGE_REQUEST_PROTOCOL.md).
+
+Esse protocolo detalha critérios obrigatórios de documentação, testes, lint, revisão por domínio, quantidade mínima de aprovações, regras para merges urgentes e responsabilidades de autores e revisores.
 
 ---
 
@@ -195,6 +213,8 @@ Toda solicitação de mudança ou sugestão deve ser registrada como issue.
 
 ## Processo de Code Review
 
+Consulte o [Protocolo de Aprovação de Pull Requests](MERGE_REQUEST_PROTOCOL.md) para os critérios obrigatórios de revisão, aprovação e merge.
+
 **Para quem submete o PR:** responda a todos os comentários de revisão, implemente as mudanças em novos commits e aguarde nova aprovação antes do merge.
 
 **Para quem faz o review:** seja construtivo e específico, explique o *porquê* das sugestões, diferencie bloqueadores de sugestões opcionais, e verifique qualidade dos modelos DBT, linhagem de dados, testes e impacto em pipelines existentes. O merge é responsabilidade dos mantenedores.
@@ -208,7 +228,8 @@ Toda solicitação de mudança ou sugestão deve ser registrada como issue.
 make test
 
 # Testes DBT por modelo específico
-dbt test --select modelo_gold_orcamento
+cd airflow_lappis/dags/dbt/<projeto>
+dbt test --select <nome_do_modelo>
 
 # Compilar modelos sem executar (validação de SQL)
 dbt compile

--- a/.github/MERGE_REQUEST_PROTOCOL.md
+++ b/.github/MERGE_REQUEST_PROTOCOL.md
@@ -1,0 +1,274 @@
+# Protocolo de Aprovação de Pull Requests
+
+Este documento define o fluxo obrigatório para abertura, revisão e aprovação de Pull Requests (PRs) no repositório. O objetivo é garantir qualidade, rastreabilidade e consistência nas contribuições de código, dados, infraestrutura e documentação.
+
+> Neste repositório, o fluxo operacional usa Pull Requests do GitHub. Quando houver referência a Merge Request (MR), considere o mesmo protocolo.
+
+---
+
+## Escopo
+
+Este protocolo se aplica a qualquer PR que envolva:
+
+- Código: novas DAGs, alterações em DAGs existentes, modelos dbt, plugins e helpers
+- Documentação: criação ou edição de arquivos `.md`, `schema.yml`, `.github/CONTRIBUTING.md`, entre outros
+- Infraestrutura e CI/CD: workflows, configurações, dependências e automações
+
+---
+
+## Fluxo Geral
+
+```text
+branch de trabalho -> commits padronizados -> PR aberto -> revisão -> aprovação -> merge na main
+```
+
+Nenhum merge deve ser feito diretamente na `main` sem passar pelo fluxo de PR.
+
+---
+
+## 1. Mensagens de Commit
+
+O projeto adota o padrão **Conventional Commits**. Toda mensagem de commit deve seguir a estrutura:
+
+```text
+<tipo>[escopo opcional]: <descrição>
+```
+
+| Tipo | Quando usar |
+| --- | --- |
+| `feat` | Nova DAG, novo modelo, nova funcionalidade |
+| `fix` | Correção de bug ou comportamento incorreto |
+| `docs` | Criação ou edição de documentação |
+| `refactor` | Refatoração sem mudança de comportamento |
+| `perf` | Melhoria de desempenho |
+| `test` | Adição ou correção de testes |
+| `build` | Mudanças em dependências ou sistema de build |
+| `ci` | Mudanças em configurações de CI |
+| `chore` | Ajustes que não afetam código-fonte ou testes |
+| `style` | Formatação que não afeta lógica |
+
+Exemplos:
+
+- `feat(siafi): adiciona dag de ingestão de notas de crédito`
+- `fix(dbt): corrige deduplicação no modelo slv_contratos_empenhos`
+- `docs: adiciona guia de padrões de engenharia`
+
+Regras:
+
+- A descrição deve estar em letras minúsculas e sem ponto final
+- O corpo do commit, quando existir, deve ser separado da descrição por uma linha em branco
+- Para fechar uma issue automaticamente, use `Closes: #<número>` no rodapé
+
+Consulte também o [template de commit](TEMPLATES/COMMIT_TEMPLATE.md).
+
+---
+
+## 2. Nomenclatura de Branches
+
+O repositório usa dois formatos aceitos.
+
+Formato padrão:
+
+```text
+<tipo>/<descricao-curta>
+```
+
+Formato com issue vinculada:
+
+```text
+<numero-da-issue>-<tipo>-<descricao-curta>
+```
+
+Exemplos:
+
+- `feat/siafi-nota-credito-ingestao`
+- `fix/fechamento-conn-postgres`
+- `docs/protocolo-mr`
+- `149-feat-ingestao-sisbolsas`
+- `24-fix-dag-nota-de-credito`
+
+---
+
+## 3. Antes de Abrir o PR
+
+Certifique-se de que sua branch está atualizada em relação à `main` do repositório principal:
+
+```bash
+git fetch upstream
+git rebase upstream/main
+```
+
+Se o clone usa apenas o remote `origin` apontando para `GovHub-br/data-application-gov-hub`, use:
+
+```bash
+git fetch origin
+git rebase origin/main
+```
+
+Para PRs de código, execute testes e lint localmente antes de abrir:
+
+```bash
+make lint
+make test
+```
+
+Para PRs de DAGs, rode a DAG localmente e confirme que não há erros de importação:
+
+```bash
+airflow dags test <nome_da_dag> <data_execucao>
+```
+
+Para PRs de modelos dbt, execute os comandos dentro do projeto dbt alterado:
+
+```bash
+cd airflow_lappis/dags/dbt/<projeto>
+dbt run --select <modelo>
+dbt test --select <modelo>
+```
+
+Para PRs de documentação, revise ortografia, links e formatação antes de abrir.
+
+---
+
+## 4. Preenchimento do PR
+
+O título do PR deve ser curto, descritivo e seguir o mesmo padrão dos commits.
+
+A descrição deve conter:
+
+- **O que foi feito:** resumo claro das mudanças
+- **Por que foi feito:** contexto ou issue relacionada
+- **Como testar:** passos para o revisor validar as mudanças
+- **Evidências:** logs, prints, resultados de testes, consultas ou links relevantes
+- **Checklist:** itens obrigatórios verificados antes da revisão
+
+Exemplo:
+
+```md
+## Descrição
+
+Adicionada DAG de ingestão de notas de crédito do SIAFI.
+
+## Issues relacionadas
+
+Closes #42
+
+## Como testar / validar
+
+1. Subir o ambiente local
+2. Triggerar manualmente a DAG `siafi_nota_credito_ingestao`
+3. Verificar registros inseridos no schema `siafi`
+
+## Evidências
+
+- `make lint` executado com sucesso
+- `make test` executado com sucesso
+
+## Checklist
+
+- [x] Título do PR segue Conventional Commits
+- [x] Issue relacionada foi referenciada
+- [x] Testes/lint foram executados ou a ausência foi justificada
+- [x] Documentação atualizada, se aplicável
+```
+
+---
+
+## 5. Revisores
+
+### Quem Deve Revisar
+
+| Tipo de PR | Revisores |
+| --- | --- |
+| DAGs de ingestão | Equipe de desenvolvimento/dados |
+| Modelos dbt | Equipe de desenvolvimento/dados |
+| Plugins e helpers | Equipe de arquitetura/infraestrutura |
+| Documentação de configuração, infraestrutura ou deploy | Equipe de arquitetura/infraestrutura |
+| Documentação de DAGs, modelos dbt ou fluxo de dados | Equipe de desenvolvimento/dados |
+
+Quando houver times configurados no GitHub, solicite revisão do time responsável pelo domínio alterado. Caso os times ainda não estejam configurados, solicite revisão de pelo menos uma pessoa mantenedora ou responsável técnica pela área.
+
+### Número Mínimo de Aprovações
+
+- PRs de código: mínimo de **1 aprovação** de uma pessoa revisora do domínio alterado
+- PRs de documentação: mínimo de **1 aprovação** de uma pessoa responsável pelo tipo de documentação
+- PRs críticos, sensíveis ou com impacto em produção: recomendado exigir **2 aprovações**
+
+### Configuração Recomendada no GitHub
+
+Para aplicar essas regras automaticamente, recomenda-se configurar:
+
+- `CODEOWNERS`, apontando cada área do projeto para o time responsável
+- Proteção da branch `main`, exigindo revisão antes do merge
+- Opção **Require review from Code Owners** habilitada
+
+Essas configurações ainda dependem da administração do repositório. Enquanto não estiverem ativas, as regras deste protocolo devem ser verificadas manualmente por autores, revisores e mantenedores.
+
+---
+
+## 6. Durante a Revisão
+
+O revisor deve:
+
+- Aprovar o PR se estiver tudo certo
+- Solicitar mudanças com comentários claros e objetivos
+- Explicar o que está errado e, sempre que possível, sugerir como corrigir
+- Bloquear o PR com `request changes` apenas em casos de problema real: bug, credencial exposta, violação de padrão crítico ou dado sensível
+
+Comentários de estilo ou preferência pessoal que não violam nenhum padrão documentado **não devem bloquear** o merge. Eles podem ser deixados como sugestão opcional.
+
+Recomenda-se que a primeira resposta de revisão aconteça em até **2 dias úteis**, salvo indisponibilidade do time.
+
+---
+
+## 7. Após Pedido de Mudança
+
+O autor deve:
+
+- Responder a **todos** os comentários antes de pedir nova revisão
+- Aplicar a mudança solicitada ou justificar por que ela não faz sentido
+- Marcar cada comentário como resolvido após endereçá-lo
+- Avisar o revisor quando as mudanças estiverem prontas para uma nova rodada
+
+Se houver discordância sobre um comentário, a discussão deve acontecer na própria thread do PR. Se não houver consenso, escale para o time no canal de comunicação para evitar que o PR fique parado indefinidamente.
+
+---
+
+## 8. Critérios de Aprovação
+
+### Para Código
+
+- [ ] A DAG ou modelo segue os padrões de engenharia e organização do repositório
+- [ ] Não há `SELECT *` em modelos finais dbt
+- [ ] Não há credenciais ou dados sensíveis commitados
+- [ ] Testes passam (`make test`, `dbt test`)
+- [ ] Lint passa (`make lint`)
+- [ ] Commits seguem Conventional Commits
+- [ ] A lógica está correta e o código é legível
+- [ ] Plugins e helpers existentes foram reaproveitados quando aplicável
+
+### Para Documentação
+
+- [ ] O conteúdo é preciso e reflete o estado real do repositório
+- [ ] A formatação Markdown está correta
+- [ ] Links estão funcionando
+- [ ] Não contradiz outras documentações existentes
+- [ ] Commits seguem Conventional Commits
+
+---
+
+## 9. Merge
+
+- O merge só pode ser feito após todas as aprovações necessárias
+- Usar **merge commit** como padrão do repositório, preservando o histórico completo dos PRs
+- Deletar a branch após o merge
+
+---
+
+## 10. PRs Urgentes
+
+Em casos excepcionais que exijam merge imediato, como incidente em produção ou correção crítica:
+
+- Notificar o time no canal de comunicação antes de mergear
+- Obter no mínimo **1 aprovação** de pessoa do time responsável
+- Abrir issue de acompanhamento para revisão posterior, se necessário

--- a/.github/MERGE_REQUEST_PROTOCOL.md
+++ b/.github/MERGE_REQUEST_PROTOCOL.md
@@ -182,7 +182,7 @@ Closes #42
 | --- | --- |
 | DAGs de ingestão | `@GovHub-br/developers` |
 | Modelos dbt | `@GovHub-br/developers` |
-| Plugins e helpers | `@GovHub-br/infra` |
+| Plugins e helpers | `@GovHub-br/developers` |
 | Documentação de configuração, infraestrutura ou deploy | `@GovHub-br/infra` |
 | Documentação de DAGs, modelos dbt ou fluxo de dados | `@GovHub-br/developers` |
 

--- a/.github/MERGE_REQUEST_PROTOCOL.md
+++ b/.github/MERGE_REQUEST_PROTOCOL.md
@@ -180,13 +180,13 @@ Closes #42
 
 | Tipo de PR | Revisores |
 | --- | --- |
-| DAGs de ingestão | Equipe de desenvolvimento/dados |
-| Modelos dbt | Equipe de desenvolvimento/dados |
-| Plugins e helpers | Equipe de arquitetura/infraestrutura |
-| Documentação de configuração, infraestrutura ou deploy | Equipe de arquitetura/infraestrutura |
-| Documentação de DAGs, modelos dbt ou fluxo de dados | Equipe de desenvolvimento/dados |
+| DAGs de ingestão | `@GovHub-br/developers` |
+| Modelos dbt | `@GovHub-br/developers` |
+| Plugins e helpers | `@GovHub-br/infra` |
+| Documentação de configuração, infraestrutura ou deploy | `@GovHub-br/infra` |
+| Documentação de DAGs, modelos dbt ou fluxo de dados | `@GovHub-br/developers` |
 
-Quando houver times configurados no GitHub, solicite revisão do time responsável pelo domínio alterado. Caso os times ainda não estejam configurados, solicite revisão de pelo menos uma pessoa mantenedora ou responsável técnica pela área.
+Os times `@GovHub-br/developers` e `@GovHub-br/infra` são os responsáveis atuais pelos domínios técnicos do repositório. Caso um PR altere mais de um domínio, solicite revisão de todos os times responsáveis pelas áreas impactadas.
 
 ### Número Mínimo de Aprovações
 
@@ -196,13 +196,14 @@ Quando houver times configurados no GitHub, solicite revisão do time responsáv
 
 ### Configuração Recomendada no GitHub
 
-Para aplicar essas regras automaticamente, recomenda-se configurar:
+Para aplicar essas regras automaticamente, o repositório usa um arquivo [`CODEOWNERS`](CODEOWNERS) com os times responsáveis por cada domínio técnico.
 
-- `CODEOWNERS`, apontando cada área do projeto para o time responsável
+Além do `CODEOWNERS`, a branch `main` deve manter as seguintes proteções habilitadas:
+
 - Proteção da branch `main`, exigindo revisão antes do merge
 - Opção **Require review from Code Owners** habilitada
 
-Essas configurações ainda dependem da administração do repositório. Enquanto não estiverem ativas, as regras deste protocolo devem ser verificadas manualmente por autores, revisores e mantenedores.
+Essas configurações de branch dependem da administração do repositório. Enquanto não estiverem ativas, as regras deste protocolo devem ser verificadas manualmente por autores, revisores e mantenedores.
 
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
 ## Descrição
 <!-- O que esse PR faz? Por que essa mudança é necessária? -->
 
+> Antes de abrir este PR, consulte o [Protocolo de Aprovação de Pull Requests](https://github.com/GovHub-br/data-application-gov-hub/blob/main/.github/MERGE_REQUEST_PROTOCOL.md).
+
 ## Tipo de mudança
 - [ ] Nova funcionalidade / pipeline
 - [ ] Correção de bug ou inconsistência de dados
@@ -15,15 +17,17 @@ Closes #
 ## Como testar / validar
 
 ```bash
-# Exemplo — ajuste conforme o tipo de mudança
+# Exemplo: ajuste conforme o tipo de mudança
 
 # Para modelos DBT
+cd airflow_lappis/dags/dbt/<projeto>
 dbt test --select <nome_do_modelo>
 
 # Para DAGs
 airflow dags test <nome_da_dag> <data_execucao>
 
 # Para testes gerais
+make lint
 make test
 ```
 
@@ -31,7 +35,10 @@ make test
 <!-- Prints, logs, resultados de query ou link de documentação -->
 
 ## Checklist
-- [ ] Testes DBT adicionados/atualizados
-- [ ] Documentação atualizada
+- [ ] Título do PR segue Conventional Commits
+- [ ] Issue relacionada foi referenciada
+- [ ] Testes/lint foram executados ou a ausência foi justificada
+- [ ] Testes DBT adicionados/atualizados, se aplicável
+- [ ] Documentação atualizada, se aplicável
 - [ ] Sem dados sensíveis ou credenciais no código
-- [ ] Branch atualizada com `upstream/main`
+- [ ] Branch atualizada com `upstream/main` ou `origin/main`

--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ git config --global commit.gpgsign true
 
 ## 🤝 Contribuição
 
-1. Crie uma nova branch para sua feature
-2. Faça as alterações e garanta que todos os testes passam
-3. Envie um merge request
+Antes de contribuir, leia o [Guia de Contribuição](.github/CONTRIBUTING.md) e o [Protocolo de Aprovação de Pull Requests](.github/MERGE_REQUEST_PROTOCOL.md), que definem o fluxo de branches, commits, Pull Requests, revisão de código, testes e lint.
+
+Resumo do fluxo:
+
+1. Crie uma branch seguindo o padrão `<tipo>/<descricao-curta>`
+2. Faça commits seguindo Conventional Commits
+3. Garanta que testes e lint passam
+4. Abra um Pull Request usando o template do repositório


### PR DESCRIPTION
## Descrição

Padroniza o fluxo de abertura, revisão, aprovação e merge de Pull Requests no repositório.

As mudanças incluem a criação de um protocolo formal de aprovação de PRs, atualização do guia de contribuição, migração do template de Pull Request para o caminho padrão do GitHub, criação do `CODEOWNERS` e atualização do README para apontar para os documentos de contribuição.

## Tipo de mudança
- [ ] Nova funcionalidade / pipeline
- [ ] Correção de bug ou inconsistência de dados
- [ ] Refatoração de modelo DBT
- [x] Documentação
- [ ] Infraestrutura / CI
- [ ] Outro: ___

## Issues relacionadas
Closes #354 

## Como testar / validar

Validação documental:

1. Conferir o protocolo em `.github/MERGE_REQUEST_PROTOCOL.md`
2. Conferir os revisores por domínio em `.github/CODEOWNERS`
3. Conferir os links adicionados em `.github/CONTRIBUTING.md`
4. Conferir o template em `.github/PULL_REQUEST_TEMPLATE.md`
5. Conferir a seção de contribuição no `README.md`

## Evidências

- `git diff --check HEAD~2..HEAD` executado sem apontar problemas
- Alterações restritas a documentação, template de Pull Request e configuração de code owners

> Após o merge, é necessário habilitar a proteção da branch `main` com `Require review from Code Owners` para que o `CODEOWNERS` passe a bloquear merges sem aprovação do time responsável.

## Checklist
- [x] Título do PR segue Conventional Commits
- [x] Issue relacionada foi referenciada
- [x] Testes/lint foram executados ou a ausência foi justificada
- [ ] Testes DBT adicionados/atualizados, se aplicável
- [x] Documentação atualizada, se aplicável
- [x] Sem dados sensíveis ou credenciais no código
- [x] Branch atualizada com `upstream/main` ou `origin/main`