### PR TITLE
fix(github): usa token dedicado para solicitar revisores

### DIFF
--- a/.github/MERGE_REQUEST_PROTOCOL.md
+++ b/.github/MERGE_REQUEST_PROTOCOL.md
@@ -263,6 +263,8 @@ Para adicionar um novo projeto, ministério ou disciplina ao fluxo de revisão:
 
 Para aplicar essas regras automaticamente, o repositório usa a workflow `Request team review`.
 
+Caso o GitHub recuse a solicitação automática de review de um time, a workflow deve registrar um aviso sem bloquear o PR. Se a solicitação de reviewers por time continuar falhando, configure o secret `TEAM_REVIEW_TOKEN` com um token autorizado a solicitar reviewers no repositório e ler times da organização.
+
 Além da workflow, a branch `main` deve manter as seguintes proteções habilitadas:
 
 - Proteção da branch `main`, exigindo revisão antes do merge

--- a/.github/workflows/request-team-review.yaml
+++ b/.github/workflows/request-team-review.yaml
@@ -17,6 +17,7 @@ jobs:
       - name: Request reviewers from team labels
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.TEAM_REVIEW_TOKEN || github.token }}
           script: |
             const { owner, repo } = context.repo;
             const pull_number = context.payload.pull_request.number;
@@ -40,14 +41,28 @@ jobs:
 
             if (team_reviewers.length === 0) {
               core.info("No team labels found for this PR.");
-              return;
+            } else {
+              const failedTeams = [];
+
+              for (const team of team_reviewers) {
+                try {
+                  await github.rest.pulls.requestReviewers({
+                    owner,
+                    repo,
+                    pull_number,
+                    team_reviewers: [team],
+                  });
+                  core.info(`Requested review from team: ${team}`);
+                } catch (error) {
+                  failedTeams.push(team);
+                  core.warning(`Could not request review from team "${team}": ${error.message}`);
+                }
+              }
+
+              if (failedTeams.length > 0) {
+                core.warning(
+                  `Some teams could not be requested automatically: ${failedTeams.join(", ")}. ` +
+                  "Check team repository access or configure TEAM_REVIEW_TOKEN with Pull requests: read/write and Members: read permissions."
+                );
+              }
             }
-
-            await github.rest.pulls.requestReviewers({
-              owner,
-              repo,
-              pull_number,
-              team_reviewers,
-            });
-
-            core.info(`Requested review from teams: ${team_reviewers.join(", ")}`);


### PR DESCRIPTION
## Descrição

Ajusta a workflow `Request team review` para usar o secret `TEAM_REVIEW_TOKEN` ao solicitar revisores por time, com fallback para o `GITHUB_TOKEN` padrão.

Essa mudança corrige o problema em que a workflow identificava corretamente as labels `team:*` e os times correspondentes, mas a API do GitHub retornava erro `422 Validation Failed` ao tentar solicitar team reviewers usando apenas o token padrão da Action.

## O que foi alterado

- A workflow passa a usar `TEAM_REVIEW_TOKEN`, quando configurado
- Mantém fallback para `github.token`
- Solicita review de cada time separadamente
- Trata falhas de solicitação como `warning`
- Evita que a Action fique vermelha por falha isolada ao solicitar um time
- Atualiza o protocolo de revisão para documentar o comportamento

## Issues relacionadas

Closes #418

## Como testar / validar

1. Garantir que o secret `TEAM_REVIEW_TOKEN` está configurado no repositório
2. Abrir ou usar um PR de teste
3. Adicionar manualmente uma label `team:*`, por exemplo:
   - `team:oss`
   - `team:mcid`
   - `team:mir`
   - `team:ipea`
   - `team:minc`
   - `team:gces`
4. Verificar em **Actions → Request team review** se a workflow executou
5. Confirmar se o time correspondente foi solicitado como reviewer

Resultado esperado: a workflow solicita o reviewer do time correspondente. Caso o GitHub recuse algum time, a execução registra um warning claro sem quebrar toda a Action.