### PR TITLE
feat: adicao de campos extras aos dbts do sgac

### DIFF
--- a/airflow_lappis/dags/dbt/ipea/models/sistema_sisbolsas/gold/schema.yml
+++ b/airflow_lappis/dags/dbt/ipea/models/sistema_sisbolsas/gold/schema.yml
@@ -27,6 +27,8 @@ models:
         description: Valor de recursos externos conforme campo orçamentário do SGAC.
       - name: recursos_ipea
         description: Valor de recursos IPEA conforme campo não orçamentário do SGAC.
+      - name: recursos_totais
+        description: Soma de recursos externos e recursos IPEA com nulos tratados como zero.
       - name: numero_do_processo
         description: Número do processo SEI associado.
       - name: coordenador
@@ -35,6 +37,20 @@ models:
         description: Fiscal e substituto com marcações HTML básicas removidas.
       - name: situacao
         description: Situação do instrumento no SGAC.
+      - name: dias_para_vencer
+        description: Quantidade de dias entre a data de conclusão e a data atual.
+      - name: mes_conclusao
+        description: Primeiro dia do mês de conclusão do instrumento.
+      - name: ano_conclusao
+        description: Ano da data de conclusão do instrumento.
+      - name: faixa_vencimento
+        description: Classificação da proximidade do vencimento em faixas de dias.
+      - name: status_vigencia
+        description: Situação de vigência do instrumento na data corrente.
+      - name: status_fiscal
+        description: Indica se há fiscal informado no registro.
+      - name: status_coordenador
+        description: Indica se há coordenador informado no registro.
 
   - name: sgac_relatorio_teds_vigentes
     description: >
@@ -63,6 +79,8 @@ models:
         description: Valor de recursos externos conforme campo orçamentário do SGAC.
       - name: recursos_ipea
         description: Valor de recursos IPEA conforme campo não orçamentário do SGAC.
+      - name: recursos_totais_sgac
+        description: Soma de recursos externos e recursos IPEA registrados no SGAC.
       - name: numero_siafi
         description: Número SIAFI registrado no SGAC.
       - name: termos_aditivos
@@ -73,13 +91,109 @@ models:
         description: Campo presente na planilha de referência; não existe no SGAC.
       - name: planejamento_diarias_passagens
         description: Campo presente na planilha de referência; não existe no SGAC.
+      - name: plano_acao
+        description: Plano de ação do TransfereGov associado ao número SIAFI, quando houver cruzamento.
+      - name: num_transf
+        description: Número de transferência usado no cruzamento com o número SIAFI do SGAC.
+      - name: sq_instrumento
+        description: Sequencial do instrumento no TransfereGov, mantido como atributo informativo.
+      - name: sigla_unidade_descentralizada
+        description: Sigla da unidade descentralizada no TransfereGov.
+      - name: unidade_descentralizada
+        description: Nome da unidade descentralizada no TransfereGov.
+      - name: sigla_unidade_descentralizadora
+        description: Sigla da unidade descentralizadora repassadora vinculada ao programa do Plano de Ação.
+      - name: sigla_unidade_responsavel_acompanhamento
+        description: Sigla da unidade responsável pelo acompanhamento do programa no TransfereGov.
+      - name: programa
+        description: Identificador do programa vinculado ao Plano de Ação no TransfereGov.
+      - name: nome_institucional_programa
+        description: Nome institucional do programa vinculado ao Plano de Ação no TransfereGov.
+      - name: percentual_vigencia
+        description: Percentual de vigência do plano de ação calculado a partir das datas de início e fim no TransfereGov.
+      - name: dt_inicio_vigencia_transferegov
+        description: Data de início da vigência no TransfereGov.
+      - name: dt_fim_vigencia_transferegov
+        description: Data de fim da vigência no TransfereGov.
+      - name: situacao_plano_acao
+        description: Situação do plano de ação no TransfereGov.
+      - name: vl_total_plano_acao
+        description: Valor total do plano de ação no TransfereGov.
+      - name: valor_firmado
+        description: Valor firmado do TED conforme TransfereGov/SIAFI.
+      - name: numeros_empenho
+        description: Lista agregada dos números de nota de empenho associados ao TED.
+      - name: quantidade_empenhos
+        description: Quantidade distinta de notas de empenho associadas ao TED.
+      - name: numeros_nc
+        description: Lista agregada dos números de nota de crédito associados ao TED.
+      - name: quantidade_ncs
+        description: Quantidade distinta de notas de crédito associadas ao TED.
+      - name: orcamento_recebido
+        description: Valor de orçamento recebido por nota de crédito.
+      - name: orcamento_devolvido
+        description: Valor de orçamento devolvido por nota de crédito.
+      - name: orcamento_liquido
+        description: Diferença entre orçamento recebido e orçamento devolvido.
+      - name: empenhado
+        description: Valor total empenhado.
+      - name: empenho_anulado
+        description: Valor total de empenhos anulados.
+      - name: empenhado_liquido
+        description: Diferença entre empenhado e empenho anulado.
+      - name: despesas_liquidada
+        description: Valor total de despesas liquidadas.
       - name: pago
         description: Valor pago derivado do cruzamento por número SIAFI, quando houver.
