### PR TITLE
feat: dbts relatorios sgac

### DIFF
--- a/airflow_lappis/dags/dbt/ipea/models/sistema_sisbolsas/gold/schema.yml
+++ b/airflow_lappis/dags/dbt/ipea/models/sistema_sisbolsas/gold/schema.yml
@@ -1,0 +1,85 @@
+version: 2
+
+models:
+  - name: sgac_relatorio_termino_vigencia_2025
+    description: >
+      Relatório gold no layout da planilha de controle de término de vigência,
+      usando dados confiáveis do SGAC.
+    meta:
+      tags:
+        - gold
+        - sgac
+        - relatorio
+    columns:
+      - name: diretoria
+        description: Diretoria responsável pelo instrumento.
+      - name: instrumento
+        description: Tipo de instrumento registrado no SGAC.
+      - name: objeto
+        description: Objeto do instrumento.
+      - name: entidades_externas
+        description: Entidades externas envolvidas.
+      - name: inicio
+        description: Data de início do instrumento.
+      - name: conclusao
+        description: Data de conclusão ou vencimento do instrumento.
+      - name: recursos_externos
+        description: Valor de recursos externos conforme campo orçamentário do SGAC.
+      - name: recursos_ipea
+        description: Valor de recursos IPEA conforme campo não orçamentário do SGAC.
+      - name: numero_do_processo
+        description: Número do processo SEI associado.
+      - name: coordenador
+        description: Coordenador registrado no SGAC.
+      - name: fiscal_e_substituto
+        description: Fiscal e substituto com marcações HTML básicas removidas.
+      - name: situacao
+        description: Situação do instrumento no SGAC.
+
+  - name: sgac_relatorio_teds_vigentes
+    description: >
+      Relatório gold no layout da planilha de TEDs vigentes. Usa dados do SGAC
+      e complementa valores financeiros apenas pelo cruzamento validável com
+      número SIAFI.
+    meta:
+      tags:
+        - gold
+        - sgac
+        - relatorio
+    columns:
+      - name: entidades_externas
+        description: Entidades externas envolvidas.
+      - name: instrumento
+        description: Tipo de instrumento registrado no SGAC.
+      - name: diretoria
+        description: Diretoria responsável pelo instrumento.
+      - name: inicio_execucao
+        description: Data de início da execução.
+      - name: data_de_conclusao
+        description: Data de conclusão ou vencimento.
+      - name: numero_do_processo
+        description: Número do processo SEI associado.
+      - name: recursos_externos
+        description: Valor de recursos externos conforme campo orçamentário do SGAC.
+      - name: recursos_ipea
+        description: Valor de recursos IPEA conforme campo não orçamentário do SGAC.
+      - name: numero_siafi
+        description: Número SIAFI registrado no SGAC.
+      - name: termos_aditivos
+        description: Informação de termos aditivos registrada no SGAC.
+      - name: apostilamentos
+        description: Campo presente na planilha de referência; não existe no SGAC.
+      - name: prorrogacao_oficio
+        description: Campo presente na planilha de referência; não existe no SGAC.
+      - name: planejamento_diarias_passagens
+        description: Campo presente na planilha de referência; não existe no SGAC.
+      - name: pago
+        description: Valor pago derivado do cruzamento por número SIAFI, quando houver.
+      - name: pendente_de_pagamento
+        description: Diferença entre valor firmado/total e valor pago no cruzamento por número SIAFI, quando houver.
+      - name: situacao
+        description: Situação do instrumento no SGAC.
+      - name: sgac_id
+        description: Identificador do item no SGAC.
+      - name: eh_ted
+        description: Indica se o instrumento foi classificado como TED ou dispensa de TED.

