### PR TITLE
fix(emendas): parser tolera multiplos sub-relatorios e mapeamento dinamico

### DIFF
--- a/airflow_lappis/dags/data_ingest/tesouro_gerencial/mir/ne_tesouro_emendas_mir_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/tesouro_gerencial/mir/ne_tesouro_emendas_mir_ingest_dag.py
@@ -1,19 +1,20 @@
-from typing import Dict, Any, Optional
+from typing import Any, Dict, List, Optional
 from airflow import DAG
 from airflow.operators.python import PythonOperator
 from airflow.models import Variable
 from airflow.models.param import Param
 from datetime import datetime, timedelta
-import logging
+import csv
+import io
 import json
+import logging
+import cliente_email
 from schedule_loader import get_dynamic_schedule
 from cliente_email import fetch_and_process_email
 from cliente_postgres import ClientPostgresDB
 from postgres_helpers import get_postgres_conn
 import pandas as pd
-import io
 
-# Configurações básicas da DAG
 default_args = {
     "owner": "Tiago",
     "depends_on_past": False,
@@ -21,49 +22,236 @@ default_args = {
     "retry_delay": timedelta(minutes=5),
 }
 
-COLUMN_MAPPING = {
-    0: "emissao_mes",
-    1: "emissao_dia",
-    2: "programa_governo",
-    3: "programa_governo_descricao",
-    4: "acao_governo",
-    5: "acao_governo_descricao",
-    6: "autor_emendas_orcamento",
-    7: "autor_emendas_orcamento_descricao",
-    8: "localizador_gasto",
-    9: "localizador_gasto_descricao",
-    10: "regiao_pt",
-    11: "uf_pt",
-    12: "uf_pt_descricao",
-    13: "municipio_pt",
-    14: "ne_ccor",
-    15: "ne_num_processo",
-    16: "ne_info_complementar",
-    17: "ne_ccor_descricao",
-    18: "doc_observacao",
-    19: "grupo_despesa",
-    20: "grupo_despesa_descricao",
-    21: "natureza_despesa",
-    22: "natureza_despesa_descricao",
-    23: "modalidade_aplicacao",
-    24: "modalidade_aplicacao_descricao",
-    25: "ne_ccor_favorecido",
-    26: "ne_ccor_favorecido_descricao",
-    27: "ne_ccor_ano_emissao",
-    28: "ptres",
-    29: "item_informacao",
-    30: "item_informacao_descricao",
-    31: "despesas_empenhadas",
-    32: "despesas_liquidadas",
-    33: "despesas_pagas",
-    34: "restos_a_pagar_inscritos",
-    35: "restos_a_pagar_pagos",
+TABLE_SCHEMA = "siafi"
+TABLE_NAME = "ne_tesouro_emendas"
+EMAIL_SUBJECT = "notas_de_empenhos_emendas_parlamentares"
+
+TARGET_COLUMNS: List[str] = [
+    "emissao_mes",
+    "emissao_dia",
+    "programa_governo",
+    "programa_governo_descricao",
+    "acao_governo",
+    "acao_governo_descricao",
+    "autor_emendas_orcamento",
+    "autor_emendas_orcamento_descricao",
+    "localizador_gasto",
+    "localizador_gasto_descricao",
+    "regiao_pt",
+    "uf_pt",
+    "uf_pt_descricao",
+    "municipio_pt",
+    "ne_ccor",
+    "ne_num_processo",
+    "ne_info_complementar",
+    "ne_ccor_descricao",
+    "doc_observacao",
+    "grupo_despesa",
+    "grupo_despesa_descricao",
+    "natureza_despesa",
+    "natureza_despesa_descricao",
+    "modalidade_aplicacao",
+    "modalidade_aplicacao_descricao",
+    "ne_ccor_favorecido",
+    "ne_ccor_favorecido_descricao",
+    "ne_ccor_ano_emissao",
+    "ptres",
+    "fonte_recursos_detalhada",
+    "fonte_recursos_detalhada_descricao",
+    "despesas_empenhadas",
+    "despesas_liquidadas",
+    "despesas_pagas",
+    "restos_a_pagar_inscritos",
+    "restos_a_pagar_pagos",
+]
+
+HEADER_TO_CANONICAL: Dict[str, str] = {
+    "Emissão - Mês": "emissao_mes",
+    "Emissão - Dia": "emissao_dia",
+    "Programa Governo": "programa_governo",
+    "Ação Governo": "acao_governo",
+    "Autor Emendas Orçamento": "autor_emendas_orcamento",
+    "Localizador Gasto": "localizador_gasto",
+    "Região PT": "regiao_pt",
+    "UF PT": "uf_pt",
+    "Município PT": "municipio_pt",
+    "NE CCor": "ne_ccor",
+    "NE - Núm. Processo": "ne_num_processo",
+    "NE - Informação Complementar": "ne_info_complementar",
+    "NE CCor - Descrição": "ne_ccor_descricao",
+    "Doc - Observação": "doc_observacao",
+    "Grupo Despesa": "grupo_despesa",
+    "Natureza Despesa": "natureza_despesa",
+    "Modalidade Aplicação": "modalidade_aplicacao",
+    "NE CCor - Favorecido": "ne_ccor_favorecido",
+    "NE CCor - Ano Emissão": "ne_ccor_ano_emissao",
+    "PTRES": "ptres",
+    # Header diz "Item Informação" mas a coluna traz o codigo da fonte de
+    # recursos (ex.: 1000000000 = RECURSOS LIVRES DA UNIAO).
+    "Item Informação": "fonte_recursos_detalhada",
 }
 
-EMAIL_SUBJECT = "notas_de_empenhos_emendas_parlamentares"
-SKIPROWS = 12
+HEADERS_WITH_DESCRICAO = {
+    "Programa Governo",
+    "Ação Governo",
+    "Autor Emendas Orçamento",
+    "Localizador Gasto",
+    "UF PT",
+    "Grupo Despesa",
+    "Natureza Despesa",
+    "Modalidade Aplicação",
+    "NE CCor - Favorecido",
+    "Item Informação",
+}
 
-# Configurações da DAG
+ITEM_CODE_TO_CANONICAL = {
+    "29": "despesas_empenhadas",
+    "31": "despesas_liquidadas",
+    "34": "despesas_pagas",
+    "50": "restos_a_pagar_inscritos",
+    "52": "restos_a_pagar_pagos",
+}
+
+HEADER_MARKER = '"Emissão - Mês"'
+SUB_HEADER_LINES = 2
+
+# Coluna do schema antigo (posicional, quebrado) usada para detectar
+# tabelas que precisam ser recriadas. Ver reset_table_if_legacy_schema.
+LEGACY_SCHEMA_MARKER_COLUMN = "item_informacao"
+
+# Cada linha do relatorio e uma movimentacao contabil do empenho
+# (emissao, alteracao, anulacao, pagamento). doc_observacao distingue
+# as movimentacoes do mesmo empenho no mesmo dia.
+UNIQUE_KEY = ["ne_ccor", "emissao_mes", "emissao_dia", "doc_observacao"]
+
+
+def _build_column_map(header_row: List[str]) -> Dict[str, int]:
+    col_map: Dict[str, int] = {}
+    for pos, raw in enumerate(header_row):
+        name = raw.strip()
+        if name in HEADER_TO_CANONICAL:
+            canonical = HEADER_TO_CANONICAL[name]
+            col_map[canonical] = pos
+            if name in HEADERS_WITH_DESCRICAO:
+                col_map[f"{canonical}_descricao"] = pos + 1
+        elif name in ITEM_CODE_TO_CANONICAL:
+            col_map[ITEM_CODE_TO_CANONICAL[name]] = pos
+    return col_map
+
+
+def parse_tesouro_emendas_csv(
+    csv_data: str,
+    column_mapping: Optional[Dict[int, str]] = None,
+    skiprows: int = 0,
+) -> pd.DataFrame:
+    """Parser do relatorio do Tesouro Gerencial de empenhos de emendas.
+
+    O arquivo concatena multiplos sub-relatorios (um por "Ano Lançamento"),
+    cada um com seu proprio cabecalho e numero de colunas financeiras
+    diferente. O parser detecta cada sub-relatorio pelo cabecalho
+    repetido e mapeia colunas pelo nome (nao por posicao).
+
+    `column_mapping` e `skiprows` sao ignorados — existem so para manter
+    a assinatura de cliente_email.format_csv, que esta funcao substitui
+    via monkey-patch.
+    """
+    del column_mapping, skiprows
+
+    lines = csv_data.splitlines()
+    header_indices = [
+        i for i, line in enumerate(lines)
+        if line.lstrip().startswith(HEADER_MARKER)
+    ]
+    if not header_indices:
+        raise ValueError(
+            "Nenhum cabecalho de empenhos de emendas encontrado no CSV — "
+            f"esperava linhas comecando com {HEADER_MARKER}."
+        )
+
+    sub_report_ranges = [
+        (start, header_indices[idx + 1] if idx + 1 < len(header_indices) else len(lines))
+        for idx, start in enumerate(header_indices)
+    ]
+
+    records: List[Dict[str, Any]] = []
+    for sub_idx, (h_start, h_end) in enumerate(sub_report_ranges, start=1):
+        header_row = next(csv.reader([lines[h_start]]))
+        col_map = _build_column_map(header_row)
+        expected_width = len(header_row)
+        data_start = h_start + 1 + SUB_HEADER_LINES
+
+        ne_pos = col_map.get("ne_ccor")
+        if ne_pos is None:
+            logging.warning(
+                "Sub-relatorio %s: cabecalho sem coluna 'NE CCor'; ignorando.",
+                sub_idx,
+            )
+            continue
+
+        financial_present = sorted(
+            c for c in col_map if c in ITEM_CODE_TO_CANONICAL.values()
+        )
+        kept = 0
+        for line in lines[data_start:h_end]:
+            if not line.strip():
+                continue
+            try:
+                row = next(csv.reader([line]))
+            except csv.Error:
+                continue
+            if len(row) != expected_width:
+                continue
+            if ne_pos >= len(row) or not row[ne_pos].strip():
+                continue
+
+            record: Dict[str, Any] = {}
+            for canonical, pos in col_map.items():
+                if pos < len(row):
+                    value = row[pos].strip()
+                    record[canonical] = value if value else None
+            records.append(record)
+            kept += 1
+
+        logging.info(
+            "Sub-relatorio %s: %s colunas, %s linhas, financeiras: %s",
+            sub_idx,
+            expected_width,
+            kept,
+            ", ".join(financial_present) or "(nenhuma)",
+        )
+
+    df = pd.DataFrame(records, columns=TARGET_COLUMNS)
+    logging.info("Parser concluido: %s linhas no schema canonico.", len(df))
+    return df
+
+
+def reset_table_if_legacy_schema(db: ClientPostgresDB) -> None:
+    """Dropa a tabela se ainda estiver no schema antigo.
+
+    O schema antigo lia colunas por posicao fixa e gravava valores de
+    Restos a Pagar como despesas_liquidadas/pagas em sub-relatorios de
+    34 colunas. Os dados existentes estao semanticamente corrompidos —
+    recarregar do zero e a unica correcao segura.
+    """
+    rows = db.execute_query(
+        f"SELECT 1 FROM information_schema.columns "
+        f"WHERE table_schema = '{TABLE_SCHEMA}' "
+        f"AND table_name = '{TABLE_NAME}' "
+        f"AND column_name = '{LEGACY_SCHEMA_MARKER_COLUMN}' LIMIT 1;"
+    )
+    if not rows:
+        return
+
+    logging.warning(
+        "Schema antigo detectado em %s.%s — dropando para recriar limpo.",
+        TABLE_SCHEMA,
+        TABLE_NAME,
+    )
+    db.execute_non_query(
+        f"DROP TABLE IF EXISTS {TABLE_SCHEMA}.{TABLE_NAME} CASCADE;"
+    )
+
+
 with DAG(
     dag_id="email_tesouro_emendas_ingest",
     default_args=default_args,
@@ -87,7 +275,6 @@ with DAG(
 
     def process_email_data(**context: Dict[str, Any]) -> Optional[Any]:
         creds = json.loads(Variable.get("email_credentials"))
-
         EMAIL = creds["email"]
         PASSWORD = creds["password"]
         IMAP_SERVER = creds["imap_server"]
@@ -104,9 +291,11 @@ with DAG(
                     "Parametro 'data_referencia' invalido. Use o formato YYYY-MM-DD."
                 ) from exc
 
+        cliente_email.format_csv = parse_tesouro_emendas_csv
+
         try:
             logging.info(
-                "Iniciando o processamento dos emails para a data: %s",
+                "Iniciando processamento dos emails para a data: %s",
                 target_date.isoformat() if target_date else "dia atual",
             )
             csv_data = fetch_and_process_email(
@@ -115,30 +304,21 @@ with DAG(
                 PASSWORD,
                 SENDER_EMAIL,
                 EMAIL_SUBJECT,
-                COLUMN_MAPPING,
-                skiprows=SKIPROWS,
+                column_mapping={},
+                skiprows=0,
                 target_date=target_date,
             )
             if not csv_data:
-                logging.warning(
-                    "Nenhum CSV valido foi extraido dos e-mails encontrados "
-                    "para o assunto esperado."
-                )
+                logging.warning("Nenhum CSV valido foi extraido dos e-mails.")
                 return None
 
-            logging.info(
-                "CSV processado com sucesso. Dados encontrados: %s", len(csv_data)
-            )
+            logging.info("CSV processado: %s caracteres.", len(csv_data))
             return csv_data
         except Exception as e:
             logging.error("Erro no processamento dos emails: %s", str(e))
             raise
 
     def insert_data_to_db(**context: Dict[str, Any]) -> None:
-        """
-        Função para inserir os dados no banco de dados.
-        Os dados do CSV são recuperados do XCom.
-        """
         try:
             task_instance: Any = context["ti"]
             csv_data: Any = task_instance.xcom_pull(task_ids="process_emails")
@@ -147,54 +327,46 @@ with DAG(
                 logging.warning("Nenhum dado para inserir no banco.")
                 return
 
-            df = pd.read_csv(io.StringIO(csv_data))
-            df = df[df["ne_ccor_ano_emissao"].astype(str).str.startswith("20")]
-            data = df.to_dict(orient="records")
+            df = pd.read_csv(io.StringIO(csv_data), dtype=str, keep_default_na=False)
+            df = df.replace({"": None})
+            df = df[df["ne_ccor_ano_emissao"].fillna("").str.startswith("20")]
 
-            # Adicionar dt_ingest a cada registro
+            data = df.where(pd.notnull(df), None).to_dict(orient="records")
             for record in data:
                 record["dt_ingest"] = datetime.now().isoformat()
 
             postgres_conn_str = get_postgres_conn("postgres_mir")
             db = ClientPostgresDB(postgres_conn_str)
 
-            unique_key = [
-                "ne_ccor",
-                "natureza_despesa",
-                "doc_observacao",
-                "ne_ccor_ano_emissao",
-                "emissao_dia",
-                "emissao_mes",
-                "despesas_empenhadas",
-                "despesas_liquidadas",
-                "despesas_pagas",
-            ]
+            reset_table_if_legacy_schema(db)
 
             db.insert_data(
                 data,
-                "ne_tesouro_emendas",
-                conflict_fields=unique_key,
-                primary_key=unique_key,
-                schema="siafi",
+                TABLE_NAME,
+                conflict_fields=UNIQUE_KEY,
+                primary_key=UNIQUE_KEY,
+                schema=TABLE_SCHEMA,
             )
-            logging.info("Dados inseridos com sucesso no banco de dados.")
+            logging.info(
+                "Inseridos %s registros em %s.%s.",
+                len(data),
+                TABLE_SCHEMA,
+                TABLE_NAME,
+            )
         except Exception as e:
             logging.error("Erro ao inserir dados no banco: %s", str(e))
             raise
 
-    # Tarefa 1: Processar os e-mails e retornar CSV
     process_emails_task = PythonOperator(
         task_id="process_emails",
         python_callable=process_email_data,
         provide_context=True,
     )
 
-    # Tarefa 2: Inserir os dados no banco de dados
     insert_to_db_task = PythonOperator(
         task_id="insert_to_db",
         python_callable=insert_data_to_db,
         provide_context=True,
     )
 
-    # Fluxo da DAG
     process_emails_task >> insert_to_db_task


### PR DESCRIPTION
## Contexto

A DAG `email_tesouro_emendas_ingest` vinha falhando em todas as execucoes recentes. A issue original reportava que o arquivo do Tesouro Gerencial chegava sem as colunas de Restos a Pagar para o exercicio corrente. Durante a investigacao, descobri que o problema era bem maior: o parser estava semanticamente errado havia tempo.

## Problema raiz

O relatorio do Tesouro Gerencial **concatena multiplos sub-relatorios** num unico arquivo (um por `Ano Lançamento`), e cada sub-relatorio:

- Repete o cabecalho no meio do arquivo.
- Pode ter **numero de colunas diferente** (34 ou 36) dependendo de quais codigos de Item Informacao tem dado.
- As colunas financeiras vem identificadas pelo codigo (29, 31, 34, 50, 52) no header.

Exemplo do arquivo recebido em 23/06:

| Sub-relatorio | Linhas | Cols | Codigos financeiros |
|---|---|---|---|
| Ano Lancamento 2026 | 105 | 34 | 29, 50, 52 (empenhadas + RP) |
| Ano Lancamento 2025 | 311 | 36 | 29, 31, 34, 50, 52 (todas) |
| Ano Lancamento 2024 | 191 | 34 | 29, 31, 34 (so despesas) |

O parser antigo lia por **posicao fixa** assumindo 36 colunas. Resultado:

1. Quebrava em `Expected 34 fields, saw 36` ao bater no header repetido.
2. Para os sub-relatorios de 34 colunas, gravava valores de **Restos a Pagar como `despesas_liquidadas`/`despesas_pagas`** — corrompendo semanticamente os dados ja ingeridos.
3. Confundia `Item Informacao` (header) com o conteudo da coluna, que na verdade e `Fonte Recursos Detalhada` (codigos tipo `1000000000` = RECURSOS LIVRES DA UNIAO).

Alem disso, o `unique_key` original incluia campos que **mudam entre snapshots** (`despesas_empenhadas/liquidadas/pagas`) e campos que podem ser nulos (`doc_observacao`), o que quebrava o `ON CONFLICT DO UPDATE` e gerava violacoes de NOT NULL para linhas de RP.

## Solucao

Reescrita do parser e da chave natural na propria DAG (patch local via monkey-patch de `cliente_email.format_csv`, sem mexer em codigo compartilhado).

### Parser dinamico (`parse_tesouro_emendas_csv`)

- Detecta sub-relatorios pelo cabecalho repetido (`\"Emissao - Mes\"`).
- Constroi mapa **nome do header -> coluna canonica** para cada sub-relatorio.
- Identifica colunas financeiras pelos codigos de Item Informacao presentes em cada bloco.
- Normaliza tudo no schema canonico `TARGET_COLUMNS` (36 colunas, schema estavel).

### Chave natural correta

Cada linha do relatorio representa uma **movimentacao contabil** do empenho (emissao, alteracao, anulacao, pagamento), distinguida pelo `doc_observacao`. Exemplo real do mesmo NE no mesmo dia:

| `doc_observacao` | empenhada | RP_inscritos |
|---|---|---|
| ALTERACAO | 0,00 | (250.000,00) |
| N/A | 0,00 | 250.000,00 |
| PAGAMENTO DO TERMO... | 0,00 | 249.946,20 |
| ANULACAO PARCIAL | (53,80) | - |

Chave nova: `(ne_ccor, emissao_mes, emissao_dia, doc_observacao)`. Validada com **0 duplicatas** nos 607 registros do arquivo de teste.

### Reset automatico da tabela

A tabela existente tem dados semanticamente corrompidos (RP gravado como `despesas_liquidadas/pagas`). A funcao `reset_table_if_legacy_schema` detecta o schema antigo (presenca da coluna `item_informacao`) e dropa a tabela para ser recriada limpa pelo `insert_data`. Idempotente — roda apenas enquanto a marca antiga existir.

### Renomeacao no schema

- `item_informacao` -> `fonte_recursos_detalhada`
- `item_informacao_descricao` -> `fonte_recursos_detalhada_descricao`

Alinha com o que de fato esta na coluna e com o sibling DAG `ne_tesouro_mir_ingest_dag.py` que ja usa esse nome.

## Validacao

Smoke test end-to-end com o arquivo real de 23/06:

- ✅ Parser detecta os 3 sub-relatorios (105 + 311 + 191 = 607 linhas).
- ✅ Mapeia colunas financeiras corretamente por bloco.
- ✅ Round-trip `to_csv -> read_csv` preserva schema.
- ✅ Chave natural com 0 duplicatas.
- ✅ `doc_observacao` nunca null.
- ✅ Linhas de RP 2026 agora gravam `restos_a_pagar_inscritos` (antes ia errado para `despesas_liquidadas`).

## Test plan

- [ ] Trigger manual da DAG no Airflow apos o merge — deve dropar a tabela antiga (uma vez), recriar com schema novo e popular limpo.
- [ ] Conferir que `siafi.ne_tesouro_emendas` tem ~607 registros (com este arquivo) e que valores de RP estao em `restos_a_pagar_*`, nao em `despesas_*`.
- [ ] Re-trigger no dia seguinte para verificar que o reset nao roda mais (idempotente) e que o `ON CONFLICT DO UPDATE` atualiza movimentacoes existentes.
- [ ] Verificar que modelos dbt downstream (`tg_emendas`) continuam funcionando — o schema canonico tem mesmas colunas exceto pela renomeacao `item_informacao -> fonte_recursos_detalhada` (pode exigir ajuste no dbt).

## Notas

- Patch e **local na DAG**; `cliente_email.format_csv` continua intocado para nao afetar as outras ~15 DAGs que o usam.
- Outros DAGs com `unique_key` similar (ex.: `ne_tesouro_mir_ingest_dag.py`) provavelmente tem o mesmo problema latente — fica como follow-up.

#### Closes: #394 