+      - name: despesas_pagas_exercicio
+        description: Valor de despesas pagas no exercício.
+      - name: despesas_pagas_rap
+        description: Valor de despesas pagas em restos a pagar.
+      - name: restos_a_pagar
+        description: Valor inscrito em restos a pagar.
+      - name: financeiro_recebido
+        description: Valor financeiro recebido via programação financeira.
+      - name: financeiro_devolvido
+        description: Valor financeiro devolvido.
+      - name: financeiro_cancelado
+        description: Valor financeiro cancelado.
+      - name: financeiro_liquido
+        description: Financeiro recebido menos devoluções e cancelamentos.
       - name: pendente_de_pagamento
         description: Diferença entre valor firmado/total e valor pago no cruzamento por número SIAFI, quando houver.
+      - name: valor_referencia_ted
+        description: Valor usado como referência para percentuais, priorizando valor firmado e usando recursos totais do SGAC como fallback.
+      - name: diferenca_valor_sgac_siafi
+        description: Diferença entre recursos totais do SGAC e valor firmado no SIAFI/TransfereGov.
       - name: situacao
         description: Situação do instrumento no SGAC.
       - name: sgac_id
         description: Identificador do item no SGAC.
       - name: eh_ted
         description: Indica se o instrumento foi classificado como TED ou dispensa de TED.
+      - name: dias_para_conclusao
+        description: Quantidade de dias entre a data de conclusão e a data atual.
+      - name: mes_conclusao
+        description: Primeiro dia do mês de conclusão do TED.
+      - name: ano_conclusao
+        description: Ano da data de conclusão do TED.
+      - name: faixa_vencimento
+        description: Classificação da proximidade do vencimento em faixas de dias.
+      - name: status_vigencia
+        description: Situação de vigência do TED na data corrente.
+      - name: status_numero_siafi
+        description: Indica se o TED possui número SIAFI informado no SGAC.
+      - name: status_cruzamento_siafi
+        description: Indica se o TED teve cruzamento com SIAFI/TransfereGov.
+      - name: status_financeiro
+        description: Classificação gerencial da execução financeira do TED.
+      - name: status_termo_aditivo
+        description: Indica se há termo aditivo informado no SGAC.
+      - name: status_entidade_externa
+        description: Indica se há entidade externa informada no SGAC.
+      - name: percentual_execucao_financeira
+        description: Percentual pago sobre o valor de referência do TED.
+      - name: percentual_empenhado
+        description: Percentual empenhado líquido sobre o valor firmado.
+      - name: percentual_financeiro_recebido
+        description: Percentual financeiro recebido sobre o valor firmado.

