### PR TITLE
chore(makefile): adiciona UGs do MIR às airflow_variables locais

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ dev:
 	@echo "Aguardando Airflow/DB ficarem prontos..."
 	@docker compose exec -T $(AIRFLOW_SERVICE) sh -c 'for i in $$(seq 1 30); do airflow db init >/dev/null 2>&1 && exit 0; sleep 2; done; echo "Airflow DB não ficou pronto a tempo para inicializar."; exit 1'
 	@docker compose exec -T $(AIRFLOW_SERVICE) airflow variables set airflow_orgao '$(AIRFLOW_LOCAL_ORGAO)'
-	@docker compose exec -T $(AIRFLOW_SERVICE) airflow variables set airflow_variables '{"ipea":{"codigos_ug":[113601,113602]},"unb":{"codigos_ug":[154040]},"ibama":{"codigos_ug":[440001,440048,440050]},"mgi":{"codigos_ug":[201082]}}'
+	@docker compose exec -T $(AIRFLOW_SERVICE) airflow variables set airflow_variables '{"ipea":{"codigos_ug":[113601,113602]},"unb":{"codigos_ug":[154040]},"ibama":{"codigos_ug":[440001,440048,440050]},"mgi":{"codigos_ug":[201082]},"mir":{"codigos_ug":[230002,810008]}}'
 	@docker compose exec -T $(AIRFLOW_SERVICE) airflow variables set dynamic_schedules '{"empenhos_tesouro_ingest_dag":{"type":"cron","value":"0 13 * * 1-6"},"nc_tesouro_ingest_dag":{"type":"cron","value":"0 13 * * 1-6"},"pf_tesouro_ingest_dag":{"type":"cron","value":"0 13 * * 1-6"},"visao_orcamentaria_ingest":{"type":"cron","value":"0 13 * * 1-6"}}'
 	@docker compose exec -T $(AIRFLOW_SERVICE) sh -c "printf '%s\n' '{\"postgres_default\":{\"conn_type\":\"postgres\",\"host\":\"$(AIRFLOW_LOCAL_DB_HOST)\",\"schema\":\"$(AIRFLOW_LOCAL_DB_NAME)\",\"login\":\"$(AIRFLOW_LOCAL_DB_USER)\",\"password\":\"$(AIRFLOW_LOCAL_DB_PASSWORD)\",\"port\":$(AIRFLOW_LOCAL_DB_PORT)}}' > /tmp/airflow-connections.json && airflow connections import --overwrite /tmp/airflow-connections.json && rm -f /tmp/airflow-connections.json"
 	@echo "Ambiente local do Airflow configurado com sucesso."


### PR DESCRIPTION
## Descrição

Adiciona o órgão **MIR** à variável `airflow_variables` definida no target `dev` do `Makefile`, incluindo seus `codigos_ug` (`230002` e `810008`). Essa variável configura o ambiente local do Airflow (`make dev`) e antes contemplava apenas `ipea`, `unb`, `ibama` e `mgi`.

## Tipo de mudança
- [ ] Nova funcionalidade / pipeline
- [ ] Correção de bug ou inconsistência de dados
- [ ] Refatoração de modelo DBT
- [ ] Documentação
- [x] Infraestrutura / CI
- [ ] Outro: ___

## Issues relacionadas
Closes #468
## Domínio de revisão

- [ ] GCES / OSS
- [ ] IPEA
- [x] MIR
- [ ] MCid
- [ ] MinC
- [ ] OSS
- [ ] Múltiplos domínios: ___

## Como testar / validar

```bash
make dev
docker compose exec -T airflow airflow variables get airflow_variables
# deve retornar o JSON com a chave "mir": {"codigos_ug": [230002, 810008]}
```

## Checklist
- [x] Título do PR segue Conventional Commits
- [ ] Issue relacionada foi referenciada
- [x] Testes/lint foram executados ou a ausência foi justificada
- [ ] Testes DBT adicionados/atualizados, se aplicável
- [ ] Documentação atualizada, se aplicável
- [x] Sem dados sensíveis ou credenciais no código
- [x] Branch atualizada com `origin/main`

