### PR TITLE
fix(deps): limita universal-pathlib a <0.2 para o airflow inicializar

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,10 @@ dependencies = [
     "s3fs",
     "boto3",
     "adlfs",
+    # O Airflow 2.8.1 declara universal-pathlib>=0.1.4 sem limite superior, mas
+    # importa `_CloudAccessor`, símbolo removido na versão 0.2. Sem este teto o
+    # resolver sobe para 0.3.x e o Airflow não inicializa.
+    "universal-pathlib>=0.1.4,<0.2",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,6 @@ dependencies = [
     "s3fs",
     "boto3",
     "adlfs",
-    # O Airflow 2.8.1 declara universal-pathlib>=0.1.4 sem limite superior, mas
-    # importa `_CloudAccessor`, símbolo removido na versão 0.2. Sem este teto o
-    # resolver sobe para 0.3.x e o Airflow não inicializa.
     "universal-pathlib>=0.1.4,<0.2",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -183,7 +183,6 @@ pandas==3.0.5
 pandocfilters==1.5.1
 parsedatetime==2.6
 parso==0.8.7
-pathlib-abc==0.5.2
 pathspec==1.0.4
 pendulum==3.2.0
 pexpect==4.9.0 ; sys_platform != 'emscripten' and sys_platform != 'win32'
@@ -266,7 +265,7 @@ typing-inspection==0.4.2
 tzdata==2026.3
 uc-micro-py==2.0.0
 unicodecsv==0.14.1
-universal-pathlib==0.3.10
+universal-pathlib==0.1.4
 uri-template==1.3.0
 urllib3==2.7.0
 virtualenv==21.7.0

--- a/uv.lock
+++ b/uv.lock
@@ -1964,6 +1964,7 @@ dependencies = [
     { name = "requests" },
     { name = "s3fs" },
     { name = "sqlalchemy" },
+    { name = "universal-pathlib" },
     { name = "zeep" },
 ]
 
@@ -2002,6 +2003,7 @@ requires-dist = [
     { name = "requests" },
     { name = "s3fs" },
     { name = "sqlalchemy" },
+    { name = "universal-pathlib", specifier = ">=0.1.4,<0.2" },
     { name = "zeep" },
 ]
 
@@ -2768,15 +2770,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pathlib-abc"
-version = "0.5.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/cb/448649d7f25d228bf0be3a04590ab7afa77f15e056f8fa976ed05ec9a78f/pathlib_abc-0.5.2.tar.gz", hash = "sha256:fcd56f147234645e2c59c7ae22808b34c364bb231f685ddd9f96885aed78a94c", size = 33342, upload-time = "2025-10-10T18:37:20.524Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/29/c028a0731e202035f0e2e0bfbf1a3e46ad6c628cbb17f6f1cc9eea5d9ff1/pathlib_abc-0.5.2-py3-none-any.whl", hash = "sha256:4c9d94cf1b23af417ce7c0417b43333b06a106c01000b286c99de230d95eefbb", size = 19070, upload-time = "2025-10-10T18:37:19.437Z" },
-]
-
-[[package]]
 name = "pathspec"
 version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2820,7 +2813,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3898,15 +3891,14 @@ sdist = { url = "https://files.pythonhosted.org/packages/6f/a4/691ab63b17505a260
 
 [[package]]
 name = "universal-pathlib"
-version = "0.3.10"
+version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fsspec" },
-    { name = "pathlib-abc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/6e/d997a70ee8f4c61f9a7e2f4f8af721cf072a3326848fc881b05187e52558/universal_pathlib-0.3.10.tar.gz", hash = "sha256:4487cbc90730a48cfb64f811d99e14b6faed6d738420cd5f93f59f48e6930bfb", size = 261110, upload-time = "2026-02-22T14:40:58.87Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/3a/569483e8790a1673f3dfbb51bdf02803707184f4a47c9ac834e5f943c56b/universal_pathlib-0.1.4.tar.gz", hash = "sha256:82e5d86d16a27e0ea1adc7d88acbcba9d02d5a45488163174f96d9ac289db2e4", size = 131349, upload-time = "2023-10-19T20:19:06.966Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/1a/5d9a402b39ec892d856bbdd9db502ff73ce28cdf4aff72eb1ce1d6843506/universal_pathlib-0.3.10-py3-none-any.whl", hash = "sha256:dfaf2fb35683d2eb1287a3ed7b215e4d6016aa6eaf339c607023d22f90821c66", size = 83528, upload-time = "2026-02-22T14:40:57.316Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6e/b726049020b66bf69b1b695b75a3d585e28f444b7259fab9be193de97b2c/universal_pathlib-0.1.4-py3-none-any.whl", hash = "sha256:f99186cf950bde1262de9a590bb019613ef84f9fabd9f276e8b019722201943a", size = 20558, upload-time = "2023-10-19T20:19:05.739Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Descrição

A partir de um clone limpo do `main`, o container do Airflow não inicializa: ele entra em crash-loop e nunca fica `healthy`. O ambiente local (`.venv`) sofre da mesma falha — `import cosmos` quebra.

O `apache-airflow==2.8.1` declara `universal-pathlib>=0.1.4` **sem limite superior**, mas o seu módulo `airflow/io/path.py` importa `_CloudAccessor`, símbolo removido na versão 0.2 do `universal-pathlib`. Sem teto, o resolver do `uv` seleciona a versão mais recente (0.3.10) e o Airflow deixa de subir:

```
File ".../airflow/io/path.py", line 29, in <module>
    from upath.implementations.cloud import CloudPath, _CloudAccessor
ImportError: cannot import name '_CloudAccessor' from 'upath.implementations.cloud'
```

Como a versão quebrada está fixada no `uv.lock` e no `requirements.txt` versionados, a falha é determinística para qualquer pessoa que clone o repositório.

Este PR declara a restrição explicitamente em `pyproject.toml` e regenera os artefatos derivados. A faixa `<0.2` corresponde ao pin do arquivo de constraints oficial do Airflow 2.8.1 (`constraints-3.11.txt`, que fixa `universal-pathlib==0.1.4`).

A re-resolução é cirúrgica — apenas `universal-pathlib` (0.3.10 → 0.1.4) e a remoção de `pathlib-abc` (dependência exclusiva do upath 0.3.x). Nenhum outro pacote é afetado.

> Antes de abrir este PR, consulte o [Protocolo de Aprovação de Pull Requests](https://github.com/GovHub-br/data-application-gov-hub/blob/main/.github/MERGE_REQUEST_PROTOCOL.md).

## Tipo de mudança
- [ ] Nova funcionalidade / pipeline
- [x] Correção de bug ou inconsistência de dados
- [ ] Refatoração de modelo DBT
- [ ] Documentação
- [ ] Infraestrutura / CI
- [ ] Outro: ___

## Issues relacionadas
Closes #487

## Domínio de revisão

- [ ] GCES / OSS
- [ ] IPEA
- [ ] MIR
- [ ] MCid
- [ ] MinC
- [x] OSS
- [ ] Múltiplos domínios: ___

## Como testar / validar

```bash
# Ambiente local
make setup
make lint
make test

# Stack completa
docker compose up -d --build
docker compose ps          # airflow deve chegar a healthy

# DAGs carregam sem erro
docker compose exec airflow airflow dags list-import-errors

# Execução ponta a ponta
make dev
docker compose exec airflow airflow dags test test_source_ingest_dag 2026-08-31
```

## Evidências

**Antes** — o serviço alterna entre `starting` e `unhealthy` indefinidamente. Como o `docker-compose.yml` define `restart: always`, o `docker compose ps` nunca reporta falha explícita; é preciso ler os logs para descobrir o `ImportError` acima.

**Depois** — validado em clone limpo com a stack completa:

```
$ docker compose ps
airflow    Up (healthy)
jupyter    Up (healthy)
minio      Up (healthy)
postgres   Up (healthy)
superset   Up (healthy)

$ docker compose exec airflow python -c "import upath, cosmos; print(upath.__version__, cosmos.__version__)"
0.1.4 1.13.1

$ docker compose exec airflow airflow dags list-import-errors
No data found                      # 53 DAGs carregadas

$ make dev-check
Validação concluída: variables e connection do Airflow estão configuradas.

$ docker compose exec airflow airflow dags test test_source_ingest_dag 2026-08-31
Marking task as SUCCESS. dag_id=test_source_ingest_dag, task_id=extract_and_store
DagRun Finished: ... state=success

$ mc ls -r local/data-lake-ipea
[2026-09-01 13:32:50 UTC] 2.8KiB test_source/entities/2026/08/30/7d635aaa.parquet
```

Qualidade de código:

```
$ make lint
black: 96 files would be left unchanged
ruff: All checks passed!
ty: All checks passed!

$ make test
80 passed in 2.64s
```

## Observação para os mantenedores

O workflow `Python CI/CD` executa `docker build`, mas nunca **sobe** o container; e os testes unitários não exercitam `cosmos` nem `airflow.io.path`. Por isso o CI permaneceu verde enquanto o ambiente estava quebrado. Sugestão de follow-up em PR separado: adicionar um guard de regressão — um smoke test que suba o container e rode `airflow dags list-import-errors`, ou um teste unitário que faça `from airflow.io.path import ObjectStoragePath`. Registrado na descrição da issue #487.

## Checklist
- [x] Título do PR segue Conventional Commits
- [x] Issue relacionada foi referenciada
- [x] Testes/lint foram executados ou a ausência foi justificada
- [ ] Testes DBT adicionados/atualizados, se aplicável — não aplicável, mudança restrita a dependências
- [ ] Documentação atualizada, se aplicável — não aplicável
- [x] Sem dados sensíveis ou credenciais no código
- [x] Branch atualizada com `upstream/main` ou `origin/main`
- [x] Revisores automáticos por domínio foram solicitados pelo GitHub ou justificados no PR