--- a/airflow_lappis/dags/dbt/ipea/models/sistema_sisbolsas/gold/sgac_relatorio_teds_vigentes.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/sistema_sisbolsas/gold/sgac_relatorio_teds_vigentes.sql
@@ -12,14 +12,8 @@ with
     ),
 
     teds_siafi as (
-        select
-            sgac_id,
-            sum(coalesce(despesas_pagas_exercicio, 0))
-                as despesas_pagas_exercicio,
-            sum(coalesce(despesas_pagas_rap, 0)) as despesas_pagas_rap,
-            max(valor_firmado) as valor_firmado
+        select *
         from {{ ref("sgac_teds_siafi") }}
-        group by sgac_id
     ),
 
     relatorio as (
@@ -32,16 +26,63 @@ with
             p.numero_do_proc as numero_do_processo,
             p.recursos_orcamentarios as recursos_externos,
             p.recursos_nao_orcamentarios as recursos_ipea,
+            coalesce(p.recursos_orcamentarios, 0)
+            + coalesce(p.recursos_nao_orcamentarios, 0) as recursos_totais_sgac,
             p.numero_siafi,
             p.termos_aditivos,
             null::text as apostilamentos,
             null::text as prorrogacao_oficio,
             null::text as planejamento_diarias_passagens,
+            s.plano_acao,
+            s.num_transf,
+            s.sq_instrumento,
+            s.sigla_unidade_descentralizada,
+            s.unidade_descentralizada,
+            s.sigla_unidade_descentralizadora,
+            s.sigla_unidade_responsavel_acompanhamento,
+            s.programa,
+            s.nome_institucional_programa,
+            s.percentual_vigencia,
+            s.dt_inicio_vigencia as dt_inicio_vigencia_transferegov,
+            s.dt_fim_vigencia as dt_fim_vigencia_transferegov,
+            s.tx_situacao_plano_acao as situacao_plano_acao,
+            s.vl_total_plano_acao,
+            s.valor_firmado,
+            s.numeros_empenho,
+            s.quantidade_empenhos,
+            s.numeros_nc,
+            s.quantidade_ncs,
+            s.orcamento_recebido,
+            s.orcamento_devolvido,
+            case
+                when s.sgac_id is not null
+                then coalesce(s.orcamento_recebido, 0)
+                    - coalesce(s.orcamento_devolvido, 0)
+            end as orcamento_liquido,
+            s.empenhado,
+            s.empenho_anulado,
+            case
+                when s.sgac_id is not null
+                then coalesce(s.empenhado, 0) - coalesce(s.empenho_anulado, 0)
+            end as empenhado_liquido,
+            s.despesas_liquidada,
             case
                 when s.sgac_id is not null
                 then coalesce(s.despesas_pagas_exercicio, 0)
                     + coalesce(s.despesas_pagas_rap, 0)
             end as pago,
+            s.despesas_pagas_exercicio,
+            s.despesas_pagas_rap,
+            s.restos_a_pagar,
+            s.financeiro_recebido,
+            s.financeiro_devolvido,
+            s.financeiro_cancelado,
+            case
+                when s.sgac_id is not null
+                then coalesce(s.financeiro_recebido, 0)
+                    - coalesce(s.financeiro_devolvido, 0)
+                    - coalesce(s.financeiro_cancelado, 0)
+            end as financeiro_liquido,
             case
                 when s.sgac_id is not null
                 then greatest(
@@ -53,13 +94,120 @@ with
                     0
                 )
             end as pendente_de_pagamento,
+            coalesce(
+                s.valor_firmado,
+                coalesce(p.recursos_orcamentarios, 0)
+                + coalesce(p.recursos_nao_orcamentarios, 0)
+            ) as valor_referencia_ted,
+            case
+                when s.valor_firmado is not null
+                then (
+                    coalesce(p.recursos_orcamentarios, 0)
+                    + coalesce(p.recursos_nao_orcamentarios, 0)
+                ) - s.valor_firmado
+            end as diferenca_valor_sgac_siafi,
             p.status as situacao,
             p.id as sgac_id,
             (
                 p.instrumento ilike '%TED%'
                 or p.instrumento ilike '%execução descentralizada%'
                 or p.instrumento ilike '%Dispensa de TED%'
-            ) as eh_ted
+            ) as eh_ted,
+            p.data_vencimento - current_date as dias_para_conclusao,
+            date_trunc('month', p.data_vencimento)::date as mes_conclusao,
+            extract(year from p.data_vencimento) as ano_conclusao,
+            case
+                when p.data_vencimento is null then 'Sem data de conclusão'
+                when p.data_vencimento < current_date then 'Vencido'
+                when p.data_vencimento <= current_date + interval '30 days'
+                then 'Vence em até 30 dias'
+                when p.data_vencimento <= current_date + interval '60 days'
+                then 'Vence entre 31 e 60 dias'
+                when p.data_vencimento <= current_date + interval '90 days'
+                then 'Vence entre 61 e 90 dias'
+                else 'Acima de 90 dias'
+            end as faixa_vencimento,
+            case
+                when p.data_inicio <= current_date
+                    and p.data_vencimento >= current_date
+                then 'Vigente'
+                when p.data_vencimento < current_date then 'Encerrado/Vencido'
+                when p.data_inicio > current_date then 'Ainda não iniciado'
+                else 'Indefinido'
+            end as status_vigencia,
+            case
+                when nullif(trim(coalesce(p.numero_siafi, '')), '') is null
+                then 'Sem número SIAFI no SGAC'
+                else 'Com número SIAFI no SGAC'
+            end as status_numero_siafi,
+            case
+                when s.sgac_id is not null then 'Com cruzamento SIAFI/TransfereGov'
+                else 'Sem cruzamento SIAFI/TransfereGov'
+            end as status_cruzamento_siafi,
+            case
+                when s.sgac_id is null then 'Sem dados SIAFI'
+                when coalesce(s.despesas_pagas_exercicio, 0)
+                    + coalesce(s.despesas_pagas_rap, 0) = 0
+                then 'Sem pagamento registrado'
+                when coalesce(s.despesas_pagas_exercicio, 0)
+                    + coalesce(s.despesas_pagas_rap, 0)
+                    >= coalesce(
+                        s.valor_firmado,
+                        coalesce(p.recursos_orcamentarios, 0)
+                        + coalesce(p.recursos_nao_orcamentarios, 0)
+                    )
+                then 'Pagamento total ou acima do valor de referência'
+                else 'Pagamento parcial'
+            end as status_financeiro,
+            case
+                when nullif(trim(coalesce(p.termos_aditivos, '')), '') is null
+                then 'Sem termo aditivo informado'
+                else 'Com termo aditivo informado'
+            end as status_termo_aditivo,
+            case
+                when nullif(trim(coalesce(p.entidades_externas, '')), '') is null
+                then 'Sem entidade externa informada'
+                else 'Com entidade externa informada'
+            end as status_entidade_externa,
+            case
+                when coalesce(
+                    s.valor_firmado,
+                    coalesce(p.recursos_orcamentarios, 0)
+                    + coalesce(p.recursos_nao_orcamentarios, 0)
+                ) > 0
+                then round(
+                    (
+                        coalesce(s.despesas_pagas_exercicio, 0)
+                        + coalesce(s.despesas_pagas_rap, 0)
+                    )
+                    / nullif(
+                        coalesce(
+                            s.valor_firmado,
+                            coalesce(p.recursos_orcamentarios, 0)
+                            + coalesce(p.recursos_nao_orcamentarios, 0)
+                        ),
+                        0
+                    ) * 100,
+                    2
+                )
+            end as percentual_execucao_financeira,
+            case
+                when s.valor_firmado is not null and s.valor_firmado > 0
+                then round(
+                    (
+                        coalesce(s.empenhado, 0) - coalesce(s.empenho_anulado, 0)
+                    ) / nullif(s.valor_firmado, 0) * 100,
+                    2
+                )
+            end as percentual_empenhado,
+            case
+                when s.valor_firmado is not null and s.valor_firmado > 0
+                then round(
+                    coalesce(s.financeiro_recebido, 0)
+                    / nullif(s.valor_firmado, 0) * 100,
+                    2
+                )
+            end as percentual_financeiro_recebido
         from projetos as p
         left join teds_siafi as s
             on s.sgac_id = p.id

