### PR TITLE
test(plugins/cliente_ibge): adiciona testes unitarios a cliente_ibge

### DIFF
--- a/airflow_lappis/plugins/cliente_ibge.py
+++ b/airflow_lappis/plugins/cliente_ibge.py
@@ -13,6 +13,8 @@ from cliente_base import ClienteBase
 class ClienteIBGE(ClienteBase):
     FTP_HOST = "ftp.ibge.gov.br"
     BASE_DIR = "/Censos/Censo_Demografico_2022/"
+    FTP_USER = "anonymous"
+    FTP_PASS = "anonymous@"
 
     def __init__(self, database: str) -> None:
         self.host = ClienteIBGE.FTP_HOST
@@ -32,7 +34,7 @@ class ClienteIBGE(ClienteBase):
         ftp = FTP(timeout=30)  # NOSONAR
         try:
             ftp.connect(self.host)
-            resp = ftp.login(user="anonymous", passwd="anonymous@")
+            resp = ftp.login(user=self.FTP_USER, passwd=self.FTP_PASS)
             logging.info("[cliente_ibge] FTP login: %s", resp)
             ftp.set_pasv(True)
             ftp.cwd(full_path)

--- a/airflow_lappis/plugins/cliente_ibge.py
+++ b/airflow_lappis/plugins/cliente_ibge.py
@@ -174,17 +174,16 @@ class ClienteIBGE(ClienteBase):
             logging.error("[cliente_ibge] Erro ao baixar '%s': %s", nome_arquivo, exc)
             return None
 
-    def obter_conteudo_texto(
-        self, nome_arquivo: str, subcaminho: str = ""
-    ) -> str | None:
+    def obter_conteudo_texto(self, nome_arquivo: str, subcaminho: str = "") -> str | None:
         """Baixa um arquivo de texto do FTP e retorna o conteúdo decodificado."""
         buffer = self.obter_conteudo_arquivo(nome_arquivo, subcaminho=subcaminho)
         if not buffer:
             return None
         raw = buffer.read()
-        for encoding in ("utf-8", "latin-1", "cp1252"):
+        for encoding in ("utf-8", "cp1252"):
             try:
                 return raw.decode(encoding)
             except UnicodeDecodeError:
                 continue
-        return raw.decode("latin-1", errors="replace")
+
+        return raw.decode("latin-1")

--- a/tests/test_plugins/test_cliente_ibge.py
+++ b/tests/test_plugins/test_cliente_ibge.py
@@ -518,25 +518,38 @@ def test_obter_conteudo_texto_decodes_utf8(
 ) -> None:
 
     file = "data.txt"
-    expected_text = "Cenário com acentuação: áéíóú ç"
 
-    mock_obter_conteudo.return_value = io.BytesIO(expected_text.encode("utf-8"))
+    mock_obter_conteudo.return_value = io.BytesIO(
+        b"Dados atuais com a\xc3\xa7\xc3\xa3o"  # "ação" in utf-8
+    )
 
     result = cliente_ibge.obter_conteudo_texto(file)
 
-    assert result == expected_text
+    assert result == "Dados atuais com ação"
     mock_obter_conteudo.assert_called_once_with(file, subcaminho="")
+
+
+def test_obter_conteudo_texto_decodes_cp1252_fallback(
+    cliente_ibge: ClienteIBGE, mock_obter_conteudo
+) -> None:
+
+    mock_obter_conteudo.return_value = io.BytesIO(
+        b"Dados Windows com a\xe7\xe3o"  # bytes (\xe7\xe3 == çã) doesnt exist in uft-8
+    )
+
+    result = cliente_ibge.obter_conteudo_texto("Windows.txt")
+
+    assert result == "Dados Windows com ação"
 
 
 def test_obter_conteudo_texto_decodes_latin1(
     cliente_ibge: ClienteIBGE, mock_obter_conteudo
 ) -> None:
 
-    file = "unsualfile.txt"
-    expected_text = "Cenário latin-1: áéíóú"
+    mock_obter_conteudo.return_value = io.BytesIO(
+        b"Dado \x81 legado"  # \x81 causes error in uft-8 AND cp1252
+    )
 
-    mock_obter_conteudo.return_value = io.BytesIO(expected_text.encode("latin-1"))
+    result = cliente_ibge.obter_conteudo_texto("unsualfile.txt")
 
-    result = cliente_ibge.obter_conteudo_texto(file)
-
-    assert result == expected_text
+    assert result == "Dado \x81 legado"

