### PR TITLE
refactor(siconv): centraliza cruzamentos de convênio em convenios_consolidados

### DIFF
--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_cronograma_desembolso.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_cronograma_desembolso.sql
@@ -3,7 +3,7 @@
 with
     convenio as (
         select *
-        from {{ ref("convenio") }}
+        from {{ ref("convenios_consolidados") }}
     ),
     cronograma_desembolso as (
         select *

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_desbloqueio.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_desbloqueio.sql
@@ -3,7 +3,7 @@
 with
     convenio as (
         select *
-        from {{ ref("convenio") }}
+        from {{ ref("convenios_consolidados") }}
     ),
     desbloqueio as (
         select *

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_desembolso.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_desembolso.sql
@@ -3,7 +3,7 @@
 with
     convenio as (
         select *
-        from {{ ref("convenio") }}
+        from {{ ref("convenios_consolidados") }}
     ),
     desembolso as (
         select *

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_empenho.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_empenho.sql
@@ -3,7 +3,7 @@
 with
     convenio as (
         select *
-        from {{ ref("convenio") }}
+        from {{ ref("convenios_consolidados") }}
     ),
     empenho as (
         select *

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_historico_situacao.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_historico_situacao.sql
@@ -3,7 +3,7 @@
 with
     convenio as (
         select *
-        from {{ ref("convenio") }}
+        from {{ ref("convenios_consolidados") }}
     ),
     historico_situacao as (
         select *

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_ingresso_contrapartida.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_ingresso_contrapartida.sql
@@ -3,7 +3,7 @@
 with
     convenio as (
         select *
-        from {{ ref("convenio") }}
+        from {{ ref("convenios_consolidados") }}
     ),
     ingresso_contrapartida as (
         select *

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_licitacao.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_licitacao.sql
@@ -3,7 +3,7 @@
 with
     convenio as (
         select *
-        from {{ ref("convenio") }}
+        from {{ ref("convenios_consolidados") }}
     ),
     licitacao as (
         select *

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_meta_crono_fisico.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_meta_crono_fisico.sql
@@ -3,7 +3,7 @@
 with
     convenio as (
         select *
-        from {{ ref("convenio") }}
+        from {{ ref("convenios_consolidados") }}
     ),
     meta_crono_fisico as (
         select *

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_pagamento.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_pagamento.sql
@@ -3,7 +3,7 @@
 with
     convenio as (
         select *
-        from {{ ref("convenio") }}
+        from {{ ref("convenios_consolidados") }}
     ),
     pagamento as (
         select *

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_pagamento_tributo.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_pagamento_tributo.sql
@@ -3,7 +3,7 @@
 with
     convenio as (
         select *
-        from {{ ref("convenio") }}
+        from {{ ref("convenios_consolidados") }}
     ),
     pagamento_tributo as (
         select *

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_proposta.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_proposta.sql
@@ -3,7 +3,7 @@
 with
     convenio as (
         select *
-        from {{ ref("convenio") }}
+        from {{ ref("convenios_consolidados") }}
     ),
     proposta as (
         select *

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_prorroga_oficio.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_prorroga_oficio.sql
@@ -3,7 +3,7 @@
 with
     convenio as (
         select *
-        from {{ ref("convenio") }}
+        from {{ ref("convenios_consolidados") }}
     ),
     prorroga_oficio as (
         select *

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_solicitacao_alteracao.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_solicitacao_alteracao.sql
@@ -3,7 +3,7 @@
 with
     convenio as (
         select *
-        from {{ ref("convenio") }}
+        from {{ ref("convenios_consolidados") }}
     ),
     solicitacao_alteracao as (
         select *

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_solicitacao_rendimento.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_solicitacao_rendimento.sql
@@ -3,7 +3,7 @@
 with
     convenio as (
         select *
-        from {{ ref("convenio") }}
+        from {{ ref("convenios_consolidados") }}
     ),
     solicitacao_rendimento as (
         select *

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_termo_aditivo.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenio_termo_aditivo.sql
@@ -3,7 +3,7 @@
 with
     convenio as (
         select *
-        from {{ ref("convenio") }}
+        from {{ ref("convenios_consolidados") }}
     ),
     termo_aditivo as (
         select *

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenios_consolidados.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/convenios_consolidados.sql
@@ -1,0 +1,75 @@
+{{ config(materialized="table") }}
+
+with
+    convenio as (
+        select *
+        from {{ ref("convenio") }}
+    ),
+    empenhos_tesouro_ted as (
+        select *
+        from {{ source("siafi", "ne_tesouro") }}
+    ),
+    convenios_ppa as (
+        select
+            cc.*,
+            et.programa_governo,
+            et.programa_governo_descricao,
+            et.acao_governo,
+            et.acao_governo_descricao
+        from convenio cc
+        right join empenhos_tesouro_ted et
+            on cast(cc.nr_convenio as text) = et.ne_info_complementar
+        where cc.nr_convenio is not null
+            and left(et.ne_ccor, 6) = '810008'
+    ),
+    convenios_consolidado as (
+        select *
+        from convenio
+        where ug_emitente = 810008
+        union distinct
+        select
+            nr_convenio,
+            id_proposta,
+            dia,
+            mes,
+            ano,
+            dia_assin_conv,
+            sit_convenio,
+            subsituacao_conv,
+            situacao_publicacao,
+            instrumento_ativo,
+            ind_opera_obtv,
+            nr_processo,
+            ug_emitente,
+            dia_publ_conv,
+            dia_inic_vigenc_conv,
+            dia_fim_vigenc_conv,
+            dia_fim_vigenc_original_conv,
+            dias_prest_contas,
+            dia_limite_prest_contas,
+            data_suspensiva,
+            data_retirada_suspensiva,
+            dias_clausula_suspensiva,
+            situacao_contratacao,
+            ind_assinado,
+            motivo_suspensao,
+            ind_foto,
+            qtde_convenios,
+            qtd_ta,
+            qtd_prorroga,
+            vl_global_conv,
+            vl_repasse_conv,
+            vl_contrapartida_conv,
+            vl_empenhado_conv,
+            vl_desembolsado_conv,
+            vl_saldo_reman_tesouro,
+            vl_saldo_reman_convenente,
+            vl_rendimento_aplicacao,
+            vl_ingresso_contrapartida,
+            vl_saldo_conta,
+            valor_global_original_conv
+        from convenios_ppa
+    )
+
+select *
+from convenios_consolidado

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/proposta_convenio.sql
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/proposta_convenio.sql
@@ -3,7 +3,7 @@
 with
     convenio as (
         select *
-        from {{ ref("convenio") }}
+        from {{ ref("convenios_consolidados") }}
     ),
     proposta as (
         select *

--- a/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/schema.yaml
+++ b/airflow_lappis/dags/dbt/mir/models/siconv_dbt/silver/schema.yaml
@@ -174,6 +174,118 @@ models:
           nome_coluna: 'vl_global_conv'
           tipo_esperado: 'numeric'
 
+  - name: convenios_consolidados
+    description: >
+      Tabela da camada silver que consolida os convênios do SICONV relacionados à
+      UG 810008. Inclui (a) todos os convênios cuja `ug_emitente` é 810008 na
+      tabela bronze `convenio` e (b) convênios adicionais identificados a partir
+      dos empenhos do Tesouro (`siafi.ne_tesouro`) cujo `ne_ccor` começa com
+      '810008' e cujo `ne_info_complementar` corresponde ao `nr_convenio`. O
+      `UNION DISTINCT` garante que não há duplicidade entre as duas fontes.
+      Esta tabela substitui a tabela `convenio` como base para todos os
+      cruzamentos da camada silver (proposta, desembolso, cronograma de
+      desembolso, desbloqueio, empenho, licitação, pagamento, pagamento de
+      tributo, ingresso de contrapartida, histórico de situação, meta /
+      cronograma físico, prorrogação de ofício, solicitação de alteração,
+      solicitação de rendimento de aplicação e termo aditivo).
+    meta:
+      tags:
+        - silver
+    columns:
+      - name: nr_convenio
+        description: "Número do convênio."
+      - name: id_proposta
+        description: "Identificador único da proposta que originou o convênio."
+      - name: dia
+        description: "Dia de assinatura do convênio."
+      - name: mes
+        description: "Mês de assinatura do convênio."
+      - name: ano
+        description: "Ano de assinatura do convênio."
+      - name: dia_assin_conv
+        description: "Data de assinatura do convênio."
+      - name: sit_convenio
+        description: "Situação do convênio."
+      - name: subsituacao_conv
+        description: "Subsituação do convênio."
+      - name: situacao_publicacao
+        description: "Situação de publicação do convênio."
+      - name: instrumento_ativo
+        description: "Indica se o instrumento está ativo."
+      - name: ind_opera_obtv
+        description: "Indicador de operação OBTV."
+      - name: nr_processo
+        description: "Número do processo."
+      - name: ug_emitente
+        description: "Código da UG emitente."
+      - name: dia_publ_conv
+        description: "Data de publicação do convênio."
+      - name: dia_inic_vigenc_conv
+        description: "Data de início da vigência do convênio."
+      - name: dia_fim_vigenc_conv
+        description: "Data de fim da vigência do convênio."
+      - name: dia_fim_vigenc_original_conv
+        description: "Data de fim da vigência original do convênio."
+      - name: dias_prest_contas
+        description: "Prazo em dias para prestação de contas."
+      - name: dia_limite_prest_contas
+        description: "Data limite para prestação de contas."
+      - name: data_suspensiva
+        description: "Data da cláusula suspensiva."
+      - name: data_retirada_suspensiva
+        description: "Data de retirada da cláusula suspensiva."
+      - name: dias_clausula_suspensiva
+        description: "Dias de cláusula suspensiva."
+      - name: situacao_contratacao
+        description: "Situação da contratação."
+      - name: ind_assinado
+        description: "Indica se o convênio foi assinado."
+      - name: motivo_suspensao
+        description: "Motivo da suspensão do convênio."
+      - name: ind_foto
+        description: "Indica se há foto associada."
+      - name: qtde_convenios
+        description: "Quantidade de convênios."
+      - name: qtd_ta
+        description: "Quantidade de termos aditivos."
+      - name: qtd_prorroga
+        description: "Quantidade de prorrogações."
+      - name: vl_global_conv
+        description: "Valor global do convênio."
+      - name: vl_repasse_conv
+        description: "Valor de repasse do convênio."
+      - name: vl_contrapartida_conv
+        description: "Valor de contrapartida do convênio."
+      - name: vl_empenhado_conv
+        description: "Valor empenhado do convênio."
+      - name: vl_desembolsado_conv
+        description: "Valor desembolsado do convênio."
+      - name: vl_saldo_reman_tesouro
+        description: "Valor do saldo remanescente do tesouro."
+      - name: vl_saldo_reman_convenente
+        description: "Valor do saldo remanescente do convenente."
+      - name: vl_rendimento_aplicacao
+        description: "Valor do rendimento de aplicação."
+      - name: vl_ingresso_contrapartida
+        description: "Valor de ingresso de contrapartida."
+      - name: vl_saldo_conta
+        description: "Valor do saldo em conta."
+      - name: valor_global_original_conv
+        description: "Valor global original do convênio."
+    tests:
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.convenios_consolidados'
+          nome_coluna: 'nr_convenio'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.convenios_consolidados'
+          nome_coluna: 'ug_emitente'
+          tipo_esperado: 'integer'
+      - verificacao_tipagem:
+          nome_tabela: 'siconv_dbt.convenios_consolidados'
+          nome_coluna: 'vl_global_conv'
+          tipo_esperado: 'numeric'
+
   - name: proposta_convenio
     description: >
       Tabela da camada silver que cruza convênios com propostas do SICONV,


### PR DESCRIPTION
## Descrição

Adiciona o modelo silver `convenios_consolidados` no schema `siconv_dbt`, que passa a ser a base única de cruzamento dos convênios relacionados à UG 810008 (MIR). A nova tabela consolida, via `UNION DISTINCT`, duas fontes:

1. Convênios da bronze `convenio` com `ug_emitente = 810008`.
2. Convênios adicionais identificados a partir dos empenhos do Tesouro (`siafi.ne_tesouro`) cujo `ne_ccor` começa com `810008` e cujo `ne_info_complementar` corresponde ao `nr_convenio` — captando convênios pagos pela UG via PPA que não aparecem com `ug_emitente = 810008` na origem.

Todos os cruzamentos silver de convênio passam a referenciar `convenios_consolidados` em vez de `convenio`, garantindo que análises downstream operem sobre o universo correto e completo de convênios da MIR.

## Tipo de mudança
- [x] Nova funcionalidade / pipeline
- [x] Refatoração de modelo DBT
- [x] Documentação

## Issues relacionadas
Closes #388 
Closes #371

## Mudanças

**Novo modelo**
- `siconv_dbt/silver/convenios_consolidados.sql` — consolida convênios por `ug_emitente = 810008` + convênios via `ne_tesouro` (PPA, `ne_ccor` iniciando em `810008`).

**Cruzamentos refatorados para usar `convenios_consolidados` no lugar de `convenio`** (16 modelos):
- `proposta_convenio`, `convenio_proposta`
- `convenio_desembolso`, `convenio_cronograma_desembolso`, `convenio_desbloqueio`
- `convenio_empenho`, `convenio_licitacao`
- `convenio_pagamento`, `convenio_pagamento_tributo`
- `convenio_ingresso_contrapartida`, `convenio_historico_situacao`
- `convenio_meta_crono_fisico`, `convenio_prorroga_oficio`
- `convenio_solicitacao_alteracao`, `convenio_solicitacao_rendimento`, `convenio_termo_aditivo`

**Documentação**
- `siconv_dbt/silver/schema.yaml` — adicionada entrada `convenios_consolidados` com descrição, 39 colunas documentadas e três testes de tipagem (`nr_convenio`, `ug_emitente`, `vl_global_conv`).

## Como testar / validar

```bash
cd airflow_lappis/dags/dbt/mir

# Build do novo modelo e seus downstreams
dbt run --select +convenios_consolidados+

# Testes de tipagem do novo modelo
dbt test --select convenios_consolidados

# Validar cruzamentos refatorados
dbt build --select convenios_consolidados+
```

Queries de sanidade sugeridas após o build:

```sql
-- Total consolidado vs. fontes individuais
select count(*) from siconv_dbt.convenios_consolidados;
select count(*) from siconv_dbt.convenio where ug_emitente = 810008;

-- Convênios capturados apenas via PPA (ne_tesouro)
select count(*)
from siconv_dbt.convenios_consolidados cc
left join siconv_dbt.convenio c
  on cc.nr_convenio = c.nr_convenio and c.ug_emitente = 810008
where c.nr_convenio is null;

-- Garantir que não há duplicidade por nr_convenio
select nr_convenio, count(*)
from siconv_dbt.convenios_consolidados
group by 1 having count(*) > 1;
```

## Evidências
<!-- Anexar contagens das queries acima e prints do `dbt build` verde. -->

## Checklist
- [x] Título do PR segue Conventional Commits
- [ ] Issue relacionada foi referenciada
- [ ] Testes/lint foram executados ou a ausência foi justificada
- [x] Testes DBT adicionados/atualizados, se aplicável
- [x] Documentação atualizada, se aplicável
- [x] Sem dados sensíveis ou credenciais no código
- [ ] Branch atualizada com `upstream/main` ou `origin/main`