--- a/airflow_lappis/dags/dbt/ipea/models/sistema_sisbolsas/gold/sgac_relatorio_termino_vigencia_2025.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/sistema_sisbolsas/gold/sgac_relatorio_termino_vigencia_2025.sql
@@ -1,34 +1,80 @@
+with base as (
+    select
+        diretoria_responsavel as diretoria,
+        instrumento,
+        objeto,
+        entidades_externas,
+        data_inicio as inicio,
+        data_vencimento as conclusao,
+        recursos_orcamentarios as recursos_externos,
+        recursos_nao_orcamentarios as recursos_ipea,
+        numero_do_proc as numero_do_processo,
+        coordenador,
+        nullif(
+            trim(
+                regexp_replace(
+                    regexp_replace(
+                        replace(
+                            replace(fiscal_e_substituto, '&nbsp;', ' '),
+                            '&#58;',
+                            ':'
+                        ),
+                        '<[^>]*>',
+                        ' ',
+                        'g'
+                    ),
+                    '\s+',
+                    ' ',
+                    'g'
+                )
+            ),
+            ''
+        ) as fiscal_e_substituto,
+        status as situacao
+    from {{ ref("sgac_projetos_sgac") }}
+)
+
 select
-    diretoria_responsavel as diretoria,
+    diretoria,
     instrumento,
     objeto,
     entidades_externas,
