### PR TITLE
test: adiciona testes de integridade para mcid empreendimento FAR

### DIFF
--- a/airflow_lappis/dags/dbt/ipea/dbt_project.yml
+++ b/airflow_lappis/dags/dbt/ipea/dbt_project.yml
@@ -50,6 +50,9 @@ models:
       +schema: sistema_sisbolsas
       bronze:
         +materialized: table
+    mcid:
+      +materialized: table
+      +schema: mcid
     # siape_dbt: 
     #   +materialized: table 
     #   +schema: siape 

--- a/airflow_lappis/dags/dbt/ipea/macros/tests/accepted_numeric_range.sql
+++ b/airflow_lappis/dags/dbt/ipea/macros/tests/accepted_numeric_range.sql
@@ -1,0 +1,18 @@
+{% test accepted_numeric_range(model, column_name, min_value=none, max_value=none) %}
+
+select *
+from {{ model }}
+where {{ column_name }} is not null
+    and (
+    {% if min_value is not none %}
+        {{ column_name }} < {{ min_value }}
+    {% endif %}
+    {% if min_value is not none and max_value is not none %}
+        or
+    {% endif %}
+    {% if max_value is not none %}
+        {{ column_name }} > {{ max_value }}
+    {% endif %}
+    )
+
+{% endtest %}

--- a/airflow_lappis/dags/dbt/ipea/macros/tests/unique_combination_of_columns.sql
+++ b/airflow_lappis/dags/dbt/ipea/macros/tests/unique_combination_of_columns.sql
@@ -1,0 +1,19 @@
+{% test unique_combination_of_columns(model, combination_of_columns) %}
+
+with validation as (
+    select
+        {% for column_name in combination_of_columns %}
+            {{ column_name }}{% if not loop.last %},{% endif %}
+        {% endfor %}
+    from {{ model }}
+    group by
+        {% for column_name in combination_of_columns %}
+            {{ column_name }}{% if not loop.last %},{% endif %}
+        {% endfor %}
+    having count(*) > 1
+)
+
+select *
+from validation
+
+{% endtest %}

--- a/airflow_lappis/dags/dbt/ipea/models/mcid/empreendimento_far_dbt/empreendimento_far.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/mcid/empreendimento_far_dbt/empreendimento_far.sql
@@ -1,0 +1,2 @@
+select *
+from {{ source("mcid", "empreendimento_far") }}

--- a/airflow_lappis/dags/dbt/ipea/models/mcid/empreendimento_far_dbt/evolucao_financeira.sql
+++ b/airflow_lappis/dags/dbt/ipea/models/mcid/empreendimento_far_dbt/evolucao_financeira.sql
@@ -1,0 +1,2 @@
+select *
+from {{ source("mcid", "evolucao_financeira") }}

