### PR TITLE
feat: adiciona controle de acesso readonly 

### DIFF
--- a/Dockerfile.superset
+++ b/Dockerfile.superset
@@ -9,4 +9,7 @@ RUN /usr/local/bin/python -m pip install psycopg2-binary --target /app/.venv/lib
 # Install other useful database drivers for future use
 RUN /usr/local/bin/python -m pip install pymysql --target /app/.venv/lib/python3.10/site-packages/
 
+COPY superset/superset_config.py /app/pythonpath/superset_config.py
+COPY superset/superset_db_dialects.py /app/pythonpath/superset_db_dialects.py
+
 USER superset

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,15 @@ test-integration:
 compose:
 	@echo "Iniciando ambiente local do Airflow com Docker Compose..."
 	docker compose up -d --build
+	$(MAKE) setup-roles
 	$(MAKE) dev
 	$(MAKE) dev-check
+
+setup-roles:
+	@echo "Garantindo roles do Postgres (role somente leitura)..."
+	@for i in $$(seq 1 30); do docker compose exec -T postgres pg_isready -U postgres >/dev/null 2>&1 && break; sleep 2; done
+	@docker compose exec -T postgres bash /docker-entrypoint-initdb.d/setup_roles.sh
+	@echo "Role somente-leitura pronta."
 
 dev:
 	@docker compose ps --status running $(AIRFLOW_SERVICE) >/dev/null 2>&1 || (echo "Serviço '$(AIRFLOW_SERVICE)' não está em execução. Rode: docker compose up -d" && exit 1)

--- a/airflow_lappis/dags/dbt/ipea/dbt_project.yml
+++ b/airflow_lappis/dags/dbt/ipea/dbt_project.yml
@@ -28,21 +28,53 @@ models:
       +schema: contratos
       bronze:
         +materialized: incremental
+        +grants:
+          select: []
+      silver:
+        +grants:
+          select: ["{{ env_var('DB_DW_READONLY_ROLE', 'de_postgres') }}"]
+      gold:
+        +grants:
+          select: ["{{ env_var('DB_DW_READONLY_ROLE', 'de_postgres') }}"]
       views:
         +materialized: view
     pessoas_dbt:
       +materialized: table
       +schema: pessoas
+      bronze:
+        +grants:
+          select: []
+      silver:
+        +grants:
+          select: ["{{ env_var('DB_DW_READONLY_ROLE', 'de_postgres') }}"]
+      gold:
+        +grants:
+          select: ["{{ env_var('DB_DW_READONLY_ROLE', 'de_postgres') }}"]
       views:
         +materialized: view
     ted_dbt:
       +materialized: table
       +schema: ted
+      bronze:
+        +grants:
+          select: []
+      silver:
+        +grants:
+          select: ["{{ env_var('DB_DW_READONLY_ROLE', 'de_postgres') }}"]
+      gold:
+        +grants:
+          select: ["{{ env_var('DB_DW_READONLY_ROLE', 'de_postgres') }}"]
       views:
         +materialized: view
     orcamento_dbt:
       +materialized: table
       +schema: orcamento
+      bronze:
+        +grants:
+          select: []
+      silver:
+        +grants:
+          select: ["{{ env_var('DB_DW_READONLY_ROLE', 'de_postgres') }}"]
       views:
         +materialized: view
     sistema_sisbolsas:
@@ -50,6 +82,14 @@ models:
       +schema: sistema_sisbolsas
       bronze:
         +materialized: table
+        +grants:
+          select: []
+      silver:
+        +grants:
+          select: ["{{ env_var('DB_DW_READONLY_ROLE', 'de_postgres') }}"]
+      gold:
+        +grants:
+          select: ["{{ env_var('DB_DW_READONLY_ROLE', 'de_postgres') }}"]
     # siape_dbt: 
     #   +materialized: table 
     #   +schema: siape 
@@ -59,3 +99,4 @@ models:
 
 on-run-start:
   - '{{create_udfs()}}'
+  - '{{conceder_usage_dinamico()}}'

