### PR TITLE
feat(compras_gov): adiciona ingestão de contratos ativos e inativos do MIR

### DIFF
--- a/airflow_lappis/dags/data_ingest/compras_gov/mir/contratos_inativos_mir_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/compras_gov/mir/contratos_inativos_mir_ingest_dag.py
@@ -1,0 +1,73 @@
+import logging
+import yaml
+from airflow.decorators import dag, task
+from airflow.models import Variable
+from datetime import datetime, timedelta
+from schedule_loader import get_dynamic_schedule
+from postgres_helpers import get_postgres_conn
+from cliente_contratos import ClienteContratos
+from cliente_postgres import ClientPostgresDB
+
+
+@dag(
+    dag_id="contratos_inativos_mir_ingest_dag",
+    schedule_interval=get_dynamic_schedule("contratos_inativos_mir_ingest_dag"),
+    start_date=datetime(2023, 1, 1),
+    catchup=False,
+    default_args={
+        "owner": "Tiago",
+        "retries": 1,
+        "retry_delay": timedelta(minutes=5),
+    },
+    tags=["contratos_inativos_api", "compras_gov", "MIR"],
+)
+def api_contratos_inativos_dag() -> None:
+    """DAG para buscar e armazenar contratos inativos de uma API no PostgreSQL."""
+
+    @task
+    def fetch_and_store_contratos_inativos() -> None:
+        logging.info("Iniciando fetch_and_store_contratos_mir_inativos")
+
+        orgao_alvo = Variable.get("airflow_orgao_1", default_var=None)
+        if not orgao_alvo:
+            logging.error("Variável airflow_orgao_1 não definida!")
+            raise ValueError("airflow_orgao_1 não definida")
+
+        orgaos_config_str = Variable.get("airflow_variables", default_var="{}")
+        orgaos_config = yaml.safe_load(orgaos_config_str)
+
+        ug_codes = orgaos_config.get(orgao_alvo, {}).get("codigos_ug", [])
+
+        if not ug_codes:
+            logging.warning(f"Nenhum código UG encontrado para o órgão '{orgao_alvo}'")
+            return
+
+        api = ClienteContratos()
+        postgres_conn_str = get_postgres_conn("postgres_mir")
+        db = ClientPostgresDB(postgres_conn_str)
+
+        for ug_code in ug_codes:
+            logging.info(f"Buscando contratos inativos para UG: {ug_code}")
+            contratos = api.get_contratos_inativos_by_ug(ug_code)
+            if contratos:
+                # Adicionar dt_ingest a cada contrato
+                for contrato in contratos:
+                    contrato["dt_ingest"] = datetime.now().isoformat()
+
+                logging.info(
+                    f"Inserindo contratos inativos da UG {ug_code} no schema compras_gov"
+                )
+                db.insert_data(
+                    contratos,
+                    "contratos",
+                    conflict_fields=["id"],
+                    primary_key=["id"],
+                    schema="compras_gov",
+                )
+            else:
+                logging.warning(f"Nenhum contrato inativo encontrado para UG {ug_code}")
+
+    fetch_and_store_contratos_inativos()
+
+
+dag_instance = api_contratos_inativos_dag()