--- a/airflow_lappis/dags/dbt/ipea/models/mcid/empreendimento_far_dbt/schema.yml
+++ b/airflow_lappis/dags/dbt/ipea/models/mcid/empreendimento_far_dbt/schema.yml
@@ -1,0 +1,108 @@
+version: 2
+
+models:
+  - name: empreendimento_far
+    description: Tabela de empreendimentos FAR do sistema MCID.
+    columns:
+      - name: apf
+        description: Chave primaria do empreendimento FAR.
+        tests:
+          - unique
+          - not_null
+      - name: uf
+        description: Sigla da unidade federativa do empreendimento.
+        tests:
+          - accepted_values:
+              values:
+                - AC
+                - AL
+                - AP
+                - AM
+                - BA
+                - CE
+                - DF
+                - ES
+                - GO
+                - MA
+                - MT
+                - MS
+                - MG
+                - PA
+                - PB
+                - PR
+                - PE
+                - PI
+                - RJ
+                - RN
+                - RS
+                - RO
+                - RR
+                - SC
+                - SP
+                - SE
+                - TO
+      - name: valor_contratado
+        description: Valor contratado do empreendimento.
+        tests:
+          - accepted_numeric_range:
+              min_value: 0
+      - name: valor_investimento
+        description: Valor de investimento do empreendimento.
+        tests:
+          - accepted_numeric_range:
+              min_value: 0
+      - name: valor_repasse
+        description: Valor de repasse do empreendimento.
+        tests:
+          - accepted_numeric_range:
+              min_value: 0
+      - name: percentual_execucao_fisica
+        description: Percentual de execucao fisica do empreendimento.
+        tests:
+          - accepted_numeric_range:
+              min_value: 0
+              max_value: 120
+      - name: percentual_execucao_financeira
+        description: Percentual de execucao financeira do empreendimento.
+        tests:
+          - accepted_numeric_range:
+              min_value: 0
+              max_value: 120
+
+  - name: evolucao_financeira
+    description: Tabela de evolucao financeira dos empreendimentos FAR.
+    tests:
+      - unique_combination_of_columns:
+          combination_of_columns:
+            - apf
+            - data_referencia
+    columns:
+      - name: apf
+        description: Identificador do empreendimento FAR.
+        tests:
+          - not_null
+      - name: data_referencia
+        description: Data de referencia da evolucao financeira.
+        tests:
+          - not_null
+      - name: valor_liberado
+        description: Valor financeiro liberado no periodo.
+        tests:
+          - accepted_numeric_range:
+              min_value: 0
+      - name: valor_desembolsado
+        description: Valor financeiro desembolsado no periodo.
+        tests:
+          - accepted_numeric_range:
+              min_value: 0
+      - name: valor_executado
+        description: Valor financeiro executado no periodo.
+        tests:
+          - accepted_numeric_range:
+              min_value: 0
+      - name: percentual_execucao_financeira
+        description: Percentual de execucao financeira no periodo.
+        tests:
+          - accepted_numeric_range:
+              min_value: 0
+              max_value: 120

--- a/airflow_lappis/dags/dbt/ipea/models/sources.yml
+++ b/airflow_lappis/dags/dbt/ipea/models/sources.yml
@@ -125,6 +125,12 @@ sources:
     schema: sgac
     tables:
       - name: projetos_sgac
+
+  - name: mcid
+    schema: mcid
+    tables:
+      - name: empreendimento_far
+      - name: evolucao_financeira
       
   - name: censo_demografico
     schema: censo_demografico

--- a/airflow_lappis/dags/dbt/ipea/tests/test_empreendimento_far_datas_contratacao.sql
+++ b/airflow_lappis/dags/dbt/ipea/tests/test_empreendimento_far_datas_contratacao.sql
@@ -1,0 +1,15 @@
+select *
+from {{ ref("empreendimento_far") }}
+where data_contratacao is not null
+    and coalesce(
+        data_contratacao > data_conclusao,
+        true
+    )
+    and coalesce(
+        data_contratacao > data_entrega,
+        true
+    )
+    and (
+        data_conclusao is not null
+        or data_entrega is not null
+    )


### PR DESCRIPTION
## Descrição
Adiciona testes de integridade estrutural e regras de negócio para as tabelas `mcid/empreendimento_far_dbt`.

Foram incluídas validações de chave primária, chave composta da evolução financeira, domínio válido de UF, faixas positivas para campos financeiros, percentuais entre 0 e 120 e teste singular para consistência entre datas de contratação, conclusão e entrega.

> Antes de abrir este PR, consulte o [Protocolo de Aprovação de Pull Requests](https://github.com/GovHub-br/data-application-gov-hub/blob/main/.github/MERGE_REQUEST_PROTOCOL.md).

## Tipo de mudança
- [ ] Nova funcionalidade / pipeline
- [ ] Correção de bug ou inconsistência de dados
- [ ] Refatoração de modelo DBT
- [ ] Documentação
- [ ] Infraestrutura / CI
- [x] Outro: Testes DBT

## Issues relacionadas
test: Implementar testes para mcid/empreendimento_far_dbt#296

## Domínio de revisão
- [ ] GCES / OSS
- [ ] IPEA
- [ ] MIR
- [x] MCid
- [ ] MinC
- [ ] OSS
- [ ] Múltiplos domínios: ___