--- a/airflow_lappis/dags/dbt/ipea/models/sistema_sisbolsas/gold/sgac_relatorio_teds_vigentes.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/sistema_sisbolsas/gold/sgac_relatorio_teds_vigentes.sql
@@ -1,0 +1,70 @@
+with
+    projetos as (
+        select *
+        from {{ ref("sgac_projetos_sgac") }}
+        where data_vencimento >= current_date
+          and coalesce(status, '') ilike '%execu%'
+          and (
+            instrumento ilike '%TED%'
+            or instrumento ilike '%execução descentralizada%'
+            or instrumento ilike '%Dispensa de TED%'
+          )
+    ),
+
+    teds_siafi as (
+        select
+            sgac_id,
+            sum(coalesce(despesas_pagas_exercicio, 0))
+                as despesas_pagas_exercicio,
+            sum(coalesce(despesas_pagas_rap, 0)) as despesas_pagas_rap,
+            max(valor_firmado) as valor_firmado
+        from {{ ref("sgac_teds_siafi") }}
+        group by sgac_id
+    ),
+
+    relatorio as (
+        select
+            p.entidades_externas,
+            p.instrumento,
+            p.diretoria_responsavel as diretoria,
+            p.data_inicio as inicio_execucao,
+            p.data_vencimento as data_de_conclusao,
+            p.numero_do_proc as numero_do_processo,
+            p.recursos_orcamentarios as recursos_externos,
+            p.recursos_nao_orcamentarios as recursos_ipea,
+            p.numero_siafi,
+            p.termos_aditivos,
+            null::text as apostilamentos,
+            null::text as prorrogacao_oficio,
+            null::text as planejamento_diarias_passagens,
+            case
+                when s.sgac_id is not null
+                then coalesce(s.despesas_pagas_exercicio, 0)
+                    + coalesce(s.despesas_pagas_rap, 0)
+            end as pago,
+            case
+                when s.sgac_id is not null
+                then greatest(
+                    coalesce(s.valor_firmado, p.total_de_recursos, 0)
+                    - (
+                        coalesce(s.despesas_pagas_exercicio, 0)
+                        + coalesce(s.despesas_pagas_rap, 0)
+                    ),
+                    0
+                )
+            end as pendente_de_pagamento,
+            p.status as situacao,
+            p.id as sgac_id,
+            (
+                p.instrumento ilike '%TED%'
+                or p.instrumento ilike '%execução descentralizada%'
+                or p.instrumento ilike '%Dispensa de TED%'
+            ) as eh_ted
+        from projetos as p
+        left join teds_siafi as s
+            on s.sgac_id = p.id
+    )
+
+select *
+from relatorio
+order by inicio_execucao desc, data_de_conclusao, diretoria, entidades_externas

--- a/airflow_lappis/dags/dbt/ipea/models/sistema_sisbolsas/gold/sgac_relatorio_termino_vigencia_2025.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/sistema_sisbolsas/gold/sgac_relatorio_termino_vigencia_2025.sql
@@ -1,0 +1,34 @@
+select
+    diretoria_responsavel as diretoria,
+    instrumento,
+    objeto,
+    entidades_externas,
+    data_inicio as inicio,
+    data_vencimento as conclusao,
+    recursos_orcamentarios as recursos_externos,
+    recursos_nao_orcamentarios as recursos_ipea,
+    numero_do_proc as numero_do_processo,
+    coordenador,
+    nullif(
+        trim(
+            regexp_replace(
+                regexp_replace(
+                    replace(
+                        replace(fiscal_e_substituto, '&nbsp;', ' '),
+                        '&#58;',
+                        ':'
+                    ),
+                    '<[^>]*>',
+                    ' ',
+                    'g'
+                ),
+                '\s+',
+                ' ',
+                'g'
+            )
+        ),
+        ''
+    ) as fiscal_e_substituto,
+    status as situacao
+from {{ ref("sgac_projetos_sgac") }}
+order by conclusao, diretoria, instrumento, entidades_externas

--- a/airflow_lappis/dags/dbt/ipea/models/sistema_sisbolsas/silver/schema.yml
+++ b/airflow_lappis/dags/dbt/ipea/models/sistema_sisbolsas/silver/schema.yml
@@ -197,3 +197,53 @@ models:
         description: Total de processos com bolsa ativa.
       - name: usuario_criacao
         description: Usuário que criou a chamada pública.
