### PR TITLE
fix(pessoas): renomeia hierarquia para forca_trabalho

### DIFF
--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/distribuicao_raca_cor_sexo_servidores_.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/distribuicao_raca_cor_sexo_servidores_.sql
@@ -5,6 +5,6 @@ SELECT
     SUM(CASE WHEN nome_sexo = 'MASCULINO' THEN 1 ELSE 0 END) AS masculino,
     nome_situacao_funcional,
     max(dt_ingest) as dt_ingest
-FROM {{ ref("hierarquia") }}
+FROM {{ ref("forca_trabalho") }}
 GROUP BY nome_cor, nome_situacao_funcional
 ORDER BY nome_cor

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/forca_trabalho.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/forca_trabalho.sql
@@ -139,7 +139,14 @@ with
             ) as ordem_grandeza,
             coalesce(nomeunidade, nome_uorg_exercicio) as nomeunidade,
             coalesce(siglaunidade, sigla_uorg_exercicio) as siglaunidade,
-            coalesce(denominacao, nome_cargo) as nome_cargo,
+            -- Estagiários (ESTAGIARIO SIGEPE) não têm cod_funcao e portanto não têm
+            -- correspondência SIORG; usamos nome_cargo do SIAPE diretamente para
+            -- garantir que o campo não fique nulo nessa situação funcional.
+            case
+                when upper(pr.nome_situacao_funcional) = 'ESTAGIARIO SIGEPE'
+                then pr.nome_cargo
+                else coalesce(pr.denominacao, pr.nome_cargo)
+            end as nome_cargo,
             case
                 when cod_situacao_funcional = '04' then 'Nomeação livre' else 'Carreira'
             end as servidores_carreira,

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/schema.yml
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/gold/schema.yml
@@ -106,13 +106,15 @@ models:
 
 
 
-  - name: hierarquia
+  - name: forca_trabalho
     description: >
       Tabela que correlaciona dados do SIAPE (dados funcionais e pessoais dos servidores)
       com a estrutura organizacional do SIORG, atribuindo uma métrica de hierarquia aos cargos
       com base na codificação da função. A hierarquia é determinada por uma fórmula baseada
       na categoria e no nível do cargo. A tabela também indica se o cargo é de carreira ou de
       nomeação livre, além de consolidar informações sobre o servidor e sua chefia imediata.
+      Estagiários (ESTAGIARIO SIGEPE) utilizam nome_cargo diretamente do SIAPE, pois não
+      possuem correspondência na estrutura SIORG.
 
     meta:
       tags:
@@ -379,7 +381,7 @@ models:
   - name: distribuicao_raca_cor_sexo
     description: >
       Tabela agregada que apresenta a distribuição de servidores por raça/cor e sexo.
-      A análise utiliza dados da tabela de hierarquia para calcular a quantidade de servidores
+      A análise utiliza dados da tabela de forca_trabalho para calcular a quantidade de servidores
       por gênero em cada categoria de raça/cor e situação funcional.
       O campo 'feminino' é multiplicado por -1 para facilitar visualizações em pirâmide.
     meta:

--- a/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/silver/servidores_completos.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/pessoas_dbt/silver/servidores_completos.sql
@@ -50,7 +50,7 @@ with
                 then 'Ativo em outro órgão'
                 else siglaunidade
             end as unidade_exercicio
-        from {{ ref("hierarquia") }} ph
+        from {{ ref("forca_trabalho") }} ph
         inner join {{ ref("dados_funcionais") }} df on ph.cpf = df.cpf
     ),
 

--- a/airflow_lappis/dags/dbt/ipea/tests/estagiarios_nome_cargo_not_null.sql
+++ b/airflow_lappis/dags/dbt/ipea/tests/estagiarios_nome_cargo_not_null.sql
@@ -1,0 +1,10 @@
+-- Teste singular: nenhum estagiário em forca_trabalho pode ter nome_cargo nulo.
+-- Retorna linhas que violam a regra; dbt falha se o resultado não for vazio.
+select
+    cpf,
+    nome_situacao_funcional,
+    nome_cargo
+from {{ ref("forca_trabalho") }}
+where
+    upper(nome_situacao_funcional) = 'ESTAGIARIO SIGEPE'
+    and nullif(trim(nome_cargo), '') is null


