### PR TITLE
test(dbt): adiciona testes de integridade em metadata

### DIFF
--- a/airflow_lappis/dags/dbt/ipea/macros/data_quality/unique_combination_of_columns.sql
+++ b/airflow_lappis/dags/dbt/ipea/macros/data_quality/unique_combination_of_columns.sql
@@ -1,0 +1,14 @@
+{% macro test_unique_combination_of_columns(model, combination_of_columns) %}
+    with
+        validation_errors as (
+            select
+                {{ combination_of_columns | join(', ') }},
+                count(*) as row_count
+            from {{ model }}
+            group by {{ combination_of_columns | join(', ') }}
+            having count(*) > 1
+        )
+
+    select *
+    from validation_errors
+{% endmacro %}

--- a/airflow_lappis/dags/dbt/ipea/models/metadata/schema.yml
+++ b/airflow_lappis/dags/dbt/ipea/models/metadata/schema.yml
@@ -12,6 +12,11 @@ models:
       tags:
         - metadata
         - governance
+    tests:
+      - unique_combination_of_columns:
+          combination_of_columns:
+            - schema_name
+            - table_name
     columns:
       - name: schema_name
         description: Nome do schema onde o modelo está localizado.
@@ -25,9 +30,13 @@ models:
 
       - name: database_name
         description: Nome do banco de dados onde o modelo está materializado.
+        tests:
+          - not_null
 
       - name: materialization
         description: Tipo de materialização do modelo (table, view, incremental, etc).
+        tests:
+          - not_null
 
       - name: description
         description: Descrição do modelo extraída do schema.yml.
@@ -44,3 +53,5 @@ models:
         description: >
           Identificador único da execução do dbt (invocation_id).
           Permite rastrear qual execução gerou a transformação.
+        tests:
+          - not_null

--- a/airflow_lappis/dags/dbt/mir/macros/data_quality/unique_combination_of_columns.sql
+++ b/airflow_lappis/dags/dbt/mir/macros/data_quality/unique_combination_of_columns.sql
@@ -1,0 +1,14 @@
+{% macro test_unique_combination_of_columns(model, combination_of_columns) %}
+    with
+        validation_errors as (
+            select
+                {{ combination_of_columns | join(', ') }},
+                count(*) as row_count
+            from {{ model }}
+            group by {{ combination_of_columns | join(', ') }}
+            having count(*) > 1
+        )
+
+    select *
+    from validation_errors
+{% endmacro %}

--- a/airflow_lappis/dags/dbt/mir/models/metadata/schema.yml
+++ b/airflow_lappis/dags/dbt/mir/models/metadata/schema.yml
@@ -12,6 +12,11 @@ models:
       tags:
         - metadata
         - governance
+    tests:
+      - unique_combination_of_columns:
+          combination_of_columns:
+            - schema_name
+            - table_name
     columns:
       - name: schema_name
         description: Nome do schema onde o modelo está localizado.
@@ -25,9 +30,13 @@ models:
 
       - name: database_name
         description: Nome do banco de dados onde o modelo está materializado.
+        tests:
+          - not_null
 
       - name: materialization
         description: Tipo de materialização do modelo (table, view, incremental, etc).
+        tests:
+          - not_null
 
       - name: description
         description: Descrição do modelo extraída do schema.yml.
@@ -44,3 +53,5 @@ models:
         description: >
           Identificador único da execução do dbt (invocation_id).
           Permite rastrear qual execução gerou a transformação.
+        tests:
+          - not_null


### PR DESCRIPTION
## Descrição
Adiciona testes básicos de integridade e nulidade nas tabelas `models_metadata` dos projetos DBT disponíveis no repositório.

A mudança inclui:
- teste de unicidade para a combinação `schema_name` + `table_name`;
- testes `not_null` para campos essenciais de metadata;
- macro reutilizável `unique_combination_of_columns`.

> Antes de abrir este PR, consulte o [Protocolo de Aprovação de Pull Requests](https://github.com/GovHub-br/data-application-gov-hub/blob/main/.github/MERGE_REQUEST_PROTOCOL.md).

## Tipo de mudança
- [ ] Nova funcionalidade / pipeline
- [ ] Correção de bug ou inconsistência de dados
- [ ] Refatoração de modelo DBT
- [ ] Documentação
- [ ] Infraestrutura / CI
- [x] Outro: testes DBT

## Issues relacionadas
#297 

## Domínio de revisão
- [x] GCES / OSS
- [x] IPEA
- [x] MIR
- [ ] MCid
- [ ] MinC
- [ ] OSS
- [ ] Múltiplos domínios: IPEA, MIR

## Como testar / validar

```bash
cd airflow_lappis/dags/dbt/ipea
dbt test --select models_metadata

cd ../mir
dbt test --select models_metadata