+
+  - name: sgac_teds_siafi
+    description: >
+      Cruzamento conservador entre TEDs do SGAC e dados SIAFI/TransfereGov
+      usando apenas o número SIAFI informado em `sgac_projetos_sgac` contra
+      o número de transferência (`num_transf`).
+      Não utiliza número de processo SEI como chave de integração.
+    meta:
+      tags:
+        - silver
+        - sgac
+        - siafi
+        - ted
+    columns:
+      - name: sgac_id
+        description: Identificador do item no SGAC.
+      - name: titulo
+        description: Título do projeto no SGAC.
+      - name: instrumento
+        description: Tipo de instrumento registrado no SGAC.
+      - name: numero_do_proc
+        description: Número do processo SEI mantido apenas como atributo informativo.
+      - name: numero_siafi
+        description: Número SIAFI usado como chave de integração.
+      - name: data_inicio
+        description: Data de início registrada no SGAC.
+      - name: data_vencimento
+        description: Data de vencimento registrada no SGAC.
+      - name: diretoria_responsavel
+        description: Diretoria responsável registrada no SGAC.
+      - name: fiscal_e_substituto
+        description: Fiscal e substituto registrados no SGAC.
+      - name: total_de_recursos
+        description: Valor total de recursos registrado no SGAC.
+      - name: plano_acao
+        description: Plano de ação correspondente ao número SIAFI, quando encontrado.
+      - name: num_transf
+        description: Número de transferência usado como chave de integração com o número SIAFI do SGAC.
+      - name: sq_instrumento
+        description: Sequencial do instrumento mantido apenas como atributo informativo do Plano de Ação.
+      - name: valor_firmado
+        description: Valor firmado no cruzamento SIAFI/TransfereGov.
+      - name: despesas_pagas_exercicio
+        description: Despesas pagas no exercício.
+      - name: despesas_pagas_rap
+        description: Despesas pagas de restos a pagar.
+      - name: chave_match
+        description: Chave utilizada no cruzamento, sempre `numero_siafi`.
+      - name: caminho_match
+        description: Descrição do caminho de integração utilizado.

--- a/airflow_lappis/dags/dbt/ipea/models/sistema_sisbolsas/silver/sgac_teds_siafi.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/sistema_sisbolsas/silver/sgac_teds_siafi.sql
@@ -1,0 +1,130 @@
+with
+    sgac_teds as (
+        select
+            id as sgac_id,
+            titulo,
+            instrumento,
+            numero_do_proc,
+            numero_siafi,
+            data_inicio,
+            data_vencimento,
+            diretoria_responsavel,
+            fiscal_e_substituto,
+            total_de_recursos,
+            regexp_replace(coalesce(numero_siafi, ''), '[^0-9]', '', 'g')
+            as siafi_norm
+        from {{ ref("sgac_projetos_sgac") }}
+        where (
+            instrumento ilike '%TED%'
+            or instrumento ilike '%execução descentralizada%'
+            or instrumento ilike '%Dispensa de TED%'
+        )
+          and regexp_replace(coalesce(numero_siafi, ''), '[^0-9]', '', 'g') <> ''
+    ),
+
+    transfere_gov_teds as (
+        select distinct
+            coalesce(r.plano_acao, p.id_plano_acao) as plano_acao,
+            r.num_transf,
+            p.sq_instrumento,
+            p.sigla_unidade_descentralizada,
+            p.unidade_descentralizada,
+            p.dt_inicio_vigencia,
+            p.dt_fim_vigencia,
+            p.tx_situacao_plano_acao,
+            p.vl_total_plano_acao,
+            r.valor_firmado,
+            r.orcamento_recebido,
+            r.orcamento_devolvido,
+            r.empenhado,
+            r.empenho_anulado,
+            r.despesas_pagas_exercicio,
+            r.despesas_pagas_rap,
+            r.restos_a_pagar,
+            r.despesas_liquidada,
+            r.financeiro_recebido,
+            r.financeiro_devolvido,
+            r.financeiro_cancelado,
+            regexp_replace(coalesce(r.num_transf, ''), '[^0-9]', '', 'g')
+            as transf_norm
+        from {{ ref("ted_resumo_orcamentario") }} as r
+        full join {{ ref("planos_acao") }} as p
+            on p.id_plano_acao = r.plano_acao
+    ),
+
+    matches as (
+        select distinct
+            s.sgac_id,
+            s.titulo,
+            s.instrumento,
+            s.numero_do_proc,
+            s.numero_siafi,
+            s.data_inicio,
+            s.data_vencimento,
+            s.diretoria_responsavel,
+            s.fiscal_e_substituto,
+            s.total_de_recursos,
+            t.plano_acao,
+            t.num_transf,
+            t.sq_instrumento,
+            t.sigla_unidade_descentralizada,
+            t.unidade_descentralizada,
+            t.dt_inicio_vigencia,
+            t.dt_fim_vigencia,
+            t.tx_situacao_plano_acao,
+            t.vl_total_plano_acao,
+            t.valor_firmado,
+            t.orcamento_recebido,
+            t.orcamento_devolvido,
+            t.empenhado,
+            t.empenho_anulado,
+            t.despesas_pagas_exercicio,
+            t.despesas_pagas_rap,
+            t.restos_a_pagar,
+            t.despesas_liquidada,
+            t.financeiro_recebido,
+            t.financeiro_devolvido,
+            t.financeiro_cancelado,
+            'numero_siafi' as chave_match,
+            'SGAC.numero_siafi -> SIAFI.num_transf' as caminho_match
+        from sgac_teds as s
+        inner join transfere_gov_teds as t
+            on length(s.siafi_norm) >= 5
+           and s.siafi_norm = t.transf_norm
+    )
+
+select
+    sgac_id,
+    titulo,
+    instrumento,
+    numero_do_proc,
+    numero_siafi,
+    data_inicio,
+    data_vencimento,
+    diretoria_responsavel,
+    fiscal_e_substituto,
+    total_de_recursos,
+    plano_acao,
+    num_transf,
+    sq_instrumento,
+    sigla_unidade_descentralizada,
+    unidade_descentralizada,
+    dt_inicio_vigencia,
+    dt_fim_vigencia,
+    tx_situacao_plano_acao,
+    vl_total_plano_acao,
+    valor_firmado,
+    orcamento_recebido,
+    orcamento_devolvido,
+    empenhado,
+    empenho_anulado,
+    despesas_pagas_exercicio,
+    despesas_pagas_rap,
+    restos_a_pagar,
+    despesas_liquidada,
+    financeiro_recebido,
+    financeiro_devolvido,
+    financeiro_cancelado,
+    chave_match,
+    caminho_match
+from matches


