### PR TITLE
fix(github): solicita revisores apenas por labels manuais

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -215,7 +215,7 @@ Toda solicitação de mudança ou sugestão deve ser registrada como issue.
 
 Consulte o [Protocolo de Aprovação de Pull Requests](MERGE_REQUEST_PROTOCOL.md) para os critérios obrigatórios de revisão, aprovação e merge.
 
-O repositório usa domínios de revisão (`IPEA`, `MIR`, `MCid`, `MinC` e `OSS`) e a workflow `Request team review` para solicitar revisões automaticamente conforme os caminhos alterados ou labels `team:*` aplicadas no PR. PRs originados na disciplina GCES devem usar a label `team:gces`, que solicita revisão do time `OSS`.
+O repositório usa domínios de revisão (`IPEA`, `MIR`, `MCid`, `MinC` e `OSS`) e a workflow `Request team review` para solicitar revisões conforme as labels `team:*` aplicadas manualmente no PR. PRs originados na disciplina GCES devem usar a label `team:gces`, que solicita revisão do time `OSS`.
 
 **Para quem submete o PR:** responda a todos os comentários de revisão, implemente as mudanças em novos commits e aguarde nova aprovação antes do merge.
 

--- a/.github/MERGE_REQUEST_PROTOCOL.md
+++ b/.github/MERGE_REQUEST_PROTOCOL.md
@@ -194,11 +194,11 @@ Os nomes acima usam os slugs dos times no GitHub. O time pode aparecer visualmen
 
 A estratégia adotada para domínios de dados é **GitHub Actions + labels `team:*`**:
 
-- A workflow `Request team review` aplica labels de domínio quando identifica caminhos conhecidos.
-- A mesma workflow solicita revisão dos times correspondentes.
-- Labels `team:*` adicionadas manualmente ao PR também solicitam revisão do time associado.
+- A label `team:*` deve ser adicionada manualmente ao PR conforme o domínio principal da mudança.
+- A workflow `Request team review` roda quando uma label é adicionada ao PR.
+- A workflow não cria nem aplica labels automaticamente; ela apenas solicita revisão dos times correspondentes às labels já presentes no PR.
 
-Essa escolha centraliza o roteamento em um único lugar, evita manter listas paralelas de caminhos, reduz erros de configuração e permite tratar casos em que o domínio é definido por label, não apenas pelo caminho do arquivo.
+Essa escolha evita manter listas frágeis de caminhos na automação, reduz falsos positivos e deixa a decisão do domínio explícita no PR.
 
 Mapa atual dos principais caminhos de DAGs e modelos:
 
@@ -226,11 +226,11 @@ Mapa atual dos principais caminhos de DAGs e modelos:
 | `airflow_lappis/dags/data_ingest/tesouro_gerencial/mcid/` | MCid |
 | `airflow_lappis/dags/data_ingest/ibge/` | GCES / OSS |
 
-Quando um PR alterar arquivos de um domínio mapeado, a workflow deve aplicar a label `team:*` correspondente e solicitar review do time associado. A ruleset da branch `main` deve exigir pelo menos uma aprovação antes do merge.
+Quando um PR alterar arquivos de um domínio, o autor ou mantenedor deve aplicar a label `team:*` correspondente. A workflow solicita review do time associado a essa label. A ruleset da branch `main` deve exigir pelo menos uma aprovação antes do merge.
 
 ### Labels de Apoio
 
-Labels podem ser usadas como sinalização complementar quando o domínio do PR não for evidente apenas pelos caminhos alterados:
+Labels são a referência para o roteamento automático de revisores:
 
 - `team:ipea`
 - `team:mir`
@@ -239,7 +239,7 @@ Labels podem ser usadas como sinalização complementar quando o domínio do PR 
 - `team:gces`
 - `team:oss`
 
-As labels são a referência principal para o roteamento automático. Se uma label indicar um domínio diferente dos arquivos alterados, o autor deve justificar no PR ou ajustar a regra da workflow se o novo padrão de caminhos for permanente.
+Se uma label indicar um domínio diferente dos arquivos alterados, o autor deve justificar no PR ou ajustar a label antes do merge.
 
 ### Como Incluir Novos Projetos ou Times
 
@@ -248,9 +248,10 @@ Para adicionar um novo projeto, ministério ou disciplina ao fluxo de revisão:
 1. Criar o time correspondente na organização `GovHub-br`.
 2. Adicionar os membros responsáveis ao time.
 3. Definir o slug oficial do time, por exemplo `@GovHub-br/minc`.
