### PR TITLE
Fix/diagnostico prs com action

### DIFF
--- a/.github/workflows/diagnose-rebase-pr.yaml
+++ b/.github/workflows/diagnose-rebase-pr.yaml
@@ -28,7 +28,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   issues: write
 
 concurrency:

--- a/.github/workflows/diagnose-rebase-pr.yaml
+++ b/.github/workflows/diagnose-rebase-pr.yaml
@@ -382,9 +382,10 @@ jobs:
                   --field body="${comment_body}" >/dev/null
                 comment_status="updated"
               else
-                gh pr comment "${pr_number}" \
-                  --repo "${owner_repo}" \
-                  --body-file "${comment_file}"
+                gh api \
+                  --method POST \
+                  "repos/${owner_repo}/issues/${pr_number}/comments" \
+                  --field body="${comment_body}" >/dev/null
                 comment_status="created"
               fi
             fi


### PR DESCRIPTION
## Descrição

Corrige a etapa de comentário do workflow `Diagnose PR rebase` para permitir que a action publique ou atualize comentários em pull requests.

Durante os testes via `workflow_dispatch`, o diagnóstico do PR era executado corretamente, mas a publicação do comentário falhava em duas etapas:

1. Primeiro, o uso de `gh pr comment` acionava a API GraphQL e retornava `Resource not accessible by integration (addComment)`.
2. Depois da troca para `gh api` usando o endpoint REST de comentários em issues/PRs, a chamada ainda falhava com `Resource not accessible by integration (HTTP 403)` porque o `GITHUB_TOKEN` tinha `issues: write`, mas apenas `pull-requests: read`.

Este PR cobre as duas correções: troca a publicação de comentários para REST e ajusta a permissão de `pull-requests` para `write`, mantendo as demais permissões restritas.

> Antes de abrir este PR, consulte o [Protocolo de Aprovação de Pull Requests](https://github.com/GovHub-br/data-application-gov-hub/blob/main/.github/MERGE_REQUEST_PROTOCOL.md).

## Tipo de mudança
- [ ] Nova funcionalidade / pipeline
- [ ] Correção de bug ou inconsistência de dados
- [ ] Refatoração de modelo DBT
- [ ] Documentação
- [x] Infraestrutura / CI
- [ ] Outro: ___

## Issues relacionadas
Closes #385

## Domínio de revisão

- [x] GCES / OSS
- [ ] IPEA
- [ ] MIR
- [ ] MCid
- [ ] MinC
- [x] OSS
- [ ] Múltiplos domínios: ___

## Como testar / validar

Validação local executada:

```bash
python3 -c 'import yaml, sys; yaml.safe_load(open(sys.argv[1])); print("yaml ok")' .github/workflows/diagnose-rebase-pr.yaml

awk 'found { if ($0 ~ /^          /) print substr($0, 11); else if ($0 !~ /^$/) found=0 } /run: \|/ { found=1 }' .github/workflows/diagnose-rebase-pr.yaml \
  | sed 's/${{[^}][^}]*}}/0/g' \
  | bash -n
```

Validação no GitHub Actions:

```bash
gh workflow run diagnose-rebase-pr.yaml \
  --repo GovHub-br/data-application-gov-hub \
  --ref fix/diagnostico_prs_com_action \
  -f pr_number=345 \
  -f old_main_ref=pre-rewrite-main \
  -f comment_normal_prs=false \
  -f max_prs=100
```

Após os ajustes, a action conseguiu concluir o diagnóstico e publicar o comentário esperado no PR.

## Evidências

- Commits da correção na branch:

```text
6d48b54 fix: Para de usar GraphQL e usa método POST da API para fazer os comentários
70cee57 fix: Ajusta permisão de escrita no PR´s
```

- Erro anterior observado ao usar `gh pr comment`:

```text
GraphQL: Resource not accessible by integration (addComment)
```

- Erro observado depois da troca para REST, ainda sem permissão de escrita em pull requests:

```text
gh: Resource not accessible by integration (HTTP 403)
```

- Permissões anteriores do token no log:

```text
Contents: read
Issues: write
PullRequests: read
```

- Permissões ajustadas no workflow:

```yaml
permissions:
  contents: read
  pull-requests: write
  issues: write
```

- O workflow continua sem executar código dos PRs; ele apenas consulta metadados, commits e diffs para gerar diagnóstico e comentário, como demonstrado na imagem abaixo.

<img width="1890" height="853" alt="Comentário automático de diagnóstico de rebase em PR" src="https://github.com/user-attachments/assets/e459b8d5-0380-42e5-b436-196e1858afc7" />

- No [PR 345](https://github.com/GovHub-br/data-application-gov-hub/pull/345), é possível identificar a divergência de histórico causada pelos ajustes na `main`. Após as correções deste PR, o bot do GitHub publicou o comentário com o diagnóstico e a receita sugerida para ajustar a branch.

## Checklist
- [x] Título do PR segue Conventional Commits
- [x] Issue relacionada foi referenciada
- [x] Testes/lint foram executados ou a ausência foi justificada
- [ ] Testes DBT adicionados/atualizados, se aplicável
- [x] Documentação atualizada, se aplicável
- [x] Sem dados sensíveis ou credenciais no código
- [x] Branch atualizada com `upstream/main` ou `origin/main`
- [x] Revisores automáticos por domínio foram solicitados pelo GitHub ou justificados no PR