-    data_inicio as inicio,
-    data_vencimento as conclusao,
-    recursos_orcamentarios as recursos_externos,
-    recursos_nao_orcamentarios as recursos_ipea,
-    numero_do_proc as numero_do_processo,
+    inicio,
+    conclusao,
+    recursos_externos,
+    recursos_ipea,
+    coalesce(recursos_externos, 0) + coalesce(recursos_ipea, 0) as recursos_totais,
+    numero_do_processo,
     coordenador,
-    nullif(
-        trim(
-            regexp_replace(
-                regexp_replace(
-                    replace(
-                        replace(fiscal_e_substituto, '&nbsp;', ' '),
-                        '&#58;',
-                        ':'
-                    ),
-                    '<[^>]*>',
-                    ' ',
-                    'g'
-                ),
-                '\s+',
-                ' ',
-                'g'
-            )
-        ),
-        ''
-    ) as fiscal_e_substituto,
-    status as situacao
-from {{ ref("sgac_projetos_sgac") }}
+    fiscal_e_substituto,
+    situacao,
+    conclusao - current_date as dias_para_vencer,
+    date_trunc('month', conclusao)::date as mes_conclusao,
+    extract(year from conclusao) as ano_conclusao,
+    case
+        when conclusao is null then 'Sem data de conclusão'
+        when conclusao < current_date then 'Vencido'
+        when conclusao <= current_date + interval '30 days'
+        then 'Vence em até 30 dias'
+        when conclusao <= current_date + interval '60 days'
+        then 'Vence entre 31 e 60 dias'
+        when conclusao <= current_date + interval '90 days'
+        then 'Vence entre 61 e 90 dias'
+        else 'Acima de 90 dias'
+    end as faixa_vencimento,
+    case
+        when inicio <= current_date and conclusao >= current_date then 'Vigente'
+        when conclusao < current_date then 'Encerrado/Vencido'
+        when inicio > current_date then 'Ainda não iniciado'
+        else 'Indefinido'
+    end as status_vigencia,
+    case
+        when fiscal_e_substituto is null then 'Sem fiscal informado'
+        else 'Com fiscal informado'
+    end as status_fiscal,
+    case
+        when coordenador is null then 'Sem coordenador informado'
+        else 'Com coordenador informado'
+    end as status_coordenador
+from base
 order by conclusao, diretoria, instrumento, entidades_externas

--- a/airflow_lappis/dags/dbt/ipea/models/sistema_sisbolsas/silver/schema.yml
+++ b/airflow_lappis/dags/dbt/ipea/models/sistema_sisbolsas/silver/schema.yml
@@ -237,8 +237,30 @@ models:
         description: Número de transferência usado como chave de integração com o número SIAFI do SGAC.
       - name: sq_instrumento
         description: Sequencial do instrumento mantido apenas como atributo informativo do Plano de Ação.
