### PR TITLE
feat(tests): adiciona teste basico de nulidade nas tabelas de metadata do mir

### DIFF
--- a/airflow_lappis/dags/dbt/mir/models/metadata/schema.yml
+++ b/airflow_lappis/dags/dbt/mir/models/metadata/schema.yml
@@ -25,12 +25,18 @@ models:
 
       - name: database_name
         description: Nome do banco de dados onde o modelo está materializado.
+        tests:
+          - not_null
 
       - name: materialization
         description: Tipo de materialização do modelo (table, view, incremental, etc).
+        tests:
+          - not_null
 
       - name: description
         description: Descrição do modelo extraída do schema.yml.
+        tests:
+          - not_null
 
       - name: dt_transform
         description: >
@@ -44,3 +50,5 @@ models:
         description: >
           Identificador único da execução do dbt (invocation_id).
           Permite rastrear qual execução gerou a transformação.
+        tests:
+          - not_null


### PR DESCRIPTION
## Descrição

Implementa testes de integridade nas tabelas de metadados do projeto dbt do MIR.

A tabela `models_metadata` (única tabela de metadata do MIR, em [models/metadata/](airflow_lappis/dags/dbt/mir/models/metadata/)) registra metadados de todos os modelos executados no dbt. Como ela é a fonte central de governança/rastreamento das execuções, nenhuma de suas colunas deve aceitar valores nulos. Antes desta mudança, apenas `schema_name`, `table_name` e `dt_transform` tinham teste de nulidade.

Esta mudança adiciona testes básicos de nulidade (`not_null`) no `schema.yml` para as colunas que ainda não eram cobertas, garantindo a integridade da tabela de metadados:

- `database_name`
- `materialization`
- `description`
- `run_id`

Com isso, todas as 7 colunas da tabela passam a ter o teste `not_null`.

## Tipo de mudança
- [ ] Nova funcionalidade / pipeline
- [ ] Correção de bug ou inconsistência de dados
- [ ] Refatoração de modelo DBT
- [ ] Documentação
- [ ] Infraestrutura / CI
- [x] Outro: Testes de qualidade de dados (dbt tests)

## Issues relacionadas
Closes #301 

## Como testar / validar

```bash
cd airflow_lappis/dags/dbt/mir
dbt test --select models_metadata
```

Todos os testes `not_null` das 7 colunas devem passar.

## Checklist
- [x] Testes DBT adicionados/atualizados
- [ ] Documentação atualizada
- [x] Sem dados sensíveis ou credenciais no código
- [ ] Branch atualizada com `upstream/main`