### PR TITLE
feat(dou): implementa cliente HTTP e DAG de ingestão da Seção 1 do DOU

### DIFF
--- a/airflow_lappis/dags/data_ingest/dou/__init__.py
+++ b/airflow_lappis/dags/data_ingest/dou/__init__.py
@@ -1,0 +1,1 @@
+# DAG package for DOU ingestion pipelines

--- a/airflow_lappis/dags/data_ingest/dou/secao1_ingest_dag.py
+++ b/airflow_lappis/dags/data_ingest/dou/secao1_ingest_dag.py
@@ -1,0 +1,170 @@
+import logging
+from datetime import date, datetime, timedelta
+from typing import Any, Dict
+
+from airflow.decorators import dag, task
+from airflow.models import Variable
+from airflow.models.param import Param
+
+from cliente_dou import ClienteDou
+from cliente_postgres import ClientPostgresDB
+from postgres_helpers import get_postgres_conn
+from schedule_loader import get_dynamic_schedule
+
+logger = logging.getLogger(__name__)
+
+# Constantes
+
+SCHEMA = "dou"
+TABLE = "secao1"
+CONFLICT_FIELDS = ["urlTitle", "pubDate"]
+# Nome da Variable Airflow que contém os órgãos monitorados.
+VARIABLE_ORGAOS = "dou_orgaos_monitorados"
+
+
+# DAG
+
+@dag(
+    dag_id="dag_dou_secao_1",
+    schedule_interval=get_dynamic_schedule("dag_dou_secao_1", default="0 6 * * 1-5"),
+    start_date=datetime(2024, 1, 1),
+    catchup=False,
+    default_args={
+        "owner": "Rafael, Letícia",
+        "retries": 1,
+        "retry_delay": timedelta(minutes=1),
+    },
+    params={
+        "data_inicio": Param(
+            default=None,
+            type=["string", "null"],
+            title="Data de Início",
+            description=(
+                "Backfill: data inicial da busca no formato DD/MM/AAAA. "
+                "Se não preenchido, usa a data de hoje."
+            ),
+        ),
+        "data_fim": Param(
+            default=None,
+            type=["string", "null"],
+            title="Data de Fim",
+            description=(
+                "Backfill: data final da busca no formato DD/MM/AAAA. "
+                "Se não preenchido, usa a data de hoje."
+            ),
+        ),
+    },
+    tags=["dou", "secao1", "diario_oficial"],
+)
+def dag_dou_secao_1() -> None:
+    """DAG de ingestão das publicações da Seção 1 do DOU.
+
+    Executa de segunda a sexta-feira às 06h (horário de Brasília).
+    Suporta backfill via formulário na UI do Airflow usando os parâmetros
+    ``data_inicio`` e ``data_fim`` (formato DD/MM/AAAA).
+
+    Os dados são gravados em ``dou.secao1`` no PostgreSQL com deduplicação
+    pela chave composta (urlTitle, pubDate).
+    """
+
+    @task
+    def buscar_e_inserir_secao1(**context: Dict[str, Any]) -> None:
+        params = context["params"]
+        data_inicio_str: str | None = params.get("data_inicio")
+        data_fim_str: str | None = params.get("data_fim")
+
+        # Se não informado via Param, usa a data de hoje
+        hoje = date.today()
+        formato_dou = "%d/%m/%Y"
+
+        if data_inicio_str:
+            data_inicio = datetime.strptime(data_inicio_str, formato_dou).date()
+        else:
+            data_inicio = hoje
+
+        if data_fim_str:
+            data_fim = datetime.strptime(data_fim_str, formato_dou).date()
+        else:
+            data_fim = hoje
+
+        if data_fim < data_inicio:
+            raise ValueError(
+                f"data_fim ({data_fim}) não pode ser anterior a data_inicio ({data_inicio})."
+            )
+
+        # Termos/órgãos monitorados vindos da Variable Airflow.
+        # Formato esperado: texto simples, um órgão por linha.
+        orgaos_raw: str = Variable.get(VARIABLE_ORGAOS, default_var="")
+        orgaos: list[str] = [
+            linha.strip().strip('"')
+            for linha in orgaos_raw.splitlines()
+            if linha.strip()
+        ]
+
+        if not orgaos:
+            logger.warning(
+                "[dag_dou_secao_1] Nenhum órgão configurado na variável '%s'. "
+                "Abortando sem inserções.",
+                VARIABLE_ORGAOS,
+            )
+            return
+
+        cliente = ClienteDou()
+        postgres_conn_str = get_postgres_conn()
+        db = ClientPostgresDB(postgres_conn_str)
+
+        # Itera por cada dia do intervalo
+        delta_dias = (data_fim - data_inicio).days
+        datas = [
+            (data_inicio + timedelta(days=d)).strftime(formato_dou)
+            for d in range(delta_dias + 1)
+        ]
+
+        total_inserido = 0
+
+        for data_str in datas:
+            logger.info(
+                "[dag_dou_secao_1] Buscando Seção 1 do DOU para data: %s", data_str
+            )
+
+            publicacoes = cliente.buscar_todas_publicacoes(
+                termos=orgaos,
+                data=data_str,
+                secao=1,
+            )
+
+            if not publicacoes:
+                logger.info(
+                    "[dag_dou_secao_1] Nenhuma publicação encontrada para %s.", data_str
+                )
+                continue
+
+            # Adiciona metadado de ingestão
+            for item in publicacoes:
+                item["dt_ingest"] = datetime.now().isoformat()
+
+            db.insert_data(
+                publicacoes,
+                table_name=TABLE,
+                conflict_fields=CONFLICT_FIELDS,
+                primary_key=CONFLICT_FIELDS,
+                schema=SCHEMA,
+            )
+            total_inserido += len(publicacoes)
+            logger.info(
+                "[dag_dou_secao_1] %d publicações inseridas em %s.%s para %s.",
+                len(publicacoes),
+                SCHEMA,
+                TABLE,
+                data_str,
+            )
+
+        logger.info(
+            "[dag_dou_secao_1] Ingestão concluída. Total inserido: %d registros.",
+            total_inserido,
+        )
+
+    buscar_e_inserir_secao1()
+
+
+dag_instance = dag_dou_secao_1()

