### PR TITLE
feat(tests): adicionar testes de qualidade e integridade estrutural para as tabelas do sistema mir/dados_abertos_dbt

### DIFF
--- a/airflow_lappis/dags/dbt/mir/models/dados_abertos_dbt/bronze/schema.yml
+++ b/airflow_lappis/dags/dbt/mir/models/dados_abertos_dbt/bronze/schema.yml
@@ -21,6 +21,9 @@ models:
         description: >
           Identificador único do deputado na API da Câmara.
           Utilizado como chave primária e referência para relacionamentos com outras tabelas.
+        tests:
+          - unique
+          - not_null
 
       - name: nome
         description: >
@@ -107,6 +110,9 @@ models:
         description: >
           Identificador único do senador na API do Senado Federal.
           Utilizado como chave primária e referência para relacionamentos com outras tabelas.
+        tests:
+          - unique
+          - not_null
 
       - name: nome_parlamentar
         description: >
@@ -210,6 +216,9 @@ models:
       - name: id
         description: >
           Identificador único da legislatura na API da Câmara dos Deputados.
+        tests:
+          - unique
+          - not_null
 
       - name: data_inicio
         description: >
@@ -265,12 +274,25 @@ models:
     columns:
       - name: id
         description: Identificador do deputado na Câmara.
+        tests:
+          - not_null
+          - relationships:
+              to: ref('deputados')
+              field: id
+              config:
+                severity: warn
       - name: nome
         description: Nome oficial do deputado na API da Câmara.
       - name: sigla_partido
         description: Partido politico atrelado ao registro do histórico de filiação.
       - name: id_legislatura
         description: Código numérico referente a legislatura do evento histórico do deputado.
+        tests:
+          - relationships:
+              to: ref('legislaturas')
+              field: id
+              config:
+                severity: warn
       - name: situacao
         description: Situação legal ou institucional durante aquele período (ex. Exercício, Afastado, Licença, etc).
       - name: data_filiacao
@@ -318,6 +340,13 @@ models:
     columns:
       - name: parlamentar_id
         description: Identificador base do senador.
+        tests:
+          - not_null
+          - relationships:
+              to: ref('senadores')
+              field: id
+              config:
+                severity: warn
       - name: codigo_partido
         description: Código associado com o registro partidário original do Senado.
       - name: sigla_partido

--- a/airflow_lappis/dags/dbt/mir/models/dados_abertos_dbt/silver/schema.yml
+++ b/airflow_lappis/dags/dbt/mir/models/dados_abertos_dbt/silver/schema.yml
@@ -14,6 +14,8 @@ models:
         description: >
           Identificador único do parlamentar na base unificada
           de deputados e senadores.
+        tests:
+          - not_null
       - name: chave_join_nome
         description: >
           Chave de junção padronizada (nome em caixa alta e trimado),
@@ -24,6 +26,8 @@ models:
       - name: cargo_parlamentar
         description: >
           Cargo do parlamentar (por exemplo, Deputado ou Senador).
+        tests:
+          - not_null
       - name: sigla_partido
         description: >
           Sigla do partido ao qual o parlamentar está filiado.
@@ -41,6 +45,10 @@ models:
           URL da imagem (logo) do partido do parlamentar,
           proveniente do seed partidos_logo.
     tests:
+      # Chave primária composta: a base unifica deputados e senadores via 
+      # UNION ALL, portanto o id só é único quando combinado com o cargo.
+      - unique:
+          column_name: "(id_parlamentar::text || '-' || cargo_parlamentar)"
       - verificacao_tipagem:
           nome_tabela: 'dados_abertos.parlamentares'
           nome_coluna: 'id_parlamentar'
@@ -88,12 +96,16 @@ models:
     columns:
       - name: id_parlamentar
         description: Identificador base unificado que representa o político (proveniente da Câmara ou Senado).
+        tests:
+          - not_null
       - name: chave_join_nome
         description: Chave string de junção formatada em caixa alta e conversões 'unaccent' na rotina TRANSLATE projetada para merge rústico.
       - name: nome_parlamentar
         description: Nome extenso original proveniente da camada bronze agregada.
       - name: cargo_parlamentar
         description: Atribuição legal do período ('Deputado' ou 'Senador').
+        tests:
+          - not_null
       - name: sigla_partido
         description: Partido representativo desta dimensão temporal do parlamentar com padronização via mapas canônicos.
       - name: uf_parlamentar


### PR DESCRIPTION
## Descrição
<!-- O que esse PR faz? Por que essa mudança é necessária? -->

Adiciona testes de qualidade e integridade estrutural ao módulo `mir/dados_abertos_dbt`, garantindo chaves primárias únicas/não nulas e validando a integridade referencial entre as tabelas de parlamentares (deputados e senadores) e seus históricos. Os testes usam apenas recursos nativos do dbt (`unique`, `not_null`, `relationships`), sem dependência de pacotes externos.

**Camada silver** (`models/dados_abertos_dbt/silver/schema.yml`):
- `parlamentares`: `not_null` em `id_parlamentar` e `cargo_parlamentar` + `unique` na PK composta `(id_parlamentar, cargo_parlamentar)` — necessária porque o modelo unifica deputados e senadores via `UNION ALL` (o `id` isolado não é único entre as duas casas).
- `parlamentares_historico`: `not_null` em `id_parlamentar` e `cargo_parlamentar` (tabela event-grained, sem PK simples única).

**Camada bronze** (`models/dados_abertos_dbt/bronze/schema.yml`):
- PKs com `unique` + `not_null`: `deputados.id`, `senadores.id`, `legislaturas.id`.
- Integridade referencial via `relationships` (`severity: warn`): `deputados_historico.id` → `deputados.id`, `deputados_historico.id_legislatura` → `legislaturas.id`, `senadores_historico.parlamentar_id` → `senadores.id`. Optou-se por `warn` pois dados abertos podem conter registros históricos órfãos legítimos (parlamentares antigos fora da base atual), reportando inconsistências sem quebrar o pipeline.

> Observação: o módulo `dados_abertos_dbt` não possui camada `gold` (apenas `bronze` e `silver`), portanto os testes de PK foram aplicados em silver (entidade) e bronze (origens).

## Tipo de mudança
- [ ] Nova funcionalidade / pipeline
- [ ] Correção de bug ou inconsistência de dados
- [x] Refatoração de modelo DBT
- [ ] Documentação
- [ ] Infraestrutura / CI
- [ ] Outro: ___

## Issues relacionadas
Closes #298 

## Como testar / validar

```bash
# Para modelos DBT
cd airflow_lappis/dags/dbt/mir

# valida que os testes são reconhecidos pelo grafo (offline)
dbt parse
dbt list --resource-type test --select dados_abertos_dbt

# executa os testes contra o banco
dbt test --select dados_abertos_dbt
```

## Evidências
<!-- Prints, logs, resultados de query ou link de documentação -->

`dbt parse` e `dbt list` confirmam o registro dos 16 novos testes sem erros (warnings de deprecation são pré-existentes do projeto, não introduzidos por este PR):

```
unique_deputados_id / unique_senadores_id / unique_legislaturas_id
unique_parlamentares__id_parlamentar_text_cargo_parlamentar_
not_null_* (deputados, senadores, legislaturas, parlamentares, parlamentares_historico)
relationships_deputados_historico_id__id__ref_deputados_
relationships_deputados_historico_id_legislatura__id__ref_legislaturas_
relationships_senadores_historico_parlamentar_id__id__ref_senadores_
```