--- a/airflow_lappis/dags/data_ingest/compras_gov/mir/contratos_mir_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/compras_gov/mir/contratos_mir_ingest_dag.py
@@ -1,0 +1,78 @@
+import logging
+import yaml
+from airflow.decorators import dag, task
+from airflow.operators.trigger_dagrun import TriggerDagRunOperator
+from airflow.models import Variable
+from datetime import datetime, timedelta
+from schedule_loader import get_dynamic_schedule
+from postgres_helpers import get_postgres_conn
+from cliente_contratos import ClienteContratos
+from cliente_postgres import ClientPostgresDB
+
+
+@dag(
+    schedule_interval=get_dynamic_schedule("contratos_mir_ingest_dag"),
+    start_date=datetime(2023, 1, 1),
+    catchup=False,
+    default_args={
+        "owner": "Luana e Tiago",
+        "retries": 1,
+        "retry_delay": timedelta(minutes=5),
+    },
+    tags=["contratos_api", "compras_gov", "MIR"],
+)
+def api_contratos_dag() -> None:
+    """DAG para buscar e armazenar contratos por órgão definido."""
+
+    @task
+    def fetch_and_store_contratos() -> None:
+        logging.info("[contratos_mir_ingest_dag.py] Iniciando extração")
+
+        orgao_alvo = Variable.get("airflow_orgao_1", default_var=None)
+        if not orgao_alvo:
+            logging.error("Variável airflow_orgao_1 não definida!")
+            raise ValueError("airflow_orgao_1 não definida")
+
+        orgaos_config_str = Variable.get("airflow_variables", default_var="{}")
+        orgaos_config = yaml.safe_load(orgaos_config_str)
+
+        codigos_ug = orgaos_config.get(orgao_alvo, {}).get("codigos_ug", [])
+
+        if not codigos_ug:
+            logging.warning(f"Nenhum código UG encontrado para o órgão '{orgao_alvo}'")
+            return
+
+        api = ClienteContratos()
+        postgres_conn_str = get_postgres_conn("postgres_mir")
+        db = ClientPostgresDB(postgres_conn_str)
+
+        for ug_code in codigos_ug:
+            logging.info(f"Buscando contratos para UG: {ug_code}")
+            contratos = api.get_contratos_by_ug(ug_code)
+
+            if contratos:
+                # Adicionar dt_ingest a cada contrato
+                for contrato in contratos:
+                    contrato["dt_ingest"] = datetime.now().isoformat()
+
+                logging.info(f"Inserindo contratos da UG {ug_code} no schema compras_gov")
+                db.insert_data(
+                    contratos,
+                    "contratos",
+                    conflict_fields=["id"],
+                    primary_key=["id"],
+                    schema="compras_gov",
+                )
+            else:
+                logging.warning(f"Nenhum contrato encontrado para UG {ug_code}")
+
+    trigger_contratos_inativos = TriggerDagRunOperator(
+        task_id="trigger_contratos_inativos",
+        trigger_dag_id="api_contratos_inativos_dag",
+        wait_for_completion=False,
+    )
+
+    fetch_and_store_contratos() >> trigger_contratos_inativos
+
+
+dag_instance = api_contratos_dag()


### PR DESCRIPTION
## Descrição

Implementa a ingestão de contratos ativos e inativos do Compras.gov para o ambiente MIR.

As novas DAGs realizam a extração de contratos a partir das UGs configuradas na variável `airflow_variables`, utilizando o órgão definido em `airflow_orgao_1`. Os dados são armazenados na tabela `compras_gov.contratos` com atualização por chave primária (`id`) e inclusão do campo `dt_ingest`.

Além disso, foi adicionada uma orquestração para que a DAG de contratos ativos acione automaticamente a DAG de contratos inativos após a conclusão da execução.

## Tipo de mudança

* [x] Nova funcionalidade / pipeline
* [ ] Correção de bug ou inconsistência de dados
* [ ] Refatoração de modelo DBT
* [ ] Documentação
* [ ] Infraestrutura / CI
* [ ] Outro: ___

## Issues relacionadas

#361

## Como testar / validar

```bash
# Testar DAG de contratos ativos
airflow dags test contratos_mir_ingest_dag 2026-06-17

# Testar DAG de contratos inativos
airflow dags test contratos_inativos_mir_ingest_dag 2026-06-17
```

Validar também que:

1. A variável `airflow_orgao_1` está configurada.
2. O órgão possui UGs cadastradas em `airflow_variables`.
3. Os registros são inseridos/atualizados na tabela `compras_gov.contratos`.
4. A DAG de contratos ativos dispara a DAG de contratos inativos ao final da execução.

## Checklist

* [x] Título do PR segue Conventional Commits
* [x] Issue relacionada foi referenciada
* [x] Testes/lint foram executados ou a ausência foi justificada
* [ ] Testes DBT adicionados/atualizados, se aplicável
* [ ] Documentação atualizada, se aplicável
* [x] Sem dados sensíveis ou credenciais no código
* [x] Branch atualizada com `upstream/main` ou `origin/main`