+      - name: sigla_unidade_descentralizada
+        description: Sigla da unidade descentralizada recebedora no TransfereGov.
+      - name: unidade_descentralizada
+        description: Nome da unidade descentralizada recebedora no TransfereGov.
+      - name: sigla_unidade_descentralizadora
+        description: Sigla da unidade descentralizadora repassadora vinculada ao programa do Plano de Ação.
+      - name: sigla_unidade_responsavel_acompanhamento
+        description: Sigla da unidade responsável pelo acompanhamento do programa no TransfereGov.
+      - name: programa
+        description: Identificador do programa vinculado ao Plano de Ação no TransfereGov.
+      - name: nome_institucional_programa
+        description: Nome institucional do programa vinculado ao Plano de Ação no TransfereGov.
+      - name: percentual_vigencia
+        description: Percentual de vigência do plano de ação calculado a partir das datas de início e fim no TransfereGov.
       - name: valor_firmado
         description: Valor firmado no cruzamento SIAFI/TransfereGov.
+      - name: numeros_empenho
+        description: Lista agregada dos números de nota de empenho associados ao Plano de Ação.
+      - name: quantidade_empenhos
+        description: Quantidade distinta de notas de empenho associadas ao Plano de Ação.
+      - name: numeros_nc
+        description: Lista agregada dos números de nota de crédito associados ao Plano de Ação.
+      - name: quantidade_ncs
+        description: Quantidade distinta de notas de crédito associadas ao Plano de Ação.
       - name: despesas_pagas_exercicio
         description: Despesas pagas no exercício.
       - name: despesas_pagas_rap

--- a/airflow_lappis/dags/dbt/ipea/models/sistema_sisbolsas/silver/sgac_teds_siafi.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/sistema_sisbolsas/silver/sgac_teds_siafi.sql
@@ -22,6 +22,40 @@ with
           and regexp_replace(coalesce(numero_siafi, ''), '[^0-9]', '', 'g') <> ''
     ),
 