--- a/airflow_lappis/plugins/cliente_dou.py
+++ b/airflow_lappis/plugins/cliente_dou.py
@@ -1,0 +1,193 @@
+import json
+import logging
+import re
+from http import HTTPMethod, HTTPStatus
+from typing import Optional
+
+import httpx
+
+from cliente_base import ClienteBase
+
+logger = logging.getLogger(__name__)
+
+# ID da tag <script> que contém o JSON embutido na resposta HTML do DOU
+_SCRIPT_ID = "_br_com_seatecnologia_in_buscadou_BuscaDouPortlet_params"
+_JSON_PATTERN = re.compile(
+    rf'<script[^>]+id="{re.escape(_SCRIPT_ID)}"[^>]*>(.*?)</script>',
+    re.DOTALL,
+)
+
+
+class ClienteDou(ClienteBase):
+    """Cliente HTTP para o portal do Diário Oficial da União (DOU).
+
+    Faz requisições GET ao endpoint de busca do DOU, extrai o bloco JSON
+    embutido no HTML retornado e suporta paginação automática.
+    """
+
+    BASE_URL = "https://www.in.gov.br"
+    ENDPOINT = "/consulta/-/buscar/dou"
+    DEFAULT_DELTA = 20  # registros por página
+
+    def __init__(self) -> None:
+        super().__init__(base_url=ClienteDou.BASE_URL)
+
+    # ------------------------------------------------------------------
+    # Helpers internos
+    # ------------------------------------------------------------------
+
+    def _formatar_query(self, termos: list[str]) -> str:
+        """Envolve cada termo em aspas duplas para forçar busca exata."""
+        return " ".join(f'"{termo}"' for termo in termos)
+
+    def _extrair_json_do_html(self, html: str) -> Optional[dict]:
+        """Extrai e decodifica o bloco JSON embutido na tag <script> do DOU."""
+        match = _JSON_PATTERN.search(html)
+        if not match:
+            logger.warning(
+                "[cliente_dou.py] Tag <script id=%s> não encontrada no HTML.",
+                _SCRIPT_ID,
+            )
+            return None
+        try:
+            return json.loads(match.group(1).strip())
+        except json.JSONDecodeError as exc:
+            logger.error(
+                "[cliente_dou.py] Falha ao decodificar JSON da tag <script>: %s", exc
+            )
+            return None
+
+    # ------------------------------------------------------------------
+    # Método principal de busca
+    # ------------------------------------------------------------------
+
+    def buscar_publicacoes(
+        self,
+        termos: list[str],
+        data: str,
+        secao: int = 1,
+        pagina: int = 1,
+        delta: int = DEFAULT_DELTA,
+    ) -> list[dict]:
+        """Busca publicações do DOU para os termos e data informados.
+
+        Args:
+            termos: Lista de termos a buscar. Cada um será envolvido em
+                    aspas duplas (busca exata).
+            data: Data de publicação no formato ``dd/mm/aaaa``.
+            secao: Seção do DOU (1, 2 ou 3). Padrão: 1.
+            pagina: Número da página (começa em 1).
+            delta: Quantidade de registros por página.
+
+        Returns:
+            Lista de dicts com os itens retornados pelo DOU.
+            Retorna lista vazia se não houver resultados ou em caso de erro.
+        """
+        query = self._formatar_query(termos)
+        params = {
+            "q": query,
+            "exactDate": data,
+            "secao": f"secao{secao}",
+            "currentPage": pagina,
+            "delta": delta,
+        }
+
+        logger.info(
+            "[cliente_dou.py] Buscando DOU | data=%s | secao=%s | pagina=%s | "
+            "termos=%s",
+            data,
+            secao,
+            pagina,
+            termos,
+        )
+
+        # O endpoint retorna HTML, portanto não podemos usar o método padrão
+        # `request()` da ClienteBase (que chama `.json()` no final).
+        # Fazemos a requisição diretamente via httpx, com o mecanismo de retry
+        # do ClienteBase inativo para essa chamada específica.
+        try:
+            response = self.client.request(
+                HTTPMethod.GET,
+                self.ENDPOINT,
+                params=params,
+                timeout=self.DEFAULT_TIMEOUT,
+            )
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            logger.error(
+                "[cliente_dou.py] Erro HTTP ao consultar o DOU: %s", exc
+            )
+            raise
+
+        # O DOU retorna HTML com o JSON embutido numa tag <script>
+        dados_json = self._extrair_json_do_html(response.text)
+        if dados_json is None:
+            return []
+
+        itens = dados_json.get("jsonArray", [])
+        if not isinstance(itens, list):
+            logger.warning(
+                "[cliente_dou.py] Campo 'jsonArray' não é uma lista: %s",
+                type(itens),
+            )
+            return []
+
+        logger.info(
+            "[cliente_dou.py] %d publicações encontradas (página %s).",
+            len(itens),
+            pagina,
+        )
+        return itens
+
+    def buscar_todas_publicacoes(
+        self,
+        termos: list[str],
+        data: str,
+        secao: int = 1,
+        delta: int = DEFAULT_DELTA,
+    ) -> list[dict]:
+        """Itera por todas as páginas e retorna a lista completa de publicações.
+
+        Args:
+            termos: Lista de termos a buscar (busca exata com aspas duplas).
+            data: Data de publicação no formato ``dd/mm/aaaa``.
+            secao: Seção do DOU (1, 2 ou 3). Padrão: 1.
+            delta: Registros por página.
+
+        Returns:
+            Lista consolidada com todos os registros de todas as páginas.
+        """
+        todas: list[dict] = []
+        pagina = 1
+
+        while True:
+            itens = self.buscar_publicacoes(
+                termos=termos,
+                data=data,
+                secao=secao,
+                pagina=pagina,
+                delta=delta,
+            )
+            if not itens:
+                logger.info(
+                    "[cliente_dou.py] Paginação encerrada na página %s "
+                    "(sem mais resultados).",
+                    pagina,
+                )
+                break
+
+            todas.extend(itens)
+
+            if len(itens) < delta:
+                logger.info(
+                    "[cliente_dou.py] Última página alcançada (página %s).",
+                    pagina,
+                )
+                break
+
+            pagina += 1
+
+        logger.info(
+            "[cliente_dou.py] Total de publicações coletadas: %d.", len(todas)
+        )
+        return todas