### PR DESCRIPTION
## Descrição
Adiciona modelos DBT para relatórios gerenciais do SGAC/Sisbolsas, separando a lógica em camadas silver e gold.

Principais mudanças:
- Cria a silver `sgac_teds_siafi`, com cruzamento conservador entre SGAC e SIAFI/TransfereGov usando apenas `numero_siafi` do SGAC contra `num_transf`.
- Cria a gold `sgac_relatorio_teds_vigentes`, com TEDs vigentes em execução e valores financeiros derivados apenas do cruzamento validado por `num_transf`.
- Cria a gold `sgac_relatorio_termino_vigencia_2025`, no layout gerencial de controle de término de vigência.
- Atualiza os `schema.yml` das camadas silver e gold para documentar os novos modelos e colunas.

> Antes de abrir este PR, consulte o [Protocolo de Aprovação de Pull Requests](https://github.com/GovHub-br/data-application-gov-hub/blob/main/.github/MERGE_REQUEST_PROTOCOL.md).

## Tipo de mudança
- [x] Nova funcionalidade / pipeline
- [ ] Correção de bug ou inconsistência de dados
- [x] Refatoração de modelo DBT
- [x] Documentação
- [ ] Infraestrutura / CI
- [ ] Outro: ___

## Issues relacionadas
Closes #

## Como testar / validar

```bash
docker exec data-application-gov-hub-airflow-1 bash -lc "
mkdir -p /tmp/dbt_profiles &&
printf '%s\n' \
'ipea:' \
'  target: prod' \
'  outputs:' \
'    prod:' \
'      type: postgres' \
'      host: postgres' \
'      user: postgres' \
'      password: postgres' \
'      port: 5432' \
'      dbname: postgres' \
'      schema: ipea' > /tmp/dbt_profiles/profiles.yml &&
cd /opt/airflow/dags/dbt/ipea &&
dbt --log-path /tmp/dbt_logs run \
  --target-path /tmp/dbt_target \
  --profiles-dir /tmp/dbt_profiles \
  --select sgac_teds_siafi sgac_relatorio_teds_vigentes sgac_relatorio_termino_vigencia_2025
"