-4. Criar ou identificar os diretórios do domínio no repositório.
-5. Adicionar os caminhos na workflow `Request team review`, ou documentar a label manual quando o domínio não puder ser inferido por caminho.
-6. Abrir um PR de teste alterando um arquivo do domínio ou aplicando a label correspondente e confirmar que o GitHub solicita revisão do time correto.
+4. Criar a label `team:*` correspondente, se ela ainda não existir.
+5. Mapear a label para o slug do time na workflow `Request team review`.
+6. Documentar quando a label deve ser usada.
+7. Abrir um PR de teste, aplicar a label correspondente e confirmar que o GitHub solicita revisão do time correto.
 
 ### Número Mínimo de Aprovações
 

--- a/.github/workflows/request-team-review.yaml
+++ b/.github/workflows/request-team-review.yaml
@@ -2,12 +2,11 @@ name: Request team review
 
 on:
   pull_request_target:
-    types: [opened, reopened, ready_for_review, synchronize, labeled]
+    types: [labeled]
 
 permissions:
   contents: read
   pull-requests: write
-  issues: write
 
 jobs:
   request-team-review:
@@ -15,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
-      - name: Apply team labels and request reviewers
+      - name: Request reviewers from team labels
         uses: actions/github-script@v7
         with:
           script: |
@@ -31,185 +30,11 @@ jobs:
               "team:oss": "oss",
             };
 
-            const labelConfig = {
-              "team:gces": {
-                color: "5319e7",
-                description: "Revisao de PRs da disciplina GCES pelo time OSS",
-              },
-              "team:ipea": {
-                color: "0e8a16",
-                description: "Revisao do dominio IPEA",
-              },
-              "team:mir": {
-                color: "1d76db",
-                description: "Revisao do dominio MIR",
-              },
-              "team:mcid": {
-                color: "fbca04",
-                description: "Revisao do dominio MCid",
-              },
-              "team:minc": {
-                color: "d93f0b",
-                description: "Revisao do dominio MinC",
-              },
-              "team:oss": {
-                color: "5319e7",
-                description: "Revisao de contribuicoes OSS, GCES e governanca aberta",
-              },
-            };
-
-            const rules = [
-              {
-                label: "team:ipea",
-                paths: [
-                  "airflow_lappis/dags/dashboards/",
-                  "airflow_lappis/dags/data_ingest/compras_gov/",
-                  "airflow_lappis/dags/dbt/ipea/",
-                  "airflow_lappis/dags/data_ingest/ipea_pro/",
-                  "airflow_lappis/dags/data_ingest/pncp/",
-                  "airflow_lappis/dags/data_ingest/sgac/",
-                  "airflow_lappis/dags/data_ingest/siafi/",
-                  "airflow_lappis/dags/data_ingest/siape/",
-                  "airflow_lappis/dags/data_ingest/siorg/",
-                  "airflow_lappis/dags/data_ingest/sisbolsas/",
-                  "airflow_lappis/dags/data_ingest/tesouro_gerencial/",
-                  "airflow_lappis/dags/data_ingest/transfere_gov/",
-                ],
-                excludePaths: [
-                  "airflow_lappis/dags/data_ingest/compras_gov/mir/",
-                  "airflow_lappis/dags/data_ingest/tesouro_gerencial/mcid/",
-                  "airflow_lappis/dags/data_ingest/tesouro_gerencial/mir/",
-                  "airflow_lappis/dags/data_ingest/transfere_gov/mir/",
-                ],
-              },
-              {
-                label: "team:mir",
-                paths: [
-                  "airflow_lappis/dags/dbt/mir/",
-                  "airflow_lappis/dags/data_ingest/compras_gov/mir/",
-                  "airflow_lappis/dags/data_ingest/dados_abertos/",
-                  "airflow_lappis/dags/data_ingest/siconv/",
-                  "airflow_lappis/dags/data_ingest/tesouro_gerencial/mir/",
-                  "airflow_lappis/dags/data_ingest/transfere_gov/mir/",
-                  "airflow_lappis/dags/data_ingest/transferegov_emendas/",
-                ],
-              },
-              {
-                label: "team:mcid",
-                paths: [
-                  "airflow_lappis/dags/data_ingest/tesouro_gerencial/mcid/",
-                ],
-              },
-              {
-                label: "team:gces",
-                paths: [
-                  "airflow_lappis/dags/data_ingest/ibge/",
-                ],
-              },
-              {
-                label: "team:oss",
-                paths: [
-                  ".github/",
-                  "airflow_lappis/dags/",
-                  "airflow_lappis/helpers/",
-                  "airflow_lappis/plugins/",
-                  "airflow_lappis/templates/",
-                  "docker/",
-                  ".github/CONTRIBUTING.md",
-                  ".github/PULL_REQUEST_TEMPLATE.md",
-                  ".github/MERGE_REQUEST_PROTOCOL.md",
-                  "tests/",
-                  "Dockerfile",
-                  "Dockerfile.superset",
-                  "Makefile",
-                  "docker-compose.yml",
-                  "pyproject.toml",
-                  "requirements.txt",
-                  "setup-git-hooks.sh",
-                  "README.md",
-                  "LICENSE",
-                ],
-                excludePaths: [
-                  "airflow_lappis/dags/dashboards/",
-                  "airflow_lappis/dags/data_ingest/compras_gov/",
-                  "airflow_lappis/dags/dbt/ipea/",
-                  "airflow_lappis/dags/data_ingest/ipea_pro/",
-                  "airflow_lappis/dags/data_ingest/pncp/",
-                  "airflow_lappis/dags/data_ingest/sgac/",
-                  "airflow_lappis/dags/data_ingest/siafi/",
-                  "airflow_lappis/dags/data_ingest/siape/",
-                  "airflow_lappis/dags/data_ingest/siorg/",
-                  "airflow_lappis/dags/data_ingest/sisbolsas/",
-                  "airflow_lappis/dags/data_ingest/tesouro_gerencial/",
-                  "airflow_lappis/dags/data_ingest/transfere_gov/",
-                  "airflow_lappis/dags/dbt/mir/",
-                  "airflow_lappis/dags/data_ingest/dados_abertos/",
-                  "airflow_lappis/dags/data_ingest/siconv/",
-                  "airflow_lappis/dags/data_ingest/transferegov_emendas/",
-                  "airflow_lappis/dags/data_ingest/ibge/",
-                ],
-              },
-            ];
-
-            const files = await github.paginate(
-              github.rest.pulls.listFiles,
-              { owner, repo, pull_number, per_page: 100 }
-            );
-
-            const changedPaths = files.map((file) => file.filename);
-            const inferredLabels = new Set();
-
-            const pathMatches = (filePath, paths) =>
-              paths.some((path) => filePath === path || filePath.startsWith(path));
-
-            for (const rule of rules) {
-              if (changedPaths.some((filePath) =>
-                pathMatches(filePath, rule.paths)
-                && !pathMatches(filePath, rule.excludePaths || [])
-              )) {
-                inferredLabels.add(rule.label);
-              }
-            }
-
             const currentLabels = new Set(
               context.payload.pull_request.labels.map((label) => label.name)
             );
 