--- a/tests/test_plugins/test_cliente_ibge.py
+++ b/tests/test_plugins/test_cliente_ibge.py
@@ -485,3 +485,58 @@ def test_obter_conteudo_arquivo_handles_exception(
     assert buffer is None
     mock_ftp.retrbinary.assert_called_once()
     assert error_msg in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# obter_conteudo_texto
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_obter_conteudo(cliente_ibge: ClienteIBGE):
+    with patch.object(cliente_ibge, "obter_conteudo_arquivo") as mock_metodo:
+        yield mock_metodo
+
+
+def test_obter_conteudo_texto_with_nonexistent_file(
+    cliente_ibge: ClienteIBGE, mock_obter_conteudo
+) -> None:
+
+    file = "nonexistent.txt"
+    subpath = "folder/subfolder"
+
+    mock_obter_conteudo.return_value = None
+
+    result = cliente_ibge.obter_conteudo_texto(file, subcaminho=subpath)
+
+    assert result is None
+    mock_obter_conteudo.assert_called_once_with(file, subcaminho=subpath)
+
+
+def test_obter_conteudo_texto_decodes_utf8(
+    cliente_ibge: ClienteIBGE, mock_obter_conteudo
+) -> None:
+
+    file = "data.txt"
+    expected_text = "Cenário com acentuação: áéíóú ç"
+
+    mock_obter_conteudo.return_value = io.BytesIO(expected_text.encode("utf-8"))
+
+    result = cliente_ibge.obter_conteudo_texto(file)
+
+    assert result == expected_text
+    mock_obter_conteudo.assert_called_once_with(file, subcaminho="")
+
+
+def test_obter_conteudo_texto_decodes_latin1(
+    cliente_ibge: ClienteIBGE, mock_obter_conteudo
+) -> None:
+
+    file = "unsualfile.txt"
+    expected_text = "Cenário latin-1: áéíóú"
+
+    mock_obter_conteudo.return_value = io.BytesIO(expected_text.encode("latin-1"))
+
+    result = cliente_ibge.obter_conteudo_texto(file)
+
+    assert result == expected_text

--- a/tests/test_plugins/test_cliente_ibge.py
+++ b/tests/test_plugins/test_cliente_ibge.py
@@ -1,0 +1,174 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from cliente_ibge import ClienteIBGE
+
+DB = "teste"
+FTP_HOST = "ftp.ibge.gov.br"
+BASE_DIR = "/Censos/Censo_Demografico_2022/"
+
+
+@pytest.fixture
+def cliente_ibge() -> ClienteIBGE:
+    return ClienteIBGE(database=DB)
+
+
+@pytest.fixture
+def mock_ftp():
+    with patch("cliente_ibge.FTP") as MockFTP:
+        mock_ftp_instance = MagicMock()
+        MockFTP.return_value = mock_ftp_instance
+        yield mock_ftp_instance
+
+
+def test_init_cliente_ibge(cliente_ibge):
+    assert cliente_ibge.host == FTP_HOST
+    assert cliente_ibge.database == DB
+
+
+# ---------------------------------------------------------------------------
+# _conectar
+# ---------------------------------------------------------------------------
+
+
+def test_conectar_estabelece_conexao(cliente_ibge: ClienteIBGE, mock_ftp) -> None:
+
+    with cliente_ibge._conectar() as ftp:
+        assert ftp == mock_ftp
+
+    mock_ftp.connect.assert_called_once_with(FTP_HOST)
+    mock_ftp.login.assert_called_once_with(user="anonymous", passwd="anonymous@")
+    mock_ftp.set_pasv.assert_called_once_with(True)
+    mock_ftp.cwd.assert_called_once_with(BASE_DIR + DB)
+
+    mock_ftp.quit.assert_called_once()
+    mock_ftp.close.assert_not_called()
+
+
+def test_conectar_trata_excecao_conexao(cliente_ibge: ClienteIBGE, mock_ftp) -> None:
+    mock_ftp.connect.side_effect = Exception("Erro de conexão")
+
+    with pytest.raises(Exception) as exc_info:
+        with cliente_ibge._conectar():
+            pass
+
+    assert str(exc_info.value) == "Erro de conexão"
+    mock_ftp.connect.assert_called_once_with(FTP_HOST)
+    mock_ftp.login.assert_not_called()
+    mock_ftp.set_pasv.assert_not_called()
+    mock_ftp.cwd.assert_not_called()
+    mock_ftp.quit.assert_called_once()
+    mock_ftp.close.assert_not_called()
+
+
+def test_conectar_trata_excecao_quit(cliente_ibge: ClienteIBGE, mock_ftp) -> None:
+    mock_ftp.quit.side_effect = Exception("Erro ao fechar conexão")
+
+    with cliente_ibge._conectar():
+        pass
+
+    mock_ftp.quit.assert_called_once()
+    mock_ftp.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# listar_arquivos_alvo
+# ---------------------------------------------------------------------------
+
+
+def test_listar_arquivos_alvo_filtra_arquivos(
+    cliente_ibge: ClienteIBGE, mock_ftp
+) -> None:
+    mock_ftp.nlst.return_value = [
+        "dados.xlsx",
+        "dados.csv",
+        "dados.txt",
+        "imagem.png",
+        "relatorio.xls",
+    ]
+
+    arquivos = cliente_ibge.listar_arquivos_alvo()
+    assert arquivos == ["dados.xlsx", "dados.csv", "relatorio.xls"]
+    mock_ftp.nlst.assert_called_once()
+
+
+def test_listar_arquivos_alvo_sem_arquivos(cliente_ibge: ClienteIBGE, mock_ftp) -> None:
+    mock_ftp.nlst.return_value = ["dados.txt", "imagem.png"]
+
+    arquivos = cliente_ibge.listar_arquivos_alvo()
+    assert arquivos == []
+    mock_ftp.nlst.assert_called_once()
+
+
+def test_listar_arquivos_alvo_trata_excecao(cliente_ibge: ClienteIBGE, mock_ftp) -> None:
+    mock_ftp.nlst.side_effect = Exception("Erro ao listar arquivos")
+
+    arquivos = cliente_ibge.listar_arquivos_alvo()
+    assert arquivos == []
+    mock_ftp.nlst.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# listar_arquivos_em_subpastas
+# ---------------------------------------------------------------------------
+
+
+def test_listar_arquivos_em_subpastas_com_sucesso(
+    cliente_ibge: ClienteIBGE, mock_ftp
+) -> None:
+
+    mock_ftp.nlst.side_effect = [
+        [".", "..", "dado_A.xlsx", "leia_me.txt"],
+        ["dado_B1.csv", "dado_B2.xls"],
+        ["dado_C.pdf"],
+    ]
+
+    resultado = cliente_ibge.listar_arquivos_em_subpastas(
+        subpastas=["pastaA", "pastaB", "pastaC"],
+        extensoes=(".xlsx", ".xls", ".csv"),
+        formato_preferido="xlsx",
+    )
+
+    expect_resultado = [
+        {"subcaminho": "pastaA/xlsx", "arquivo": "dado_A.xlsx"},
+        {"subcaminho": "pastaB/xlsx", "arquivo": "dado_B1.csv"},
+        {"subcaminho": "pastaB/xlsx", "arquivo": "dado_B2.xls"},
+    ]
+
+    assert resultado == expect_resultado
+
+    # 1 chamada para cada subpasta + 1 chamada para o diretório base
+    assert mock_ftp.cwd.call_count == 4
+
+    mock_ftp.cwd.assert_any_call(BASE_DIR + DB + "/pastaA/xlsx")
+    mock_ftp.cwd.assert_any_call(BASE_DIR + DB + "/pastaB/xlsx")
+    mock_ftp.cwd.assert_any_call(BASE_DIR + DB + "/pastaC/xlsx")
+
+    assert mock_ftp.nlst.call_count == 3
+
+
+def test_listar_arquivos_em_subpastas_sem_formato_preferido(
+    cliente_ibge: ClienteIBGE, mock_ftp
+) -> None:
+    mock_ftp.nlst.side_effect = [
+        ["dado_A.xlsx", "dado_B.csv", "dado_C.txt"],
+        ["leia_me.txt"],
+    ]
+
+    resultado = cliente_ibge.listar_arquivos_em_subpastas(
+        subpastas=["pastaA", "pastaB"],
+        extensoes=(".xlsx", ".csv"),
+        formato_preferido=None,
+    )
+
+    expect_resultado = [
+        {"subcaminho": "pastaA", "arquivo": "dado_A.xlsx"},
+        {"subcaminho": "pastaA", "arquivo": "dado_B.csv"},
+    ]
+
+    assert resultado == expect_resultado
+
+    # 1 chamada para cada subpasta + 1 chamada para o diretório base
+    assert mock_ftp.cwd.call_count == 3
+    mock_ftp.cwd.assert_any_call(BASE_DIR + DB + "/pastaA")
+    mock_ftp.cwd.assert_any_call(BASE_DIR + DB + "/pastaB")
+    assert mock_ftp.nlst.call_count == 2

--- a/tests/test_plugins/test_cliente_ibge.py
+++ b/tests/test_plugins/test_cliente_ibge.py
@@ -1,8 +1,10 @@
+from ftplib import error_perm
+
 import pytest
 from unittest.mock import patch, MagicMock
 from cliente_ibge import ClienteIBGE
 
-DB = "teste"
+DB = "test"
 FTP_HOST = "ftp.ibge.gov.br"
 BASE_DIR = "/Censos/Censo_Demografico_2022/"
 
@@ -30,7 +32,7 @@ def test_init_cliente_ibge(cliente_ibge):
 # ---------------------------------------------------------------------------
 
 
-def test_conectar_estabelece_conexao(cliente_ibge: ClienteIBGE, mock_ftp) -> None:
+def test_conectar_establishes_connection(cliente_ibge: ClienteIBGE, mock_ftp) -> None:
 
     with cliente_ibge._conectar() as ftp:
         assert ftp == mock_ftp
@@ -44,14 +46,34 @@ def test_conectar_estabelece_conexao(cliente_ibge: ClienteIBGE, mock_ftp) -> Non
     mock_ftp.close.assert_not_called()
 
 
-def test_conectar_trata_excecao_conexao(cliente_ibge: ClienteIBGE, mock_ftp) -> None:
-    mock_ftp.connect.side_effect = Exception("Erro de conexão")
+def test_conectar_establishes_connection_with_subpath(
+    cliente_ibge: ClienteIBGE, mock_ftp
+) -> None:
+
+    with cliente_ibge._conectar(subcaminho="subfolder") as ftp:
+        assert ftp == mock_ftp
+
+    mock_ftp.connect.assert_called_once_with(FTP_HOST)
+    mock_ftp.login.assert_called_once_with(user="anonymous", passwd="anonymous@")
+    mock_ftp.set_pasv.assert_called_once_with(True)
+    mock_ftp.cwd.assert_called_once_with(BASE_DIR + DB + "/subfolder")
+
+    mock_ftp.quit.assert_called_once()
+    mock_ftp.close.assert_not_called()
+
+
+def test_conectar_handles_connection_exception(
+    cliente_ibge: ClienteIBGE, mock_ftp
+) -> None:
+
+    error_msg = "Connection error"
+    mock_ftp.connect.side_effect = Exception(error_msg)
 
     with pytest.raises(Exception) as exc_info:
         with cliente_ibge._conectar():
             pass
 
-    assert str(exc_info.value) == "Erro de conexão"
+    assert str(exc_info.value) == error_msg
     mock_ftp.connect.assert_called_once_with(FTP_HOST)
     mock_ftp.login.assert_not_called()
     mock_ftp.set_pasv.assert_not_called()
@@ -60,8 +82,8 @@ def test_conectar_trata_excecao_conexao(cliente_ibge: ClienteIBGE, mock_ftp) -> 
     mock_ftp.close.assert_not_called()
 
 
-def test_conectar_trata_excecao_quit(cliente_ibge: ClienteIBGE, mock_ftp) -> None:
-    mock_ftp.quit.side_effect = Exception("Erro ao fechar conexão")
+def test_conectar_handles_quit_exception(cliente_ibge: ClienteIBGE, mock_ftp) -> None:
+    mock_ftp.quit.side_effect = Exception("Error closing connection")
 
     with cliente_ibge._conectar():
         pass
@@ -75,36 +97,45 @@ def test_conectar_trata_excecao_quit(cliente_ibge: ClienteIBGE, mock_ftp) -> Non
 # ---------------------------------------------------------------------------
 
 
-def test_listar_arquivos_alvo_filtra_arquivos(
-    cliente_ibge: ClienteIBGE, mock_ftp
-) -> None:
+def test_listar_arquivos_alvo_filters_files(cliente_ibge: ClienteIBGE, mock_ftp) -> None:
+    """
+    -> Normal execution with a mix of target and non-target files in the listing.
+    """
     mock_ftp.nlst.return_value = [
-        "dados.xlsx",
-        "dados.csv",
-        "dados.txt",
-        "imagem.png",
-        "relatorio.xls",
+        "data.xlsx",
+        "data.csv",
+        "data.txt",
+        "image.png",
+        "report.xls",
     ]
 
-    arquivos = cliente_ibge.listar_arquivos_alvo()
-    assert arquivos == ["dados.xlsx", "dados.csv", "relatorio.xls"]
+    files = cliente_ibge.listar_arquivos_alvo()
+    assert files == ["data.xlsx", "data.csv", "report.xls"]
     mock_ftp.nlst.assert_called_once()
 
 
-def test_listar_arquivos_alvo_sem_arquivos(cliente_ibge: ClienteIBGE, mock_ftp) -> None:
-    mock_ftp.nlst.return_value = ["dados.txt", "imagem.png"]
+def test_listar_arquivos_alvo_without_files(cliente_ibge: ClienteIBGE, mock_ftp) -> None:
+    mock_ftp.nlst.return_value = ["data.txt", "image.png"]
 
-    arquivos = cliente_ibge.listar_arquivos_alvo()
-    assert arquivos == []
+    files = cliente_ibge.listar_arquivos_alvo()
+    assert files == []
     mock_ftp.nlst.assert_called_once()
 
 
-def test_listar_arquivos_alvo_trata_excecao(cliente_ibge: ClienteIBGE, mock_ftp) -> None:
-    mock_ftp.nlst.side_effect = Exception("Erro ao listar arquivos")
+def test_listar_arquivos_alvo_handles_exception(
+    cliente_ibge: ClienteIBGE, mock_ftp, caplog
+) -> None:
 
-    arquivos = cliente_ibge.listar_arquivos_alvo()
-    assert arquivos == []
+    error_msg = "Error listing files"
+    mock_ftp.nlst.side_effect = Exception(error_msg)
+
+    with caplog.at_level("ERROR"):
+        files = cliente_ibge.listar_arquivos_alvo()
+
+    assert files == []
     mock_ftp.nlst.assert_called_once()
+
+    assert error_msg in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -112,63 +143,269 @@ def test_listar_arquivos_alvo_trata_excecao(cliente_ibge: ClienteIBGE, mock_ftp)
 # ---------------------------------------------------------------------------
 
 
-def test_listar_arquivos_em_subpastas_com_sucesso(
+def test_listar_arquivos_em_subpastas_successfully(
     cliente_ibge: ClienteIBGE, mock_ftp
 ) -> None:
+    """
+    -> Normal execution with valid files in subfolders.
+        --> validates subfolder slash trimming with strip()
+        --> ignores non-target files and directories in the listing
+    """
 
     mock_ftp.nlst.side_effect = [
-        [".", "..", "dado_A.xlsx", "leia_me.txt"],
-        ["dado_B1.csv", "dado_B2.xls"],
-        ["dado_C.pdf"],
+        [".", "..", "data_A.xlsx", "leia_me.txt"],
+        ["data_B1.csv", "data_B2.xls"],
+        ["data_C.pdf"],
     ]
 
-    resultado = cliente_ibge.listar_arquivos_em_subpastas(
-        subpastas=["pastaA", "pastaB", "pastaC"],
+    result = cliente_ibge.listar_arquivos_em_subpastas(
+        subpastas=["folderA", "folderB", "folderC"],
         extensoes=(".xlsx", ".xls", ".csv"),
         formato_preferido="xlsx",
     )
 
-    expect_resultado = [
-        {"subcaminho": "pastaA/xlsx", "arquivo": "dado_A.xlsx"},
-        {"subcaminho": "pastaB/xlsx", "arquivo": "dado_B1.csv"},
-        {"subcaminho": "pastaB/xlsx", "arquivo": "dado_B2.xls"},
+    expected_result = [
+        {"subcaminho": "folderA/xlsx", "arquivo": "data_A.xlsx"},
+        {"subcaminho": "folderB/xlsx", "arquivo": "data_B1.csv"},
+        {"subcaminho": "folderB/xlsx", "arquivo": "data_B2.xls"},
     ]
 
-    assert resultado == expect_resultado
+    assert result == expected_result
 
-    # 1 chamada para cada subpasta + 1 chamada para o diretório base
+    # 1 call for each subfolder + 1 call for the base directory
     assert mock_ftp.cwd.call_count == 4
 
-    mock_ftp.cwd.assert_any_call(BASE_DIR + DB + "/pastaA/xlsx")
-    mock_ftp.cwd.assert_any_call(BASE_DIR + DB + "/pastaB/xlsx")
-    mock_ftp.cwd.assert_any_call(BASE_DIR + DB + "/pastaC/xlsx")
+    mock_ftp.cwd.assert_any_call(BASE_DIR + DB + "/folderA/xlsx")
+    mock_ftp.cwd.assert_any_call(BASE_DIR + DB + "/folderB/xlsx")
+    mock_ftp.cwd.assert_any_call(BASE_DIR + DB + "/folderC/xlsx")
 
     assert mock_ftp.nlst.call_count == 3
 
 
-def test_listar_arquivos_em_subpastas_sem_formato_preferido(
+def test_listar_arquivos_em_subpastas_without_preferred_format(
     cliente_ibge: ClienteIBGE, mock_ftp
 ) -> None:
     mock_ftp.nlst.side_effect = [
-        ["dado_A.xlsx", "dado_B.csv", "dado_C.txt"],
-        ["leia_me.txt"],
+        ["data_A1.xlsx", "data_A2.csv", "data_A3.txt"],
+        ["readme.txt"],
     ]
 
-    resultado = cliente_ibge.listar_arquivos_em_subpastas(
-        subpastas=["pastaA", "pastaB"],
+    result = cliente_ibge.listar_arquivos_em_subpastas(
+        subpastas=["folderA", "folderB"],
         extensoes=(".xlsx", ".csv"),
         formato_preferido=None,
     )
 
-    expect_resultado = [
-        {"subcaminho": "pastaA", "arquivo": "dado_A.xlsx"},
-        {"subcaminho": "pastaA", "arquivo": "dado_B.csv"},
+    expected_result = [
+        {"subcaminho": "folderA", "arquivo": "data_A1.xlsx"},
+        {"subcaminho": "folderA", "arquivo": "data_A2.csv"},
     ]
 
-    assert resultado == expect_resultado
+    assert result == expected_result
 
-    # 1 chamada para cada subpasta + 1 chamada para o diretório base
+    # 1 call for each subfolder + 1 call for the base directory
     assert mock_ftp.cwd.call_count == 3
-    mock_ftp.cwd.assert_any_call(BASE_DIR + DB + "/pastaA")
-    mock_ftp.cwd.assert_any_call(BASE_DIR + DB + "/pastaB")
+    mock_ftp.cwd.assert_any_call(BASE_DIR + DB + "/folderA")
+    mock_ftp.cwd.assert_any_call(BASE_DIR + DB + "/folderB")
     assert mock_ftp.nlst.call_count == 2
+
+
+def test_listar_arquivos_em_subpastas_without_valid_files(
+    cliente_ibge: ClienteIBGE, mock_ftp
+) -> None:
+    mock_ftp.nlst.side_effect = [
+        ["data_A.txt", "readme.txt"],
+        [".", "data_B.pdf", "subfolder"],
+    ]
+
+    result = cliente_ibge.listar_arquivos_em_subpastas(
+        subpastas=["folderA", "folderB"],
+        extensoes=(".xlsx", ".csv"),
+        formato_preferido=None,
+    )
+
+    assert result == []
+    # 1 call for each subfolder + 1 call for the base directory
+    assert mock_ftp.cwd.call_count == 3
+    mock_ftp.cwd.assert_any_call(BASE_DIR + DB + "/folderA")
+    mock_ftp.cwd.assert_any_call(BASE_DIR + DB + "/folderB")
+    assert mock_ftp.nlst.call_count == 2
+
+
+def test_listar_arquivos_em_subpastas_with_inaccessible_subfolder(
+    cliente_ibge: ClienteIBGE, mock_ftp, caplog
+) -> None:
+
+    error_msg = "550 Failed to change directory."
+
+    mock_ftp.cwd.side_effect = [
+        None,  # _conectar() to base directory
+        None,
+        error_perm(error_msg),
+    ]
+
+    mock_ftp.nlst.return_value = ["data_A.xlsx", "readme.txt"]
+
+    with caplog.at_level("WARNING"):
+        resultado = cliente_ibge.listar_arquivos_em_subpastas(
+            subpastas=["exists", "not-exists"],
+            extensoes=(".xlsx",),
+            formato_preferido="xlsx",
+        )
+
+    expected_result = [
+        {"subcaminho": "exists/xlsx", "arquivo": "data_A.xlsx"},
+    ]
+
+    assert resultado == expected_result
+
+    # 1 call for each subfolder + 1 call for the base directory
+    assert mock_ftp.cwd.call_count == 3
+    mock_ftp.cwd.assert_any_call(BASE_DIR + DB + "/not-exists/xlsx")
+    mock_ftp.cwd.assert_any_call(BASE_DIR + DB + "/exists/xlsx")
+    assert mock_ftp.nlst.call_count == 1
+
+    assert BASE_DIR + DB + "/not-exists/xlsx" in caplog.text
+    assert error_msg in caplog.text
+
+
+def test_listar_arquivos_em_subpastas_handles_exception(
+    cliente_ibge: ClienteIBGE, mock_ftp, caplog
+) -> None:
+
+    error_msg = "Error listing files"
+
+    mock_ftp.nlst.side_effect = Exception(error_msg)
+
+    with caplog.at_level("ERROR"):
+        resultado = cliente_ibge.listar_arquivos_em_subpastas(
+            subpastas=["folderA"],
+            extensoes=(".xlsx",),
+            formato_preferido="xlsx",
+        )
+
+    assert resultado == []
+    mock_ftp.cwd.assert_any_call(BASE_DIR + DB + "/folderA/xlsx")
+    mock_ftp.nlst.assert_called_once()
+
+    assert error_msg in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# listar_arquivos_texto
+# ---------------------------------------------------------------------------
+
+
+def test_listar_arquivos_texto_successfully(cliente_ibge: ClienteIBGE, mock_ftp) -> None:
+    """
+    -> Normal execution with text files present in the listing.
+        --> ignores missing input entries
+        --> validates subfolder slash trimming with strip()
+    """
+
+    entries = [
+        ("folderA", "index_a1.txt"),
+        ("folderA", "index_a2.txt"),
+        ("folderB", "dont_exist.txt"),
+        ("folderC/", "index_c.txt"),
+    ]
+
+    mock_ftp.nlst.side_effect = [
+        ["index_a1.txt"],
+        ["index_a2.txt"],
+        ["other.txt"],
+        ["index_c.txt"],
+    ]
+
+    result = cliente_ibge.listar_arquivos_texto(entries)
+
+    expected_result = [
+        {"subcaminho": "folderA", "arquivo": "index_a1.txt"},
+        {"subcaminho": "folderA", "arquivo": "index_a2.txt"},
+        {"subcaminho": "folderC", "arquivo": "index_c.txt"},
+    ]
+
+    assert result == expected_result
+    # 1 call for each entry + 1 call for the base directory
+    assert mock_ftp.cwd.call_count == 5
+    assert mock_ftp.nlst.call_count == 4
+
+
+def test_listar_arquivos_texto_without_existing_files(
+    cliente_ibge: ClienteIBGE, mock_ftp
+) -> None:
+    entries = [
+        ("folderA", "index_a.txt"),
+        ("folderB", "index_b.txt"),
+    ]
+
+    mock_ftp.nlst.side_effect = [
+        ["other.txt"],
+        ["another.txt"],
+    ]
+
+    result = cliente_ibge.listar_arquivos_texto(entries)
+
+    assert result == []
+    # 1 call for each entry + 1 call for the base directory
+    assert mock_ftp.cwd.call_count == 3
+    assert mock_ftp.nlst.call_count == 2
+
+
+def test_listar_arquivos_texto_invalid_folder(
+    cliente_ibge: ClienteIBGE, mock_ftp, caplog
+) -> None:
+
+    error_msg = "550 Failed to change directory."
+
+    entries = [
+        ("folderA", "index_a.pdf"),
+        ("invalid_folder", "index_b.pdf"),
+    ]
+
+    mock_ftp.cwd.side_effect = [
+        None,  # _conectar() to base directory
+        None,
+        error_perm(error_msg),
+    ]
+
+    mock_ftp.nlst.side_effect = [["index_a.pdf"]]
+
+    with caplog.at_level("WARNING"):
+        result = cliente_ibge.listar_arquivos_texto(entries)
+
+    expected_result = [
+        {"subcaminho": "folderA", "arquivo": "index_a.pdf"},
+    ]
+
+    assert result == expected_result
+    # 1 call for each entry + 1 call for the base directory
+    assert mock_ftp.cwd.call_count == 3
+    assert mock_ftp.nlst.call_count == 1
+
+    assert BASE_DIR + DB + "/invalid_folder" in caplog.text
+    assert error_msg in caplog.text
+
+
+def test_listar_arquivos_texto_handles_exception(
+    cliente_ibge: ClienteIBGE, mock_ftp, caplog
+) -> None:
+
+    entries = [
+        ("folderA", "index_a.pdf"),
+        ("folderB", "index_b.pdf"),
+    ]
+
+    error_msg = "Connection error"
+    mock_ftp.connect.side_effect = Exception(error_msg)
+
+    with caplog.at_level("ERROR"):
+        result = cliente_ibge.listar_arquivos_texto(entries)
+
+    assert result == []
+
+    mock_ftp.connect.assert_called_once()
+    mock_ftp.cwd.assert_not_called()
+    mock_ftp.nlst.assert_not_called()
+
+    assert error_msg in caplog.text

--- a/tests/test_plugins/test_cliente_ibge.py
+++ b/tests/test_plugins/test_cliente_ibge.py
@@ -39,7 +39,9 @@ def test_conectar_establishes_connection(cliente_ibge: ClienteIBGE, mock_ftp) ->
         assert ftp == mock_ftp
 
     mock_ftp.connect.assert_called_once_with(FTP_HOST)
-    mock_ftp.login.assert_called_once_with(user="anonymous", passwd="anonymous@")
+    mock_ftp.login.assert_called_once_with(
+        user=ClienteIBGE.FTP_USER, passwd=ClienteIBGE.FTP_PASS
+    )
     mock_ftp.set_pasv.assert_called_once_with(True)
     mock_ftp.cwd.assert_called_once_with(BASE_DIR + DB)
 
@@ -54,9 +56,6 @@ def test_conectar_establishes_connection_with_subpath(
     with cliente_ibge._conectar(subcaminho="subfolder") as ftp:
         assert ftp == mock_ftp
 
-    mock_ftp.connect.assert_called_once_with(FTP_HOST)
-    mock_ftp.login.assert_called_once_with(user="anonymous", passwd="anonymous@")
-    mock_ftp.set_pasv.assert_called_once_with(True)
     mock_ftp.cwd.assert_called_once_with(BASE_DIR + DB + "/subfolder")
 
     mock_ftp.quit.assert_called_once()
@@ -72,9 +71,8 @@ def test_conectar_handles_connection_exception(
 
     with pytest.raises(Exception) as exc_info:
         with cliente_ibge._conectar():
-            pass
+            assert str(exc_info.value) == error_msg
 
-    assert str(exc_info.value) == error_msg
     mock_ftp.connect.assert_called_once_with(FTP_HOST)
     mock_ftp.login.assert_not_called()
     mock_ftp.set_pasv.assert_not_called()
@@ -86,8 +84,8 @@ def test_conectar_handles_connection_exception(
 def test_conectar_handles_quit_exception(cliente_ibge: ClienteIBGE, mock_ftp) -> None:
     mock_ftp.quit.side_effect = Exception("Error closing connection")
 
-    with cliente_ibge._conectar():
-        pass
+    with cliente_ibge._conectar() as ftp:
+        assert ftp == mock_ftp
 
     mock_ftp.quit.assert_called_once()
     mock_ftp.close.assert_called_once()

--- a/tests/test_plugins/test_cliente_ibge.py
+++ b/tests/test_plugins/test_cliente_ibge.py
@@ -1,4 +1,5 @@
 from ftplib import error_perm
+import io
 
 import pytest
 from unittest.mock import patch, MagicMock
@@ -408,4 +409,79 @@ def test_listar_arquivos_texto_handles_exception(
     mock_ftp.cwd.assert_not_called()
     mock_ftp.nlst.assert_not_called()
 
+    assert error_msg in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# obter_conteudo_arquivo
+# ---------------------------------------------------------------------------
+
+
+def test_obter_conteudo_arquivo_successfully(
+    cliente_ibge: ClienteIBGE, mock_ftp, caplog
+) -> None:
+
+    file_content = b"Test file content"
+
+    file = "data.csv"
+
+    def mock_retrbinary(_, callback):
+        callback(file_content)
+
+    mock_ftp.retrbinary.side_effect = mock_retrbinary
+
+    with caplog.at_level("INFO"):
+        buffer = cliente_ibge.obter_conteudo_arquivo(file)
+
+    assert isinstance(buffer, io.BytesIO)
+    assert buffer.tell() == 0  # moves buffer to the beginning after writing
+    assert buffer.read() == file_content
+    mock_ftp.retrbinary.assert_called_once_with("RETR " + file, buffer.write)
+
+    mock_ftp.cwd.assert_called_once_with(BASE_DIR + DB)
+
+    assert f"./{file}" in caplog.text
+
+
+def test_obter_conteudo_arquivo_with_subcaminho(
+    cliente_ibge: ClienteIBGE, mock_ftp, caplog
+) -> None:
+
+    file_content = b""
+
+    file = "data.xlsx"
+    subcaminho = "folderA"
+
+    def mock_retrbinary(_, callback):
+        callback(file_content)
+
+    mock_ftp.retrbinary.side_effect = mock_retrbinary
+
+    with caplog.at_level("INFO"):
+        buffer = cliente_ibge.obter_conteudo_arquivo(file, subcaminho=subcaminho)
+
+    assert isinstance(buffer, io.BytesIO)
+    assert buffer.tell() == 0  # moves buffer to the beginning after writing
+    assert buffer.read() == file_content
+    mock_ftp.retrbinary.assert_called_once_with("RETR " + file, buffer.write)
+
+    mock_ftp.cwd.assert_called_once_with(BASE_DIR + DB + "/" + subcaminho)
+
+    assert f"{subcaminho}/{file}" in caplog.text
+
+
+def test_obter_conteudo_arquivo_handles_exception(
+    cliente_ibge: ClienteIBGE, mock_ftp, caplog
+) -> None:
+
+    file = "data.txt"
+
+    error_msg = "Error downloading file"
+    mock_ftp.retrbinary.side_effect = Exception(error_msg)
+
+    with caplog.at_level("ERROR"):
+        buffer = cliente_ibge.obter_conteudo_arquivo(file)
+
+    assert buffer is None
+    mock_ftp.retrbinary.assert_called_once()
     assert error_msg in caplog.text


### PR DESCRIPTION
## Descrição
- Criação dos testes unitários para cliente_ibge, com criação de mock ftp e testes do caminhos de execução e exceção dos métodos da classe.
- Correção de um bug no método `obter_conteudo_arquivo` que não percorria todos os caminhos de execução. (mais detalhes na Observação)

## Tipo de mudança
- [ ] Nova funcionalidade / pipeline
- [x] Correção de bug ou inconsistência de dados
- [ ] Refatoração de modelo DBT
- [ ] Documentação
- [ ] Infraestrutura / CI
- [x] Outro: Casos de Testes

## Issues relacionadas
Closes #313 

## Como testar / validar

```bash
make lint
make test
```

## Evidências
### Cobertura de testes de `cliente_ibge` em 100%
<img width="864" height="530" alt="image" src="https://github.com/user-attachments/assets/59708bb1-a159-42f8-aafc-a28e92abad21" />


## Checklist
- [x] Título do PR segue Conventional Commits
- [x] Issue relacionada foi referenciada
- [x] Testes/lint foram executados ou a ausência foi justificada
- [ ] Branch atualizada com `upstream/main` ou `origin/main`

## Observações

`make lint`: executei o lint com sucesso nos arquivos que alterei, mas quando executo localmente para o projeto todo, são encontrados vários erros e o make falha, apontando arquivos que não editei.

### bug do método `obter_conteudo_arquivo`:

O problema estava que a função  `.decode("latin-1")` não gera a exceção `UnicodeDecodeError`, porque o 'latin-1' aceita qualquer byte. (mais informações sobre [nesse post](https://stackoverflow.com/questions/57041010/when-utf-is-multibyte-latin1-is-single-byte-why-do-i-get-error)) 

 A correção aborda testar o decode com `utf-8` e `cp1252` primeiro, antes de gerar o decode com `latin-1`.
