### PR TITLE
fix(github): ajusta roteamento de revisores por dominio

### DIFF
--- a/.github/MERGE_REQUEST_PROTOCOL.md
+++ b/.github/MERGE_REQUEST_PROTOCOL.md
@@ -206,7 +206,7 @@ Mapa atual dos principais caminhos de DAGs e modelos:
 | --- | --- |
 | `airflow_lappis/dags/dashboards/` | IPEA |
 | `airflow_lappis/dags/dbt/ipea/` | IPEA |
-| `airflow_lappis/dags/data_ingest/compras_gov/` | IPEA |
+| `airflow_lappis/dags/data_ingest/compras_gov/` | IPEA, exceto subpasta `mir/` |
 | `airflow_lappis/dags/data_ingest/ipea_pro/` | IPEA |
 | `airflow_lappis/dags/data_ingest/pncp/` | IPEA |
 | `airflow_lappis/dags/data_ingest/sgac/` | IPEA |
@@ -217,6 +217,7 @@ Mapa atual dos principais caminhos de DAGs e modelos:
 | `airflow_lappis/dags/data_ingest/tesouro_gerencial/` | IPEA, exceto subpastas `mir/` e `mcid/` |
 | `airflow_lappis/dags/data_ingest/transfere_gov/` | IPEA, exceto subpasta `mir/` |
 | `airflow_lappis/dags/dbt/mir/` | MIR |
+| `airflow_lappis/dags/data_ingest/compras_gov/mir/` | MIR |
 | `airflow_lappis/dags/data_ingest/dados_abertos/` | MIR |
 | `airflow_lappis/dags/data_ingest/siconv/` | MIR |
 | `airflow_lappis/dags/data_ingest/tesouro_gerencial/mir/` | MIR |

--- a/.github/workflows/request-team-review.yaml
+++ b/.github/workflows/request-team-review.yaml
@@ -76,6 +76,7 @@ jobs:
                   "airflow_lappis/dags/data_ingest/transfere_gov/",
                 ],
                 excludePaths: [
+                  "airflow_lappis/dags/data_ingest/compras_gov/mir/",
                   "airflow_lappis/dags/data_ingest/tesouro_gerencial/mcid/",
                   "airflow_lappis/dags/data_ingest/tesouro_gerencial/mir/",
                   "airflow_lappis/dags/data_ingest/transfere_gov/mir/",
@@ -85,6 +86,7 @@ jobs:
                 label: "team:mir",
                 paths: [
                   "airflow_lappis/dags/dbt/mir/",
+                  "airflow_lappis/dags/data_ingest/compras_gov/mir/",
                   "airflow_lappis/dags/data_ingest/dados_abertos/",
                   "airflow_lappis/dags/data_ingest/siconv/",
                   "airflow_lappis/dags/data_ingest/tesouro_gerencial/mir/",


### PR DESCRIPTION
## Descrição

Corrige o roteamento automático de revisão para arquivos em `airflow_lappis/dags/data_ingest/compras_gov/mir/`.

Esse caminho pertence ao domínio MIR, mas podia ser classificado também como IPEA por causa da regra genérica de `compras_gov/`.

> Antes de abrir este PR, consulte o [Protocolo de Aprovação de Pull Requests](https://github.com/GovHub-br/data-application-gov-hub/blob/main/.github/MERGE_REQUEST_PROTOCOL.md).

## Tipo de mudança
- [ ] Nova funcionalidade / pipeline
- [x] Correção de bug ou inconsistência de dados
- [ ] Refatoração de modelo DBT
- [x] Documentação
- [x] Infraestrutura / CI
- [ ] Outro: ___

## Issues relacionadas
Closes #410

## Domínio de revisão

- [ ] GCES / OSS
- [ ] IPEA
- [ ] MIR
- [ ] MCid
- [ ] MinC
- [x] OSS
- [ ] Múltiplos domínios: ___

## Como testar / validar

- Conferido que `airflow_lappis/dags/data_ingest/compras_gov/mir/` passa a gerar `team:mir`.
- Conferido que `airflow_lappis/dags/data_ingest/compras_gov/mir/` não gera mais `team:ipea`.
- Executado `git diff --check`.
- Validada a sintaxe do script embutido no workflow com Node.
- Após o merge na `main`, validar em PR real que o workflow `Request team review` solicita apenas o time esperado.

## Evidências

Validação local confirmou que o caminho `airflow_lappis/dags/data_ingest/compras_gov/mir/contratos_mir_ingest_dag.py` infere apenas `team:mir`.

## Checklist
- [x] Título do PR segue Conventional Commits
- [x] Issue relacionada foi referenciada
- [x] Testes/lint foram executados ou a ausência foi justificada
- [ ] Testes DBT adicionados/atualizados, se aplicável
- [x] Documentação atualizada, se aplicável
- [x] Sem dados sensíveis ou credenciais no código
- [x] Branch atualizada com `upstream/main` ou `origin/main`
- [x] Revisores automáticos por domínio foram solicitados pelo GitHub ou justificados no PR