-            const labelsToAdd = [...inferredLabels]
-              .filter((label) => !currentLabels.has(label));
-
-            if (labelsToAdd.length > 0) {
-              for (const label of labelsToAdd) {
-                try {
-                  await github.rest.issues.getLabel({
-                    owner,
-                    repo,
-                    name: label,
-                  });
-                } catch (error) {
-                  if (error.status !== 404) {
-                    throw error;
-                  }
-
-                  await github.rest.issues.createLabel({
-                    owner,
-                    repo,
-                    name: label,
-                    ...labelConfig[label],
-                  });
-                }
-              }
-
-              await github.rest.issues.addLabels({
-                owner,
-                repo,
-                issue_number: pull_number,
-                labels: labelsToAdd,
-              });
-            }
-
-            const labelsForReview = new Set([...currentLabels, ...inferredLabels]);
-            const team_reviewers = [...new Set([...labelsForReview]
+            const team_reviewers = [...new Set([...currentLabels]
               .map((label) => teamByLabel[label])
               .filter(Boolean))];
 


### PR DESCRIPTION
## Descrição

Ajusta a workflow de revisão automática para que ela não aplique mais labels `team:*` automaticamente nem tente inferir o domínio do PR pelos caminhos alterados.

Com essa mudança, a workflow passa a rodar apenas quando uma label é adicionada manualmente ao PR. A partir da label `team:*`, ela solicita o review do time correspondente.

## O que foi alterado

- Removida a inferência automática de domínio por caminhos alterados
- Removida a criação/aplicação automática de labels pela workflow
- Mantido o mapeamento entre labels `team:*` e times do GitHub
- Ajustado o gatilho da workflow para rodar apenas no evento `labeled`
- Atualizado o protocolo de revisão de PRs
- Atualizado o guia de contribuição

## Issues relacionadas

Closes #413

## Como testar / validar

1. Abrir ou usar um PR de teste
2. Adicionar manualmente uma label, por exemplo:
   - `team:mir`
   - `team:ipea`
   - `team:mcid`
   - `team:minc`
   - `team:oss`
   - `team:gces`
3. Verificar em **Actions → Request team review** se a workflow executou
4. Confirmar se o time correspondente foi solicitado como reviewe