--- a/airflow_lappis/dags/dbt/ipea/macros/conceder_usage_dinamico.sql
+++ b/airflow_lappis/dags/dbt/ipea/macros/conceder_usage_dinamico.sql
@@ -1,0 +1,48 @@
+{% macro conceder_usage_dinamico() %}
+{#
+    Concede USAGE no schema do role somente-leitura (de_postgres
+    via DB_DW_READONLY_ROLE) para todo schema que o próprio dbt gerencia.
+
+    Por que isso é seguro: USAGE só permite "entrar" no schema, não dá
+    SELECT em nada. Quem decide o que o role pode LER continua sendo só
+    o +grants de cada model (bronze: select: [], silver/gold: select:
+    [role]) -- dar USAGE largo aqui não expõe bronze em lugar nenhum,
+    nem na listagem via information_schema (que filtra por privilégio
+    de tabela, não de schema).
+
+    A lista de schemas vem do graph.nodes (os models reais do projeto),
+    não de uma lista fixa -- então um domínio novo já entra sozinho no
+    próximo dbt run, sem precisar editar esse arquivo.
+#}
+{% if execute %}
+    {% set role = env_var('DB_DW_READONLY_ROLE', 'de_postgres') %}
+    {% set schemas_configurados = graph.nodes.values()
+        | selectattr('resource_type', 'equalto', 'model')
+        | map(attribute='schema')
+        | unique
+        | list %}
+
+    {#
+        Nem todo schema declarado em +schema já existe de fato no banco
+        -- um domínio pode estar configurado no dbt_project.yml mas nunca
+        ter rodado com sucesso ainda (ex.: falta fonte de dado). Sem esse
+        filtro, o GRANT quebra o dbt run inteiro por causa de um schema
+        que nem foi criado.
+    #}
+    {% set schemas_existentes_query %}
+        select schema_name from information_schema.schemata
+        where schema_name in ({{ "'" ~ schemas_configurados | join("','") ~ "'" }})
+    {% endset %}
+    {% set resultado = run_query(schemas_existentes_query) %}
+    {% set schemas_existentes = resultado.columns[0].values() if resultado is not none else [] %}
+
+    {% for schema in schemas_configurados %}
+        {% if schema in schemas_existentes %}
+            {% do run_query('GRANT USAGE ON SCHEMA "' ~ schema ~ '" TO "' ~ role ~ '"') %}
+            {{ log("USAGE concedido em " ~ schema ~ " para " ~ role, info=true) }}
+        {% else %}
+            {{ log("Pulando " ~ schema ~ " -- schema ainda não existe no banco", info=true) }}
+        {% endif %}
+    {% endfor %}
+{% endif %}
+{% endmacro %}

--- a/docker/postgres/setup_roles.sh
+++ b/docker/postgres/setup_roles.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+# Role somente-leitura usado pelo +grants do dbt para
+# restringir bronze/silver/gold no Postgres local de desenvolvimento.
+
+# Nome e senha vêm do .env (DB_DW_READONLY_ROLE/DB_DW_READONLY_PASSWORD),
+
+DB_DW_READONLY_ROLE="${DB_DW_READONLY_ROLE:-de_postgres}"
+DB_DW_READONLY_PASSWORD="${DB_DW_READONLY_PASSWORD:-de_postgres}"
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+	DO \$\$
+	BEGIN
+	    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '${DB_DW_READONLY_ROLE}') THEN
+	        CREATE ROLE ${DB_DW_READONLY_ROLE} LOGIN PASSWORD '${DB_DW_READONLY_PASSWORD}';
+	    END IF;
+	END
+	\$\$;
+
+	GRANT CONNECT ON DATABASE ${POSTGRES_DB} TO ${DB_DW_READONLY_ROLE};
+EOSQL

--- a/local.env
+++ b/local.env
@@ -20,6 +20,11 @@ POSTGRES_USER_DW=postgres_dw
 POSTGRES_PASSWORD_DW=postgres_dw
 POSTGRES_DB_DW=data_warehouse
 
+# Role somente-leitura criado por docker/postgres/setup_roles.sh e usado
+# pelo +grants do dbt (bronze fica de fora, silver/gold liberado).
+DB_DW_READONLY_ROLE=de_postgres
+DB_DW_READONLY_PASSWORD=de_postgres
+
 
 # <---------- MinIO ---------->
 MINIO_ENDPOINT=http://minio:9000

--- a/superset/superset_config.py
+++ b/superset/superset_config.py
@@ -1,0 +1,5 @@
+import superset_db_dialects  
+
+FEATURE_FLAGS = {
+    "DASHBOARD_RBAC": True,
+}

--- a/superset/superset_db_dialects.py
+++ b/superset/superset_db_dialects.py
@@ -1,0 +1,72 @@
+"""SQLAlchemy dialect that makes Postgres schema/table reflection grant-aware.
+
+Superset's "+ Dataset" table picker and the SQL Lab schema/table dropdown use
+SQLAlchemy's ``get_schema_names``/``get_table_names``/``get_view_names``. The
+stock Postgres dialect implements these by querying ``pg_catalog`` directly
+(``pg_namespace``/``pg_class``), which Postgres exposes to every authenticated
+role regardless of GRANT/REVOKE. In practice this means a read-only role with
+zero privilege on a schema (e.g. a "bronze" layer revoked via dbt's
+``+grants``) still shows up as a browsable option in Superset, even though any
+actual SELECT against it fails.
+
+``information_schema.tables``/``information_schema.schemata`` are already
+privilege-aware in Postgres (they only list objects the connected role has
+some privilege on), so swapping the reflection queries to use them makes the
+picker match reality automatically -- no manual Superset permission upkeep
+per table, it just tracks whatever dbt's ``+grants`` currently allow.
+
+Usage: register once (done at import time below) and point a Superset
+database connection's SQLAlchemy URI at ``postgresql+infoschema://...``
+instead of ``postgresql+psycopg2://...``. Only apply this to connections
+where you want browsing restricted to granted objects (e.g. the read-only
+"user" connection) -- the admin/owner connection can keep the default driver.
+"""
+
+from sqlalchemy import sql
+from sqlalchemy.dialects import registry
+from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
+from sqlalchemy.engine import reflection
+
+
+class PGDialectInfoSchema(PGDialect_psycopg2):
+    """Postgres dialect where schema/table/view listing honors GRANT/REVOKE."""
+
+    @reflection.cache
+    def get_schema_names(self, connection, **kw):
+        result = connection.execute(
+            sql.text(
+                "SELECT schema_name FROM information_schema.schemata "
+                "WHERE schema_name NOT IN ('pg_catalog', 'information_schema') "
+                "ORDER BY schema_name"
+            )
+        )
+        return [name for name, in result]
+
+    @reflection.cache
+    def get_table_names(self, connection, schema=None, **kw):
+        result = connection.execute(
+            sql.text(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = :schema AND table_type = 'BASE TABLE' "
+                "ORDER BY table_name"
+            ),
+            {"schema": schema or self.default_schema_name},
+        )
+        return [name for name, in result]
+
+    @reflection.cache
+    def get_view_names(self, connection, schema=None, **kw):
+        result = connection.execute(
+            sql.text(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = :schema AND table_type = 'VIEW' "
+                "ORDER BY table_name"
+            ),
+            {"schema": schema or self.default_schema_name},
+        )
+        return [name for name, in result]
+
+
+registry.register(
+    "postgresql.infoschema", "superset_db_dialects", "PGDialectInfoSchema"
+)


### PR DESCRIPTION
## Descrição
Este PR adiciona um sistema de controle de acesso somente-leitura (RO) no banco de dados, com o objetivo de limitar quais tabelas um usuário do Superset consegue ver (inclusive na listagem de schema/tabela usada ao criar um chart/dataset) — não só o dado em si, mas a própria visibilidade da tabela.

## O que foi adicionado

**1. `+grants` no `dbt_project.yml`** — revoga `SELECT` de bronze e concede só pra silver/gold, pro role somente-leitura declarado em `DB_DW_READONLY_ROLE`:

```yaml
bronze:
  +grants:
    select: []
silver:
  +grants:
    select: ["{{ env_var('DB_DW_READONLY_ROLE', 'de_postgres') }}"]
gold:
  +grants:
    select: ["{{ env_var('DB_DW_READONLY_ROLE', 'de_postgres') }}"]
```

**2. O problema que o `+grants` sozinho não resolve, e a solução** — o `+grants` revoga o `SELECT`, mas não impede a tabela de aparecer listada no seletor do Superset. Isso acontece porque a conexão via `psycopg2` reflete schema/tabela consultando o `pg_catalog` do Postgres, que não é filtrado por privilégio — qualquer role autenticado consegue ver que a tabela existe, mesmo sem `SELECT` nela.

A solução foi criar um dialect customizado do SQLAlchemy que troca essa consulta de `pg_catalog` para `information_schema`. O `information_schema` já tem, na própria definição das suas views, uma cláusula `WHERE` que verifica o privilégio real do role conectado (`has_table_privilege`/`has_schema_privilege`) — como o usuário RO tem `SELECT` revogado em bronze, essas tabelas somem da listagem também, não só da leitura de dado.

Arquivos alterados por conta disso:
*   **`superset/superset_db_dialects.py`** (novo) — dialect customizado (`postgresql+infoschema`), que herda do dialect padrão do Postgres e sobrescreve só a listagem de schema/tabela/view.
*   **`superset/superset_config.py`** — importa o arquivo acima (é isso que registra o dialect no Superset).
*   **`Dockerfile.superset`** — copia os dois arquivos pra dentro da imagem do Superset.

**3. Criação automática do role RO (`docker/postgres/setup_roles.sh`)** — se o role declarado em `DB_DW_READONLY_ROLE` não existir no Postgres, o `+grants` (que faz `GRANT`/`REVOKE` pra esse role a cada model materializado) falha, e isso derruba o `dbt run` inteiro, não só aquele model. Pra garantir que esse role sempre exista antes do dbt rodar, foi criado este script, idempotente, executado automaticamente na subida do ambiente (e também via `make setup-roles` para ambientes que já existiam antes dessa mudança):

```bash
#!/bin/bash
set -e

DB_DW_READONLY_ROLE="${DB_DW_READONLY_ROLE:-de_postgres}"
DB_DW_READONLY_PASSWORD="${DB_DW_READONLY_PASSWORD:-de_postgres}"

psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
	DO \$\$
	BEGIN
	    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '${DB_DW_READONLY_ROLE}') THEN
	        CREATE ROLE ${DB_DW_READONLY_ROLE} LOGIN PASSWORD '${DB_DW_READONLY_PASSWORD}';
	    END IF;
	END
	\$\$;

	GRANT CONNECT ON DATABASE ${POSTGRES_DB} TO ${DB_DW_READONLY_ROLE};
EOSQL
```

**4. `USAGE` automático em schema novo (`macros/conceder_usage_dinamico.sql`)** — o `+grants` do dbt só cuida de `SELECT` por tabela; `USAGE` no schema (pré-requisito pra qualquer `SELECT` funcionar) o dbt nunca concede sozinho. Essa macro, rodada em todo `dbt run` via `on-run-start`, concede `USAGE` automaticamente pro role RO em todo schema que o próprio dbt gerencia — sem lista fixa, então um domínio novo já é coberto no próximo run, sem precisar editar nada.

**5. `local.env`** — adicionadas `DB_DW_READONLY_ROLE`/`DB_DW_READONLY_PASSWORD`, lidas tanto pelo `dbt_project.yml`/macro quanto pelo `setup_roles.sh` — um lugar só pra configurar nome/senha do role RO.

## Tipo de mudança
- [ ] Nova funcionalidade / pipeline
- [ ] Correção de bug ou inconsistência de dados
- [ ] Refatoração de modelo DBT
- [ ] Documentação
- [ ] Infraestrutura / CI
- [ ] Outro: ___

## Issues relacionadas
Closes #

## Domínio de revisão
- [x] IPEA
- [ ] GCES / OSS
- [ ] MIR
- [ ] MCid
- [ ] MinC
- [ ] OSS
- [ ] Múltiplos domínios: ___

## Como testar / validar

```bash
# Sobe o ambiente do zero (cria o role RO automaticamente)
make compose

# Confirma que o grant bloqueia bronze e libera silver/gold
docker compose exec -T postgres psql -U postgres -d postgres -c   "select has_table_privilege('de_postgres','ted.bolsas_pagas','SELECT');"   # esperado: f
docker compose exec -T postgres psql -U postgres -d postgres -c   "select has_table_privilege('de_postgres','ted.pf_plano_acao','SELECT');"  # esperado: t

# Dispara o dbt e confirma que a macro de USAGE roda sem quebrar o run
cd airflow_lappis/dags/dbt/ipea
dbt run --select <nome_do_modelo>

# No Superset, compara a listagem de tabelas nas duas conexões do usuário RO:
# - postgresql+psycopg2://   -> lista tabelas bronze
# - postgresql+infoschema:// -> não lista tabelas bronze
```

## Evidências
Com a conexão feita via psycopg2 o usuário poderia listar todos os schemas porque ele puxaria os dados do pg_catalog como visto na imagem:
<img width="402" height="583" alt="image" src="https://github.com/user-attachments/assets/9327d58d-f350-4bf1-87a6-2588d8d5d176" />

Com a conexão feito via infoschema ele pode listar apenas aquelas tabelas que ele tem permissão de USAGE no schema  e permissão de select naquela tabela:
Visualização dos schemas:
<img width="402" height="583" alt="image" src="https://github.com/user-attachments/assets/e9061c93-853a-4a74-9af3-2fac06738c35" />

Visualização das tabelas:
<img width="410" height="619" alt="image" src="https://github.com/user-attachments/assets/c2e6ecc4-8874-4294-a7d9-098ce50c486e" />

Como mostrado acima o usuário não tem visualização nas tabelas bronze. Ex: bolsas_pagas



## Checklist
- [ ] Título do PR segue Conventional Commits
- [ ] Issue relacionada foi referenciada
- [ ] Testes/lint foram executados ou a ausência foi justificada
- [ ] Testes DBT adicionados/atualizados, se aplicável
- [ ] Documentação atualizada, se aplicável
- [ ] Sem dados sensíveis ou credenciais no código
- [ ] Branch atualizada com `upstream/main` ou `origin/main`
- [ ] Revisores automáticos por domínio foram solicitados pelo GitHub ou justificados no PR