### PR DESCRIPTION
> [!CAUTION]
> **WIP — Não revisar ainda.**
> A validação da DAG está pendente: o portal `https://www.in.gov.br/consulta/-/buscar/dou`
> está fora do ar no momento. O PR será movido para revisão assim que o site voltar
> e os testes forem executados.

## Descrição
Implementa a primeira pipeline de ingestão do Diário Oficial da União (DOU) — **Seção 1**.
Cria o `cliente_dou.py`, cliente HTTP que faz requisições GET ao portal oficial
(`https://www.in.gov.br/consulta/-/buscar/dou`), extrai o bloco JSON embutido na tag
`<script id="_br_com_seatecnologia_in_buscadou_BuscaDouPortlet_params">` do HTML retornado,
força busca exata envolvendo os termos em aspas duplas e suporta paginação automática.
Cria também a DAG `dag_dou_secao_1`, agendada para rodar de segunda a sexta às 06h, com
formulário de backfill via `Param` (`data_inicio` / `data_fim`) e gravação no PostgreSQL
no schema `dou`, tabela `secao1`, com deduplicação por `(urlTitle, pubDate)`.

> Antes de abrir este PR, consulte o [Protocolo de Aprovação de Pull Requests](https://github.com/GovHub-br/data-application-gov-hub/blob/main/.github/MERGE_REQUEST_PROTOCOL.md).

## Tipo de mudança
- [x] Nova funcionalidade / pipeline
- [ ] Correção de bug ou inconsistência de dados
- [ ] Refatoração de modelo DBT
- [ ] Documentação
- [ ] Infraestrutura / CI
- [ ] Outro: ___

## Issues relacionadas
Closes #289 

## Domínio de revisão
<!-- Marque o domínio/time principal impactado por este PR. Use labels team:* quando ajudar na triagem. -->

- [ ] GCES / OSS
- [ ] IPEA
- [ ] MIR
- [ ] MCid
- [ ] MinC
- [x] OSS
- [ ] Múltiplos domínios: ___

## Como testar / validar

```bash
# Exemplo: ajuste conforme o tipo de mudança

# Para DAGs
airflow dags test dag_dou_secao_1 2025-01-01

```

## Evidências
<!-- Prints, logs, resultados de query ou link de documentação -->

## Checklist
- [x] Título do PR segue Conventional Commits
- [x] Issue relacionada foi referenciada
- [ ] Testes/lint foram executados ou a ausência foi justificada
- [ ] Testes DBT adicionados/atualizados, se aplicável
- [ ] Documentação atualizada, se aplicável
- [x] Sem dados sensíveis ou credenciais no código
- [x] Branch atualizada com `upstream/main` ou `origin/main`
- [ ] Revisores automáticos por domínio foram solicitados pelo GitHub ou justificados no PR
