### PR TITLE
fix: ajusta skiprows da ingestão de NC MIR até 2025

### DIFF
--- a/airflow_lappis/dags/data_ingest/tesouro_gerencial/mir/nc_tesouro_ingest_2025_mir_dag.py
+++ b/airflow_lappis/dags/data_ingest/tesouro_gerencial/mir/nc_tesouro_ingest_2025_mir_dag.py
@@ -51,7 +51,7 @@ EMAIL_CONFIGS = {
     "enviadas": {
         "subject": "notas_credito_mir_ate_2025",
         "column_mapping": COLUMN_MAPPING,
-        "skiprows": 3,
+        "skiprows": 6,
     },
     "recebidas": {
         "subject": "notas_credito_recebidas_ate_2025",


### PR DESCRIPTION
# Descrição

## O que foi alterado

Atualiza a configuração `skiprows` da DAG `nc_tesouro_ingest_2025_mir_dag.py` para adequar a leitura do arquivo recebido por e-mail.

### Alteração realizada

- `skiprows`: `3` → `6`

## Motivação

O layout atual do relatório contém linhas adicionais no cabeçalho, exigindo o ajuste da quantidade de linhas ignoradas durante a leitura do arquivo para garantir o correto processamento dos dados.

## Tipo de alteração

- [ ] Chore
- [x] Bugfix
- [ ] Feature
- [ ] Refatoração
- [ ] Documentação