### PR DESCRIPTION
## Descrição

Este PR refatora o modelo DBT `pessoas.hierarquia`, renomeando-o para `pessoas.forca_trabalho`.

A alteração alinha o nome do modelo ao conceito de **força de trabalho** utilizado no dashboard do IPEA, tornando a nomenclatura mais clara e consistente com o domínio dos dados.

Além da renomeação do modelo, foram atualizadas as referências downstream versionadas que consumiam `ref("hierarquia")`, substituindo-as por `ref("forca_trabalho")`. Entre os modelos impactados estão:

- `servidores_completos`
- `distribuicao_raca_cor_sexo_servidores_`

A documentação do modelo também foi atualizada em `gold/schema.yml`, refletindo o novo nome e mantendo a consistência da camada gold.

Também foi adicionada uma validação DBT para garantir que registros de estagiários em `forca_trabalho` não fiquem com `nome_cargo` nulo ou vazio.

## Tipo de mudança

- [ ] Nova funcionalidade / pipeline
- [x] Correção de bug ou inconsistência de dados
- [x] Refatoração de modelo DBT
- [x] Documentação
- [ ] Infraestrutura / CI
- [ ] Outro: ___

## Issues relacionadas

Refs #372

## Como testar / validar

Executar os comandos abaixo no diretório do projeto DBT:

```bash
cd airflow_lappis/dags/dbt/ipea

dbt parse
dbt ls --select forca_trabalho+
dbt ls --select hierarquia
````

Em ambiente com dados e fontes carregadas, executar também:

```bash
dbt run --select forca_trabalho+
dbt test --select forca_trabalho+
```

Validação complementar após a materialização do modelo:

```sql
SELECT count(*) AS estagiarios_sem_cargo
FROM pessoas.forca_trabalho
WHERE upper(nome_situacao_funcional) = 'ESTAGIARIO SIGEPE'
  AND nullif(trim(nome_cargo), '') IS NULL;
```

Resultado esperado:

```text
0
```

Após a validação em ambiente com dados reais, a tabela antiga pode ser removida em uma etapa segura de pós-deploy:

```sql
DROP TABLE IF EXISTS pessoas.hierarquia;
```

## Evidências

Validações executadas localmente:

* `dbt parse`: passou.
* `dbt ls --select forca_trabalho+`: passou e selecionou o novo modelo e seus downstream.
* `dbt ls --select hierarquia`: nenhum nó selecionado.
* Busca estática não encontrou referências restantes a `ref("hierarquia")` nem a `pessoas.hierarquia` no código versionado.

Não foi possível executar localmente os comandos abaixo:

```bash
dbt run --select forca_trabalho+
dbt test --select forca_trabalho+
```

A execução falhou porque o ambiente local aponta para o database `data_warehouse`, enquanto o projeto configura `+database: analytics`, resultando no seguinte erro:

```text
ERROR: Cross-db references not allowed in postgres (analytics vs data_warehouse)
```

Além disso, o banco local não possui os schemas e tabelas fonte necessários, como `pessoas`, `siape` e `siorg`.

Por esse motivo, a execução completa deve ser realizada em ambiente com o database `analytics` configurado e com as fontes carregadas.

## Checklist

* [x] Título do PR segue Conventional Commits
* [x] Issue relacionada foi referenciada
* [x] Testes/lint foram executados ou a ausência foi justificada
* [x] Testes DBT adicionados/atualizados, se aplicável
* [x] Documentação atualizada, se aplicável
* [x] Sem dados sensíveis ou credenciais no código
* [ ] Branch atualizada com `upstream/main` ou `origin/main`