+    resumo_programa_plano_acao as (
+        select
+            plano_acao,
+            max(programa) as programa,
+            max(nome_institucional_programa) as nome_institucional_programa,
+            max(percentual_conclusao) as percentual_vigencia,
+            max(sigla_unidade_descentralizadora_programa)
+                as sigla_unidade_descentralizadora,
+            max(sigla_unidade_responsavel_acompanhamento)
+                as sigla_unidade_responsavel_acompanhamento
+        from {{ ref("resumo_programa_plano_acao_") }}
+        group by plano_acao
+    ),
+
+    empenhos_por_plano_acao as (
+        select
+            plano_acao,
+            string_agg(distinct ne, ' | ' order by ne) as numeros_empenho,
+            count(distinct ne) as quantidade_empenhos
+        from {{ ref("empenhos_plano_acao") }}
+        where nullif(trim(coalesce(ne, '')), '') is not null
+        group by plano_acao
+    ),
+
+    ncs_por_plano_acao as (
+        select
+            plano_acao,
+            string_agg(distinct nc, ' | ' order by nc) as numeros_nc,
+            count(distinct nc) as quantidade_ncs
+        from {{ ref("nc_plano_acao") }}
+        where nullif(trim(coalesce(nc, '')), '') is not null
+        group by plano_acao
+    ),
+
     transfere_gov_teds as (
         select distinct
             coalesce(r.plano_acao, p.id_plano_acao) as plano_acao,
@@ -29,6 +63,11 @@ with
             p.sq_instrumento,
             p.sigla_unidade_descentralizada,
             p.unidade_descentralizada,
+            rp.sigla_unidade_descentralizadora,
+            rp.sigla_unidade_responsavel_acompanhamento,
+            rp.programa,
+            rp.nome_institucional_programa,
+            rp.percentual_vigencia,
             p.dt_inicio_vigencia,
             p.dt_fim_vigencia,
             p.tx_situacao_plano_acao,
@@ -45,11 +84,21 @@ with
             r.financeiro_recebido,
             r.financeiro_devolvido,
             r.financeiro_cancelado,
+            epa.numeros_empenho,
+            epa.quantidade_empenhos,
+            npa.numeros_nc,
+            npa.quantidade_ncs,
             regexp_replace(coalesce(r.num_transf, ''), '[^0-9]', '', 'g')
             as transf_norm
         from {{ ref("ted_resumo_orcamentario") }} as r
         full join {{ ref("planos_acao") }} as p
             on p.id_plano_acao = r.plano_acao
+        left join resumo_programa_plano_acao as rp
+            on rp.plano_acao = coalesce(r.plano_acao, p.id_plano_acao)
+        left join empenhos_por_plano_acao as epa
+            on epa.plano_acao = coalesce(r.plano_acao, p.id_plano_acao)
+        left join ncs_por_plano_acao as npa
+            on npa.plano_acao = coalesce(r.plano_acao, p.id_plano_acao)
     ),
 
     matches as (
@@ -69,6 +118,11 @@ with
             t.sq_instrumento,
             t.sigla_unidade_descentralizada,
             t.unidade_descentralizada,
+            t.sigla_unidade_descentralizadora,
+            t.sigla_unidade_responsavel_acompanhamento,
+            t.programa,
+            t.nome_institucional_programa,
+            t.percentual_vigencia,
             t.dt_inicio_vigencia,
             t.dt_fim_vigencia,
             t.tx_situacao_plano_acao,
@@ -85,6 +139,10 @@ with
             t.financeiro_recebido,
             t.financeiro_devolvido,
             t.financeiro_cancelado,
+            t.numeros_empenho,
+            t.quantidade_empenhos,
+            t.numeros_nc,
+            t.quantidade_ncs,
             'numero_siafi' as chave_match,
             'SGAC.numero_siafi -> SIAFI.num_transf' as caminho_match
         from sgac_teds as s
@@ -109,6 +167,11 @@ select
     sq_instrumento,
     sigla_unidade_descentralizada,
     unidade_descentralizada,
+    sigla_unidade_descentralizadora,
+    sigla_unidade_responsavel_acompanhamento,
+    programa,
+    nome_institucional_programa,
+    percentual_vigencia,
     dt_inicio_vigencia,
     dt_fim_vigencia,
     tx_situacao_plano_acao,
@@ -125,6 +188,10 @@ select
     financeiro_recebido,
     financeiro_devolvido,
     financeiro_cancelado,
+    numeros_empenho,
+    quantidade_empenhos,
+    numeros_nc,
+    quantidade_ncs,
     chave_match,
     caminho_match
 from matches


### PR DESCRIPTION
## Descrição
Este PR adiciona modelos DBT para relatórios gerenciais do SGAC no domínio `sistema_sisbolsas`, com foco em TEDs vigentes e controle de término de vigência.

As mudanças estruturam uma camada `gold` para relatórios finais e mantêm na `silver` o cruzamento validado entre SGAC, TransfereGov e SIAFI. O cruzamento dos TEDs usa apenas o `numero_siafi` do SGAC contra o `num_transf`, evitando o uso do número do processo SEI como chave de integração.

Também foram adicionados campos de enriquecimento do TransfereGov/SIAFI no relatório de TEDs vigentes, incluindo plano de ação, programa, unidades envolvidas, valores orçamentários, execução financeira, empenhos, notas de crédito e indicadores gerenciais de vigência e execução.

## Tipo de mudança
- [x] Nova funcionalidade / pipeline
- [ ] Correção de bug ou inconsistência de dados
- [x] Refatoração de modelo DBT
- [x] Documentação
- [ ] Infraestrutura / CI
- [ ] Outro: ___

## Issues relacionadas
Closes #

## Domínio de revisão
- [ ] GCES / OSS
- [x] IPEA
- [ ] MIR
- [ ] MCid
- [ ] MinC
- [ ] OSS
- [ ] Múltiplos domínios: ___

## Como testar / validar

```bash
cd airflow_lappis/dags/dbt/ipea
